### PR TITLE
fix: derive vector dir from custom db path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Derive the default vector directory from custom database paths, including `GITCRAWL_DB_PATH`, so separate stores do not share embeddings unless `vector_dir` is set explicitly.
 - Refuse to refresh a portable store checkout when its Git remote does not match the requested portable store, avoiding accidental resets of unrelated working trees.
 - Ignore non-finite vector similarity scores so malformed embeddings cannot surface as neighbors.
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1992,6 +1992,9 @@ func (a *App) runInit(ctx context.Context, args []string) error {
 	if strings.TrimSpace(*dbPath) != "" {
 		cfg.DBPath = strings.TrimSpace(*dbPath)
 	}
+	if err := cfg.Normalize(); err != nil {
+		return err
+	}
 	if err := config.Save(a.configPath, cfg); err != nil {
 		return err
 	}

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -24,7 +24,8 @@ import (
 func TestInitWritesConfig(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.toml")
-	dbPath := filepath.Join(dir, "gitcrawl.db")
+	dbPath := filepath.Join(dir, "custom", "gitcrawl.db")
+	wantVectorDir := filepath.Join(filepath.Dir(dbPath), "vectors")
 	app := New()
 	var stdout bytes.Buffer
 	app.Stdout = &stdout
@@ -35,6 +36,16 @@ func TestInitWritesConfig(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), `"config_path"`) {
 		t.Fatalf("expected json init output, got %q", stdout.String())
+	}
+	var result initResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode init output: %v\n%s", err, stdout.String())
+	}
+	if result.VectorDir != wantVectorDir {
+		t.Fatalf("vector dir = %q, want %q", result.VectorDir, wantVectorDir)
+	}
+	if _, err := os.Stat(wantVectorDir); err != nil {
+		t.Fatalf("stat vector dir: %v", err)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,12 +61,11 @@ func Default() Config {
 			LogDir:   filepath.Join(homeDir(), ".config", "gitcrawl", "logs"),
 		}
 	}
-	base := filepath.Dir(paths.DBPath)
 	return Config{
 		Version:        1,
 		DBPath:         paths.DBPath,
 		CacheDir:       paths.CacheDir,
-		VectorDir:      filepath.Join(base, "vectors"),
+		VectorDir:      defaultVectorDirForDB(paths.DBPath),
 		LogDir:         paths.LogDir,
 		EmbeddingBasis: "title_original",
 		GitHub: GitHubConfig{
@@ -139,6 +138,7 @@ func EnsureRuntimeDirs(cfg Config) error {
 
 func (c *Config) Normalize() error {
 	def := Default()
+	vectorDirWasDefault := c.VectorDir == "" || expandHome(c.VectorDir) == expandHome(def.VectorDir)
 	if c.Version == 0 {
 		c.Version = def.Version
 	}
@@ -147,9 +147,6 @@ func (c *Config) Normalize() error {
 	}
 	if c.CacheDir == "" {
 		c.CacheDir = def.CacheDir
-	}
-	if c.VectorDir == "" {
-		c.VectorDir = def.VectorDir
 	}
 	if c.LogDir == "" {
 		c.LogDir = def.LogDir
@@ -183,7 +180,11 @@ func (c *Config) Normalize() error {
 	}
 	c.DBPath = expandHome(c.DBPath)
 	c.CacheDir = expandHome(c.CacheDir)
-	c.VectorDir = expandHome(c.VectorDir)
+	if vectorDirWasDefault {
+		c.VectorDir = defaultVectorDirForDB(c.DBPath)
+	} else {
+		c.VectorDir = expandHome(c.VectorDir)
+	}
 	c.LogDir = expandHome(c.LogDir)
 	return nil
 }
@@ -191,7 +192,11 @@ func (c *Config) Normalize() error {
 func (c *Config) ApplyRuntimeEnv() {
 	c.OpenAI.SummaryModel = c.envOrDefault("GITCRAWL_SUMMARY_MODEL", c.OpenAI.SummaryModel)
 	c.OpenAI.EmbedModel = c.envOrDefault("GITCRAWL_EMBED_MODEL", c.OpenAI.EmbedModel)
+	vectorDirWasDefault := expandHome(c.VectorDir) == defaultVectorDirForDB(expandHome(c.DBPath))
 	c.DBPath = expandHome(c.envOrDefault("GITCRAWL_DB_PATH", c.DBPath))
+	if vectorDirWasDefault {
+		c.VectorDir = defaultVectorDirForDB(c.DBPath)
+	}
 }
 
 func ResolveGitHubToken(cfg Config) TokenResolution {
@@ -232,6 +237,10 @@ func (c Config) configEnv(primary string) string {
 
 func expandHome(path string) string {
 	return crawlconfig.ExpandHome(path)
+}
+
+func defaultVectorDirForDB(dbPath string) string {
+	return filepath.Join(filepath.Dir(expandHome(dbPath)), "vectors")
 }
 
 func homeDir() string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -61,6 +61,10 @@ func TestApplyRuntimeEnvUsesDBEnv(t *testing.T) {
 	if cfg.DBPath != dbPath {
 		t.Fatalf("db path: got %q want %q", cfg.DBPath, dbPath)
 	}
+	wantVectorDir := filepath.Join(dir, "vectors")
+	if cfg.VectorDir != wantVectorDir {
+		t.Fatalf("vector dir: got %q want %q", cfg.VectorDir, wantVectorDir)
+	}
 }
 
 func TestResolveTokens(t *testing.T) {
@@ -167,8 +171,65 @@ func TestApplyRuntimeEnvUsesConfigEnvFallback(t *testing.T) {
 	if cfg.DBPath != dbPath {
 		t.Fatalf("db path: got %q want %q", cfg.DBPath, dbPath)
 	}
+	if cfg.VectorDir != filepath.Join(dir, "vectors") {
+		t.Fatalf("vector dir: got %q want custom db sibling vectors", cfg.VectorDir)
+	}
 	if cfg.OpenAI.SummaryModel != "summary-config" || cfg.OpenAI.EmbedModel != "embed-config" {
 		t.Fatalf("config env models not used: %+v", cfg.OpenAI)
+	}
+}
+
+func TestNormalizeDerivesVectorDirFromCustomDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "stores", "gitcrawl.db")
+	cfg := Config{DBPath: dbPath}
+	if err := cfg.Normalize(); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if cfg.VectorDir != filepath.Join(dir, "stores", "vectors") {
+		t.Fatalf("vector dir: got %q want sibling vectors", cfg.VectorDir)
+	}
+}
+
+func TestNormalizeMovesDefaultVectorDirWithChangedDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "custom.db")
+	cfg := Default()
+	cfg.DBPath = dbPath
+	if err := cfg.Normalize(); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if cfg.VectorDir != filepath.Join(dir, "vectors") {
+		t.Fatalf("vector dir: got %q want custom db sibling vectors", cfg.VectorDir)
+	}
+}
+
+func TestNormalizeKeepsExplicitVectorDir(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "custom.db")
+	vectorDir := filepath.Join(dir, "explicit-vectors")
+	cfg := Config{DBPath: dbPath, VectorDir: vectorDir}
+	if err := cfg.Normalize(); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if cfg.VectorDir != vectorDir {
+		t.Fatalf("vector dir: got %q want explicit %q", cfg.VectorDir, vectorDir)
+	}
+}
+
+func TestApplyRuntimeEnvKeepsExplicitVectorDir(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "override.db")
+	vectorDir := filepath.Join(dir, "explicit-vectors")
+	t.Setenv("GITCRAWL_DB_PATH", dbPath)
+
+	cfg := Config{VectorDir: vectorDir}
+	if err := cfg.Normalize(); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	cfg.ApplyRuntimeEnv()
+	if cfg.VectorDir != vectorDir {
+		t.Fatalf("vector dir: got %q want explicit %q", cfg.VectorDir, vectorDir)
 	}
 }
 


### PR DESCRIPTION
## Summary
- derive the default vector_dir from the effective db_path instead of the app-wide default DB
- update GITCRAWL_DB_PATH/config-env handling so runtime DB overrides get isolated vectors
- preserve explicit non-default vector_dir and cover init output/runtime-dir behavior with tests

## Validation
- go test ./internal/cli -run TestInitWritesConfig -count=1
- go test ./internal/config -count=1
- env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
- codex-review clean: no accepted/actionable findings reported
