### PR TITLE
fix: guard portable store checkout remotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Refuse to refresh a portable store checkout when its Git remote does not match the requested portable store, avoiding accidental resets of unrelated working trees.
 - Ignore non-finite vector similarity scores so malformed embeddings cannot surface as neighbors.
 
 ## 0.3.4 - 2026-05-14

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -2097,6 +2098,9 @@ func syncPortableStore(ctx context.Context, remoteURL, dir string) (string, erro
 	}
 	gitDir := filepath.Join(dir, ".git")
 	if info, err := os.Stat(gitDir); err == nil && info.IsDir() {
+		if err := ensurePortableStoreRemote(ctx, remoteURL, dir); err != nil {
+			return "", err
+		}
 		if !gitWorktreeClean(ctx, dir) {
 			if resetErr := runGit(ctx, "", "-C", dir, "reset", "--hard", "HEAD"); resetErr != nil {
 				return "", resetErr
@@ -2146,6 +2150,74 @@ func syncPortableStore(ctx context.Context, remoteURL, dir string) (string, erro
 	return "cloned", nil
 }
 
+func ensurePortableStoreRemote(ctx context.Context, remoteURL, dir string) error {
+	remote := gitBranchRemote(ctx, dir, currentGitBranch(ctx, dir))
+	origin, err := gitConfigValue(ctx, dir, "remote."+remote+".url")
+	if err != nil {
+		return fmt.Errorf("read portable store remote %q: %w", remote, err)
+	}
+	if !sameGitRemote(origin, remoteURL) {
+		return fmt.Errorf("portable store directory %s is a checkout of %q, not %q", dir, gitRemoteForMessage(origin), gitRemoteForMessage(remoteURL))
+	}
+	return nil
+}
+
+func sameGitRemote(left, right string) bool {
+	left = canonicalGitRemote(left)
+	right = canonicalGitRemote(right)
+	return left != "" && left == right
+}
+
+func canonicalGitRemote(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if parsed, err := url.Parse(value); err == nil && parsed.Scheme != "" {
+		parsed.Scheme = strings.ToLower(parsed.Scheme)
+		parsed.Host = strings.ToLower(parsed.Host)
+		if parsed.Scheme == "http" || parsed.Scheme == "https" {
+			parsed.User = nil
+		}
+		parsed.Path = strings.TrimSuffix(parsed.Path, "/")
+		if parsed.Scheme != "file" {
+			parsed.Path = strings.TrimSuffix(parsed.Path, ".git")
+		}
+		return parsed.String()
+	}
+	if !filepath.IsAbs(value) && strings.Contains(value, ":") && !strings.Contains(value, "://") {
+		value = strings.TrimSuffix(strings.TrimSuffix(value, "/"), ".git")
+		return canonicalSCPGitRemote(value)
+	}
+	if abs, err := filepath.Abs(value); err == nil {
+		return filepath.Clean(abs)
+	}
+	return filepath.Clean(value)
+}
+
+func canonicalSCPGitRemote(value string) string {
+	userHost, path, ok := strings.Cut(value, ":")
+	if !ok {
+		return value
+	}
+	user := ""
+	host := userHost
+	if before, after, ok := strings.Cut(userHost, "@"); ok {
+		user = before + "@"
+		host = after
+	}
+	return user + strings.ToLower(host) + ":" + path
+}
+
+func gitRemoteForMessage(value string) string {
+	value = strings.TrimSpace(value)
+	if parsed, err := url.Parse(value); err == nil && parsed.Scheme != "" {
+		parsed.User = nil
+		return parsed.String()
+	}
+	return value
+}
+
 func removePortableSQLiteSidecars(dir string) error {
 	return filepath.WalkDir(dir, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
@@ -2173,16 +2245,7 @@ func isDirtyPortablePullError(err error) bool {
 
 func fastForwardGitCheckout(ctx context.Context, dir string, quiet bool) error {
 	branch := currentGitBranch(ctx, dir)
-	remote := ""
-	if branch != "" {
-		value, err := gitConfigValue(ctx, dir, "branch."+branch+".remote")
-		if err == nil {
-			remote = value
-		}
-	}
-	if strings.TrimSpace(remote) == "" {
-		remote = "origin"
-	}
+	remote := gitBranchRemote(ctx, dir, branch)
 	fetchArgs := []string{"-C", dir, "fetch", "--prune"}
 	if quiet {
 		fetchArgs = append(fetchArgs, "--quiet")
@@ -2208,6 +2271,16 @@ func fastForwardGitCheckout(ctx context.Context, dir string, quiet bool) error {
 	}
 	mergeArgs = append(mergeArgs, target)
 	return runGit(ctx, "", mergeArgs...)
+}
+
+func gitBranchRemote(ctx context.Context, dir, branch string) string {
+	if branch != "" {
+		value, err := gitConfigValue(ctx, dir, "branch."+branch+".remote")
+		if err == nil && strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return "origin"
 }
 
 func currentGitBranch(ctx context.Context, dir string) string {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -417,6 +417,137 @@ func TestSyncPortableStoreIgnoresBrokenPullRebaseConfig(t *testing.T) {
 	}
 }
 
+func TestSyncPortableStoreRejectsDifferentExistingCheckout(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	remoteDir := filepath.Join(dir, "remote")
+	otherRemoteDir := filepath.Join(dir, "other-remote")
+	checkoutDir := filepath.Join(dir, "checkout")
+	for _, repoDir := range []string{remoteDir, otherRemoteDir} {
+		if err := os.MkdirAll(filepath.Join(repoDir, "data"), 0o755); err != nil {
+			t.Fatalf("mkdir repo: %v", err)
+		}
+		if err := runGit(ctx, repoDir, "init", "-b", "main"); err != nil {
+			t.Fatalf("git init: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(repoDir, "data", "openclaw__openclaw.sync.db"), []byte(filepath.Base(repoDir)), 0o644); err != nil {
+			t.Fatalf("write db: %v", err)
+		}
+		if err := runGit(ctx, repoDir, "add", "data/openclaw__openclaw.sync.db"); err != nil {
+			t.Fatalf("git add: %v", err)
+		}
+		if err := runGit(ctx, repoDir, "-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-m", "seed store"); err != nil {
+			t.Fatalf("git commit seed: %v", err)
+		}
+	}
+	if _, err := syncPortableStore(ctx, otherRemoteDir, checkoutDir); err != nil {
+		t.Fatalf("initial portable sync: %v", err)
+	}
+	dirtyPath := filepath.Join(checkoutDir, "data", "openclaw__openclaw.sync.db")
+	if err := os.WriteFile(dirtyPath, []byte("dirty local data"), 0o644); err != nil {
+		t.Fatalf("dirty checkout: %v", err)
+	}
+
+	if _, err := syncPortableStore(ctx, remoteDir, checkoutDir); err == nil {
+		t.Fatal("mismatched existing checkout should fail")
+	}
+	got, err := os.ReadFile(dirtyPath)
+	if err != nil {
+		t.Fatalf("read dirty checkout: %v", err)
+	}
+	if string(got) != "dirty local data" {
+		t.Fatalf("mismatched checkout was modified: %q", string(got))
+	}
+}
+
+func TestSyncPortableStoreHonorsBranchRemote(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	remoteDir := filepath.Join(dir, "remote")
+	checkoutDir := filepath.Join(dir, "checkout")
+	if err := os.MkdirAll(filepath.Join(remoteDir, "data"), 0o755); err != nil {
+		t.Fatalf("mkdir remote: %v", err)
+	}
+	if err := runGit(ctx, remoteDir, "init", "-b", "main"); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	dbPath := filepath.Join(remoteDir, "data", "openclaw__openclaw.sync.db")
+	if err := os.WriteFile(dbPath, []byte("remote-v1"), 0o644); err != nil {
+		t.Fatalf("write db: %v", err)
+	}
+	if err := runGit(ctx, remoteDir, "add", "data/openclaw__openclaw.sync.db"); err != nil {
+		t.Fatalf("git add: %v", err)
+	}
+	if err := runGit(ctx, remoteDir, "-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-m", "seed store"); err != nil {
+		t.Fatalf("git commit seed: %v", err)
+	}
+	if _, err := syncPortableStore(ctx, remoteDir, checkoutDir); err != nil {
+		t.Fatalf("initial portable sync: %v", err)
+	}
+	if err := runGit(ctx, "", "-C", checkoutDir, "remote", "rename", "origin", "store"); err != nil {
+		t.Fatalf("rename remote: %v", err)
+	}
+	if err := os.WriteFile(dbPath, []byte("remote-v2"), 0o644); err != nil {
+		t.Fatalf("write updated remote db: %v", err)
+	}
+	if err := runGit(ctx, remoteDir, "add", "data/openclaw__openclaw.sync.db"); err != nil {
+		t.Fatalf("git add update: %v", err)
+	}
+	if err := runGit(ctx, remoteDir, "-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-m", "update store"); err != nil {
+		t.Fatalf("git commit update: %v", err)
+	}
+
+	action, err := syncPortableStore(ctx, remoteDir, checkoutDir)
+	if err != nil {
+		t.Fatalf("portable sync with renamed remote: %v", err)
+	}
+	if action != "pulled" {
+		t.Fatalf("action = %q, want pulled", action)
+	}
+	got, err := os.ReadFile(filepath.Join(checkoutDir, "data", "openclaw__openclaw.sync.db"))
+	if err != nil {
+		t.Fatalf("read checkout db: %v", err)
+	}
+	if string(got) != "remote-v2" {
+		t.Fatalf("checkout db = %q, want remote-v2", string(got))
+	}
+}
+
+func TestSameGitRemoteKeepsLocalDotGitDistinct(t *testing.T) {
+	dir := t.TempDir()
+	repoDir := filepath.Join(dir, "store")
+	bareRepoDir := filepath.Join(dir, "store.git")
+
+	if sameGitRemote(repoDir, bareRepoDir) {
+		t.Fatalf("local paths %q and %q must not compare equal", repoDir, bareRepoDir)
+	}
+}
+
+func TestSameGitRemotePreservesSCPPathCase(t *testing.T) {
+	if !sameGitRemote("git@Example.com:Team/Store.git", "git@example.com:Team/Store") {
+		t.Fatal("scp-style host case and .git suffix should normalize")
+	}
+	if sameGitRemote("git@example.com:Team/Store.git", "git@example.com:team/store.git") {
+		t.Fatal("scp-style repository path case must stay distinct")
+	}
+}
+
+func TestSameGitRemoteIgnoresHTTPSCredentials(t *testing.T) {
+	if !sameGitRemote("https://user:old-token@example.com/org/store.git", "https://user:new-token@example.com/org/store") {
+		t.Fatal("https credential changes should not change remote identity")
+	}
+}
+
+func TestGitRemoteForMessageRedactsURLCredentials(t *testing.T) {
+	got := gitRemoteForMessage("https://user:secret@example.com/org/store.git")
+	if strings.Contains(got, "user") || strings.Contains(got, "secret") {
+		t.Fatalf("remote message leaked credentials: %q", got)
+	}
+	if got != "https://example.com/org/store.git" {
+		t.Fatalf("remote message = %q, want sanitized URL", got)
+	}
+}
+
 func TestInitWithPortableStoreCloneAndPull(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- refuse to refresh an existing portable-store checkout when its configured fetch remote does not match the requested store
- keep mismatched dirty checkouts untouched and redact URL credentials in mismatch errors
- cover local .git path distinction, scp path case, HTTPS token rotation, and renamed branch remotes

## Validation
- env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
- codex-review clean: no accepted/actionable findings reported
