### PR TITLE
fix(embed): truncate inputs over 8192-token limit

### DIFF
--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1459,6 +1459,91 @@ func TestEmbedErrorBranchesRecordFailures(t *testing.T) {
 	}
 }
 
+func TestEmbedTruncatesOversizedBody(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	dbPath := filepath.Join(dir, "gitcrawl.db")
+	if err := New().Run(ctx, []string{"--config", configPath, "init", "--db", dbPath}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	st, err := store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	repoID, err := st.UpsertRepository(ctx, store.Repository{
+		Owner: "openclaw", Name: "openclaw", FullName: "openclaw/openclaw",
+		GitHubRepoID: "12345", RawJSON: "{}", UpdatedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("seed repository: %v", err)
+	}
+	body := strings.Repeat("a", 100_000)
+	if _, err := st.UpsertThread(ctx, store.Thread{
+		RepoID: repoID, GitHubID: "27137", Number: 27137, Kind: "issue", State: "open",
+		Title: "Oversized issue", Body: body,
+		HTMLURL: "https://github.com/openclaw/openclaw/issues/27137",
+		LabelsJSON: "[]", AssigneesJSON: "[]", RawJSON: "{}",
+		ContentHash: "h", UpdatedAtGitHub: "2026-04-30T01:00:00Z", UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed thread: %v", err)
+	}
+	st.Close()
+
+	const serverInputCap = 30_000
+	openAIServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload struct {
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode embeddings request: %v", err)
+		}
+		for index, input := range payload.Input {
+			if len(input) > serverInputCap {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"error": map[string]any{
+						"message": fmt.Sprintf("Invalid 'input[%d]': maximum input length is 8192 tokens.", index),
+						"type":    "invalid_request_error",
+					},
+				})
+				return
+			}
+		}
+		data := make([]map[string]any, 0, len(payload.Input))
+		for index := range payload.Input {
+			data = append(data, map[string]any{"index": index, "embedding": []float64{1, 0.01 * float64(index)}})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": data})
+	}))
+	defer openAIServer.Close()
+
+	t.Setenv("OPENAI_API_KEY", "test-openai-key")
+	t.Setenv("GITCRAWL_OPENAI_BASE_URL", openAIServer.URL)
+
+	app := New()
+	var stderr bytes.Buffer
+	app.Stderr = &stderr
+	if err := app.Run(ctx, []string{"--config", configPath, "embed", "openclaw/openclaw"}); err != nil {
+		t.Fatalf("embed should truncate oversized body, got: %v\nstderr=%s", err, stderr.String())
+	}
+
+	st, err = store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer st.Close()
+	vectors, err := st.ListThreadVectors(ctx, repoID)
+	if err != nil {
+		t.Fatalf("list vectors: %v", err)
+	}
+	if len(vectors) != 1 {
+		t.Fatalf("expected 1 vector after truncating embed, got %d", len(vectors))
+	}
+}
+
 func githubIssueJSON(number int, kind string, title string) map[string]any {
 	return map[string]any{
 		"id":         number + 10000,

--- a/internal/store/embedding_tasks.go
+++ b/internal/store/embedding_tasks.go
@@ -97,6 +97,19 @@ func (s *Store) ListEmbeddingTasks(ctx context.Context, options EmbeddingTaskOpt
 	return out, nil
 }
 
+// maxEmbeddingInputRunes caps embedding input to fit under OpenAI's 8192-token
+// limit using a conservative 3 chars/token floor. See issue #2; #3 tracks
+// per-model dynamic detection.
+const maxEmbeddingInputRunes = 24576
+
+func truncateForEmbedding(text string) string {
+	runes := []rune(text)
+	if len(runes) <= maxEmbeddingInputRunes {
+		return text
+	}
+	return string(runes[:maxEmbeddingInputRunes])
+}
+
 func embeddingTextForBasis(basis, title, body, rawText, dedupeText, keySummary string) (string, error) {
 	switch basis {
 	case "", "title_original":
@@ -106,15 +119,15 @@ func embeddingTextForBasis(basis, title, body, rawText, dedupeText, keySummary s
 		} else if strings.TrimSpace(rawText) != "" {
 			parts = append(parts, strings.TrimSpace(rawText))
 		}
-		return strings.TrimSpace(strings.Join(parts, "\n\n")), nil
+		return truncateForEmbedding(strings.TrimSpace(strings.Join(parts, "\n\n"))), nil
 	case "dedupe_text":
-		return strings.TrimSpace(dedupeText), nil
+		return truncateForEmbedding(strings.TrimSpace(dedupeText)), nil
 	case "llm_key_summary":
 		keySummary = strings.TrimSpace(keySummary)
 		if keySummary == "" {
 			return "", nil
 		}
-		return strings.TrimSpace("title: " + strings.TrimSpace(title) + "\n\nkey_summary:\n" + keySummary), nil
+		return truncateForEmbedding(strings.TrimSpace("title: " + strings.TrimSpace(title) + "\n\nkey_summary:\n" + keySummary)), nil
 	default:
 		return "", fmt.Errorf("embedding basis %q is not supported yet", basis)
 	}

--- a/internal/store/embedding_tasks_test.go
+++ b/internal/store/embedding_tasks_test.go
@@ -5,7 +5,23 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
+
+func TestEmbeddingTextForBasisTruncatesOversizedBody(t *testing.T) {
+	title := "Big issue"
+	body := strings.Repeat("a", 100_000)
+
+	for _, basis := range []string{"title_original", "dedupe_text", "llm_key_summary"} {
+		text, err := embeddingTextForBasis(basis, title, body, body, body, body)
+		if err != nil {
+			t.Fatalf("%s: embedding text: %v", basis, err)
+		}
+		if got := utf8.RuneCountInString(text); got > 30_000 {
+			t.Fatalf("%s: embedding text not truncated: got %d runes, want <= 30000", basis, got)
+		}
+	}
+}
 
 func TestListEmbeddingTasksUsesLatestLLMKeySummary(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- Cap embedding input at 24,576 runes (~3 chars/token floor × 8192) so threads with oversized bodies stop blowing the entire batch.
- Repro added: unit test on `embeddingTextForBasis` and e2e test with a fake OpenAI server that returns the real 400 error.

Closes #2. Per-model dynamic detection tracked in #3.

## Test plan
- [x] `go test ./...` (full suite green)
- [x] Both new tests fail pre-fix with the production error message, pass post-fix