### PR TITLE
fix: retire missing durable clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Retire durable clusters that disappear from a successful clustering run, while still preserving local close overrides across reclustering.
 - Derive the default vector directory from custom database paths, including `GITCRAWL_DB_PATH`, so separate stores do not share embeddings unless `vector_dir` is set explicitly.
 - Refuse to refresh a portable store checkout when its Git remote does not match the requested portable store, avoiding accidental resets of unrelated working trees.
 - Ignore non-finite vector similarity scores so malformed embeddings cannot surface as neighbors.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -413,7 +413,20 @@ func (a *App) runRefresh(ctx context.Context, args []string) error {
 			return err
 		}
 		if len(vectors) == 0 {
-			vectors, err = rt.Store.ListThreadVectorsFiltered(ctx, store.ThreadVectorQuery{RepoID: repo.ID})
+			fallbackQuery := store.ThreadVectorQuery{RepoID: repo.ID}
+			fallbackVectors, err := rt.Store.ListThreadVectorsFiltered(ctx, fallbackQuery)
+			if err != nil {
+				_ = rt.Store.Close()
+				return err
+			}
+			if len(fallbackVectors) > 0 {
+				query = fallbackQuery
+				vectors = fallbackVectors
+			}
+		}
+		retireMissing := minSize <= 1 && !stateIncludesClosed(*state)
+		if retireMissing {
+			retireMissing, err = completeClusterVectorCoverage(ctx, rt.Store, query, vectors)
 			if err != nil {
 				_ = rt.Store.Close()
 				return err
@@ -425,6 +438,7 @@ func (a *App) runRefresh(ctx context.Context, args []string) error {
 			MaxClusterSize:     maxClusterSize,
 			Fanout:             fanout,
 			CrossKindThreshold: crossKindThreshold,
+			RetireMissing:      retireMissing,
 		})
 		_ = rt.Store.Close()
 		if err != nil {
@@ -683,13 +697,25 @@ func (a *App) runCluster(ctx context.Context, args []string) error {
 		return err
 	}
 	if len(vectors) == 0 && strings.TrimSpace(*model) == "" && strings.TrimSpace(*basis) == "" {
-		vectors, err = rt.Store.ListThreadVectorsFiltered(ctx, store.ThreadVectorQuery{RepoID: repo.ID, IncludeClosed: *includeClosed})
+		fallbackQuery := store.ThreadVectorQuery{RepoID: repo.ID, IncludeClosed: *includeClosed}
+		fallbackVectors, err := rt.Store.ListThreadVectorsFiltered(ctx, fallbackQuery)
 		if err != nil {
 			return err
+		}
+		if len(fallbackVectors) > 0 {
+			query = fallbackQuery
+			vectors = fallbackVectors
 		}
 	}
 	if limit > 0 && len(vectors) > limit {
 		vectors = vectors[:limit]
+	}
+	retireMissing := minSize <= 1 && limit == 0 && strings.TrimSpace(*model) == "" && strings.TrimSpace(*basis) == "" && !*includeClosed
+	if retireMissing {
+		retireMissing, err = completeClusterVectorCoverage(ctx, rt.Store, query, vectors)
+		if err != nil {
+			return err
+		}
 	}
 	clusterResult, err := clusterRepository(ctx, rt.Store, repo.ID, vectors, clusterBuildOptions{
 		Threshold:          threshold,
@@ -697,6 +723,7 @@ func (a *App) runCluster(ctx context.Context, args []string) error {
 		MaxClusterSize:     maxClusterSize,
 		Fanout:             fanout,
 		CrossKindThreshold: crossKindThreshold,
+		RetireMissing:      retireMissing,
 	})
 	if err != nil {
 		return err
@@ -2672,6 +2699,7 @@ type clusterBuildOptions struct {
 	MaxClusterSize     int
 	Fanout             int
 	CrossKindThreshold float64
+	RetireMissing      bool
 }
 
 func parseClusterShapeOptions(command, maxClusterSizeRaw, fanoutRaw, crossKindThresholdRaw string) (int, int, float64, error) {
@@ -2951,12 +2979,36 @@ type clusterRepositoryResult struct {
 	RunID        int64
 }
 
+func completeClusterVectorCoverage(ctx context.Context, st *store.Store, query store.ThreadVectorQuery, storedVectors []store.ThreadVector) (bool, error) {
+	if strings.TrimSpace(query.Model) == "" || strings.TrimSpace(query.Basis) == "" {
+		return false, nil
+	}
+	if !store.SupportsEmbeddingBasis(query.Basis) {
+		return false, nil
+	}
+	pending, err := st.ListEmbeddingTasks(ctx, store.EmbeddingTaskOptions{
+		RepoID:        query.RepoID,
+		Basis:         query.Basis,
+		Model:         query.Model,
+		IncludeClosed: query.IncludeClosed,
+	})
+	if err != nil {
+		return false, err
+	}
+	return len(pending) == 0, nil
+}
+
 func clusterRepository(ctx context.Context, st *store.Store, repoID int64, storedVectors []store.ThreadVector, options clusterBuildOptions) (clusterRepositoryResult, error) {
 	inputs, edgeCount, err := buildDurableClusterInputs(ctx, st, repoID, storedVectors, options)
 	if err != nil {
 		return clusterRepositoryResult{}, err
 	}
-	saveResult, err := st.SaveDurableClusters(ctx, repoID, inputs)
+	var saveResult store.SaveDurableClustersResult
+	if options.RetireMissing {
+		saveResult, err = st.SaveCompleteDurableClusters(ctx, repoID, inputs)
+	} else {
+		saveResult, err = st.SaveDurableClusters(ctx, repoID, inputs)
+	}
 	if err != nil {
 		return clusterRepositoryResult{}, err
 	}

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -2728,7 +2728,6 @@ func TestClusterCommandPersistsDurableClusters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reopen store: %v", err)
 	}
-	defer st.Close()
 	clusters, err := st.ListClusterSummaries(ctx, store.ClusterSummaryOptions{RepoID: repoID, IncludeClosed: false, MinSize: 1, Limit: 20})
 	if err != nil {
 		t.Fatalf("list clusters: %v", err)
@@ -2740,6 +2739,334 @@ func TestClusterCommandPersistsDurableClusters(t *testing.T) {
 	sort.Ints(memberCounts)
 	if len(memberCounts) != 2 || memberCounts[0] != 1 || memberCounts[1] != 2 {
 		t.Fatalf("expected duplicate cluster plus singleton, got %#v", clusters)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close store before limited cluster: %v", err)
+	}
+
+	stdout.Reset()
+	if err := run.Run(ctx, []string{"--config", configPath, "cluster", "openclaw/openclaw", "--threshold", "0.90", "--limit", "2", "--json"}); err != nil {
+		t.Fatalf("limited cluster: %v", err)
+	}
+	st, err = store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("reopen store after limited cluster: %v", err)
+	}
+	clusters, err = st.ListClusterSummaries(ctx, store.ClusterSummaryOptions{RepoID: repoID, IncludeClosed: false, MinSize: 1, Limit: 20})
+	if err != nil {
+		t.Fatalf("list clusters after limited run: %v", err)
+	}
+	if len(clusters) != 2 {
+		t.Fatalf("limited cluster run should not retire unprocessed clusters, got %#v", clusters)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close store after limited cluster: %v", err)
+	}
+
+	if err := run.Run(ctx, []string{"--config", configPath, "configure", "--embed-model", "text-embedding-3-large"}); err != nil {
+		t.Fatalf("configure new embed model: %v", err)
+	}
+	st, err = store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("reopen store before model migration cluster: %v", err)
+	}
+	for _, vector := range []store.ThreadVector{
+		{ThreadID: firstID, Basis: "title_original", Model: "text-embedding-3-large", Dimensions: 2, ContentHash: "hash-91-large", Vector: []float64{1, 0}, CreatedAt: now, UpdatedAt: now},
+		{ThreadID: secondID, Basis: "title_original", Model: "text-embedding-3-large", Dimensions: 2, ContentHash: "hash-92-large", Vector: []float64{0.95, 0.05}, CreatedAt: now, UpdatedAt: now},
+	} {
+		if err := st.UpsertThreadVector(ctx, vector); err != nil {
+			t.Fatalf("upsert migrated vector: %v", err)
+		}
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close store before model migration cluster: %v", err)
+	}
+
+	stdout.Reset()
+	if err := run.Run(ctx, []string{"--config", configPath, "cluster", "openclaw/openclaw", "--threshold", "0.90", "--json"}); err != nil {
+		t.Fatalf("model migration cluster: %v", err)
+	}
+	st, err = store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("reopen store after model migration cluster: %v", err)
+	}
+	clusters, err = st.ListClusterSummaries(ctx, store.ClusterSummaryOptions{RepoID: repoID, IncludeClosed: false, MinSize: 1, Limit: 20})
+	if err != nil {
+		t.Fatalf("list clusters after model migration run: %v", err)
+	}
+	if len(clusters) != 2 {
+		t.Fatalf("partial model migration run should not retire clusters without new vectors, got %#v", clusters)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close store after model migration cluster: %v", err)
+	}
+
+	st, err = store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("reopen store before close-all cluster: %v", err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `update threads set state = 'closed', closed_at_gh = ?, updated_at = ? where repo_id = ?`, now, now, repoID); err != nil {
+		t.Fatalf("close seeded threads: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close store before close-all cluster: %v", err)
+	}
+
+	stdout.Reset()
+	if err := run.Run(ctx, []string{"--config", configPath, "cluster", "openclaw/openclaw", "--threshold", "0.90", "--json"}); err != nil {
+		t.Fatalf("close-all cluster: %v", err)
+	}
+	st, err = store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("reopen store after close-all cluster: %v", err)
+	}
+	clusters, err = st.ListClusterSummaries(ctx, store.ClusterSummaryOptions{RepoID: repoID, IncludeClosed: false, MinSize: 1, Limit: 20})
+	if err != nil {
+		t.Fatalf("list clusters after close-all run: %v", err)
+	}
+	if len(clusters) != 0 {
+		t.Fatalf("complete zero-vector run should retire active clusters, got %#v", clusters)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close store after close-all cluster: %v", err)
+	}
+}
+
+func TestCompleteClusterVectorCoverageRequiresFreshVectors(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	repoID, err := st.UpsertRepository(ctx, store.Repository{Owner: "openclaw", Name: "openclaw", FullName: "openclaw/openclaw", RawJSON: "{}", UpdatedAt: now})
+	if err != nil {
+		t.Fatalf("seed repository: %v", err)
+	}
+	firstThread := store.Thread{
+		RepoID: repoID, GitHubID: "501", Number: 501, Kind: "issue", State: "open",
+		Title: "Fresh vector coverage", Body: "original body",
+		HTMLURL: "https://github.com/openclaw/openclaw/issues/501", LabelsJSON: "[]", AssigneesJSON: "[]",
+		RawJSON: "{}", ContentHash: "hash-501", UpdatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	firstThreadID, err := st.UpsertThread(ctx, firstThread)
+	if err != nil {
+		t.Fatalf("seed first thread: %v", err)
+	}
+	secondThread := store.Thread{
+		RepoID: repoID, GitHubID: "502", Number: 502, Kind: "issue", State: "open",
+		Title: "Stale vector coverage", Body: "original stale body",
+		HTMLURL: "https://github.com/openclaw/openclaw/issues/502", LabelsJSON: "[]", AssigneesJSON: "[]",
+		RawJSON: "{}", ContentHash: "hash-502", UpdatedAt: "2026-04-26T00:00:00Z",
+	}
+	secondThreadID, err := st.UpsertThread(ctx, secondThread)
+	if err != nil {
+		t.Fatalf("seed second thread: %v", err)
+	}
+	query := store.ThreadVectorQuery{RepoID: repoID, Basis: "title_original", Model: "text-embedding-3-small"}
+	tasks, err := st.ListEmbeddingTasks(ctx, store.EmbeddingTaskOptions{RepoID: repoID, Basis: query.Basis, Model: query.Model})
+	if err != nil {
+		t.Fatalf("list embedding tasks: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("embedding tasks = %#v", tasks)
+	}
+	hashByNumber := map[int]string{}
+	for _, task := range tasks {
+		hashByNumber[task.Number] = task.ContentHash
+	}
+	if err := st.UpsertThreadVector(ctx, store.ThreadVector{
+		ThreadID: firstThreadID, Basis: query.Basis, Model: query.Model, Dimensions: 2,
+		ContentHash: hashByNumber[501], Vector: []float64{1, 0}, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("upsert first vector: %v", err)
+	}
+	if err := st.UpsertThreadVector(ctx, store.ThreadVector{
+		ThreadID: secondThreadID, Basis: query.Basis, Model: query.Model, Dimensions: 2,
+		ContentHash: "stale-hash", Vector: []float64{0, 1}, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("upsert stale second vector: %v", err)
+	}
+	vectors, err := st.ListThreadVectorsFiltered(ctx, query)
+	if err != nil {
+		t.Fatalf("list vectors: %v", err)
+	}
+	complete, err := completeClusterVectorCoverage(ctx, st, query, vectors)
+	if err != nil {
+		t.Fatalf("stale older coverage: %v", err)
+	}
+	if complete {
+		t.Fatal("stale older vector should not complete cluster coverage")
+	}
+
+	if err := st.UpsertThreadVector(ctx, store.ThreadVector{
+		ThreadID: secondThreadID, Basis: query.Basis, Model: query.Model, Dimensions: 2,
+		ContentHash: hashByNumber[502], Vector: []float64{0, 1}, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("refresh second vector: %v", err)
+	}
+	vectors, err = st.ListThreadVectorsFiltered(ctx, query)
+	if err != nil {
+		t.Fatalf("list fresh vectors: %v", err)
+	}
+	complete, err = completeClusterVectorCoverage(ctx, st, query, vectors)
+	if err != nil {
+		t.Fatalf("fresh complete coverage: %v", err)
+	}
+	if !complete {
+		t.Fatal("fresh vectors should complete cluster coverage")
+	}
+
+	firstThread.Body = "changed body"
+	firstThread.ContentHash = "hash-501-updated"
+	firstThread.UpdatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := st.UpsertThread(ctx, firstThread); err != nil {
+		t.Fatalf("update thread: %v", err)
+	}
+	complete, err = completeClusterVectorCoverage(ctx, st, query, vectors)
+	if err != nil {
+		t.Fatalf("stale complete coverage: %v", err)
+	}
+	if complete {
+		t.Fatal("stale vector should not complete cluster coverage")
+	}
+}
+
+func TestCompleteClusterVectorCoverageAllowsUnembeddableSummaryThreads(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	repoID, err := st.UpsertRepository(ctx, store.Repository{Owner: "openclaw", Name: "openclaw", FullName: "openclaw/openclaw", RawJSON: "{}", UpdatedAt: now})
+	if err != nil {
+		t.Fatalf("seed repository: %v", err)
+	}
+	firstID, err := st.UpsertThread(ctx, store.Thread{
+		RepoID: repoID, GitHubID: "511", Number: 511, Kind: "issue", State: "open",
+		Title: "Has key summary", Body: "body",
+		HTMLURL: "https://github.com/openclaw/openclaw/issues/511", LabelsJSON: "[]", AssigneesJSON: "[]",
+		RawJSON: "{}", ContentHash: "hash-511", UpdatedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("seed first thread: %v", err)
+	}
+	if _, err := st.UpsertThread(ctx, store.Thread{
+		RepoID: repoID, GitHubID: "512", Number: 512, Kind: "issue", State: "open",
+		Title: "No key summary", Body: "body",
+		HTMLURL: "https://github.com/openclaw/openclaw/issues/512", LabelsJSON: "[]", AssigneesJSON: "[]",
+		RawJSON: "{}", ContentHash: "hash-512", UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed second thread: %v", err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `
+		insert into thread_revisions(thread_id, source_updated_at, content_hash, title_hash, body_hash, labels_hash, created_at)
+		values(?, ?, 'content', 'title', 'body', 'labels', ?)
+	`, firstID, now, now); err != nil {
+		t.Fatalf("seed revision: %v", err)
+	}
+	var revisionID int64
+	if err := st.DB().QueryRowContext(ctx, `select id from thread_revisions where thread_id = ?`, firstID).Scan(&revisionID); err != nil {
+		t.Fatalf("revision id: %v", err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `
+		insert into thread_key_summaries(thread_revision_id, summary_kind, prompt_version, provider, model, input_hash, output_hash, key_text, created_at)
+		values(?, 'llm_key_summary', 'test', 'test', 'test', 'input', 'output', 'key summary text', ?)
+	`, revisionID, now); err != nil {
+		t.Fatalf("seed key summary: %v", err)
+	}
+
+	query := store.ThreadVectorQuery{RepoID: repoID, Basis: "llm_key_summary", Model: "text-embedding-3-small"}
+	tasks, err := st.ListEmbeddingTasks(ctx, store.EmbeddingTaskOptions{RepoID: repoID, Basis: query.Basis, Model: query.Model})
+	if err != nil {
+		t.Fatalf("list embedding tasks: %v", err)
+	}
+	if len(tasks) != 1 || tasks[0].Number != 511 {
+		t.Fatalf("embedding tasks = %#v", tasks)
+	}
+	if err := st.UpsertThreadVector(ctx, store.ThreadVector{
+		ThreadID: firstID, Basis: query.Basis, Model: query.Model, Dimensions: 2,
+		ContentHash: tasks[0].ContentHash, Vector: []float64{1, 0}, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("upsert summary vector: %v", err)
+	}
+	vectors, err := st.ListThreadVectorsFiltered(ctx, query)
+	if err != nil {
+		t.Fatalf("list vectors: %v", err)
+	}
+	complete, err := completeClusterVectorCoverage(ctx, st, query, vectors)
+	if err != nil {
+		t.Fatalf("summary coverage: %v", err)
+	}
+	if !complete {
+		t.Fatal("unembeddable summary thread should not block complete cluster coverage")
+	}
+}
+
+func TestClusterCommandAllowsExplicitUnsupportedBasisWithoutRetirement(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	dbPath := filepath.Join(dir, "gitcrawl.db")
+	app := New()
+	if err := app.Run(ctx, []string{"--config", configPath, "init", "--db", dbPath}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	st, err := store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	repoID, err := st.UpsertRepository(ctx, store.Repository{Owner: "openclaw", Name: "openclaw", FullName: "openclaw/openclaw", RawJSON: "{}", UpdatedAt: now})
+	if err != nil {
+		t.Fatalf("seed repository: %v", err)
+	}
+	threadID, err := st.UpsertThread(ctx, store.Thread{
+		RepoID: repoID, GitHubID: "601", Number: 601, Kind: "issue", State: "open",
+		Title: "Custom basis vector", Body: "custom vector body",
+		HTMLURL: "https://github.com/openclaw/openclaw/issues/601", LabelsJSON: "[]", AssigneesJSON: "[]",
+		RawJSON: "{}", ContentHash: "hash-601", UpdatedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("seed thread: %v", err)
+	}
+	if err := st.UpsertThreadVector(ctx, store.ThreadVector{
+		ThreadID: threadID, Basis: "external_basis", Model: "external-model", Dimensions: 2,
+		ContentHash: "external-hash", Vector: []float64{1, 0}, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("upsert vector: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	run := New()
+	var stdout bytes.Buffer
+	run.Stdout = &stdout
+	if err := run.Run(ctx, []string{"--config", configPath, "cluster", "openclaw/openclaw", "--basis", "external_basis", "--model", "external-model", "--json"}); err != nil {
+		t.Fatalf("cluster explicit basis: %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"cluster_count": 1`) {
+		t.Fatalf("cluster output = %q", stdout.String())
+	}
+
+	configure := New()
+	if err := configure.Run(ctx, []string{"--config", configPath, "configure", "--embed-model", "external-model", "--embedding-basis", "external_basis"}); err != nil {
+		t.Fatalf("configure custom basis: %v", err)
+	}
+	stdout.Reset()
+	configured := New()
+	configured.Stdout = &stdout
+	if err := configured.Run(ctx, []string{"--config", configPath, "cluster", "openclaw/openclaw", "--min-size", "1", "--json"}); err != nil {
+		t.Fatalf("cluster configured custom basis: %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"cluster_count": 1`) {
+		t.Fatalf("configured cluster output = %q", stdout.String())
 	}
 }
 

--- a/internal/store/clusters.go
+++ b/internal/store/clusters.go
@@ -684,6 +684,14 @@ func (s *Store) ReopenClusterLocally(ctx context.Context, repoID, clusterID int6
 }
 
 func (s *Store) SaveDurableClusters(ctx context.Context, repoID int64, inputs []DurableClusterInput) (SaveDurableClustersResult, error) {
+	return s.saveDurableClusters(ctx, repoID, inputs, false)
+}
+
+func (s *Store) SaveCompleteDurableClusters(ctx context.Context, repoID int64, inputs []DurableClusterInput) (SaveDurableClustersResult, error) {
+	return s.saveDurableClusters(ctx, repoID, inputs, true)
+}
+
+func (s *Store) saveDurableClusters(ctx context.Context, repoID int64, inputs []DurableClusterInput, retireMissing bool) (SaveDurableClustersResult, error) {
 	if repoID <= 0 {
 		return SaveDurableClustersResult{}, fmt.Errorf("repo id must be positive")
 	}
@@ -695,11 +703,13 @@ func (s *Store) SaveDurableClusters(ctx context.Context, repoID int64, inputs []
 			return err
 		}
 		result.RunID = runID
+		seenClusterIDs := make([]int64, 0, len(inputs))
 		for _, input := range inputs {
 			clusterID, err := tx.upsertDurableCluster(ctx, repoID, runID, input, now)
 			if err != nil {
 				return err
 			}
+			seenClusterIDs = append(seenClusterIDs, clusterID)
 			memberIDs := make([]int64, 0, len(input.Members))
 			for _, member := range input.Members {
 				if member.ThreadID <= 0 {
@@ -737,9 +747,14 @@ func (s *Store) SaveDurableClusters(ctx context.Context, repoID int64, inputs []
 				return err
 			}
 		}
+		if retireMissing {
+			if err := tx.markMissingDurableClustersRetired(ctx, repoID, runID, seenClusterIDs, now); err != nil {
+				return err
+			}
+		}
 		if len(inputs) > 0 {
 			if _, err := tx.q().ExecContext(ctx, `
-				delete from cluster_groups
+					delete from cluster_groups
 				where repo_id = ?
 				  and cluster_type = 'similarity'
 			`, repoID); err != nil {
@@ -976,17 +991,25 @@ func (s *Store) upsertDurableCluster(ctx context.Context, repoID, runID int64, i
 			repo_id, stable_key, stable_slug, status, cluster_type, representative_thread_id, title, created_at, updated_at
 		)
 		values(?, ?, ?, 'active', ?, ?, ?, ?, ?)
-		on conflict(repo_id, stable_key) do update set
-			stable_slug = excluded.stable_slug,
-			cluster_type = excluded.cluster_type,
-			representative_thread_id = case
-				when cluster_groups.status = 'closed' then cluster_groups.representative_thread_id
-				else excluded.representative_thread_id
-			end,
-			title = excluded.title,
-			updated_at = excluded.updated_at
-		returning id
-	`, repoID, stableKey, stableSlug, clusterType, nullInt(input.RepresentativeThreadID), nullString(input.Title), now, now).Scan(&clusterID); err != nil {
+			on conflict(repo_id, stable_key) do update set
+				status = case
+					when exists(select 1 from cluster_closures where cluster_id = cluster_groups.id and actor_kind = 'local') then cluster_groups.status
+					else 'active'
+				end,
+				stable_slug = excluded.stable_slug,
+				cluster_type = excluded.cluster_type,
+				representative_thread_id = case
+					when exists(select 1 from cluster_closures where cluster_id = cluster_groups.id and actor_kind = 'local') then cluster_groups.representative_thread_id
+					else excluded.representative_thread_id
+				end,
+				title = excluded.title,
+				closed_at = case
+					when exists(select 1 from cluster_closures where cluster_id = cluster_groups.id and actor_kind = 'local') then cluster_groups.closed_at
+					else null
+				end,
+				updated_at = excluded.updated_at
+			returning id
+		`, repoID, stableKey, stableSlug, clusterType, nullInt(input.RepresentativeThreadID), nullString(input.Title), now, now).Scan(&clusterID); err != nil {
 		return 0, fmt.Errorf("upsert durable cluster: %w", err)
 	}
 	if _, err := s.q().ExecContext(ctx, `
@@ -996,6 +1019,52 @@ func (s *Store) upsertDurableCluster(ctx context.Context, repoID, runID int64, i
 		return 0, fmt.Errorf("record durable cluster event: %w", err)
 	}
 	return clusterID, nil
+}
+
+func (s *Store) markMissingDurableClustersRetired(ctx context.Context, repoID, runID int64, seenClusterIDs []int64, now string) error {
+	where := `repo_id = ? and status = 'active' and closed_at is null`
+	args := []any{now, now, repoID}
+	if len(seenClusterIDs) > 0 {
+		placeholders := make([]string, 0, len(seenClusterIDs))
+		for _, id := range seenClusterIDs {
+			placeholders = append(placeholders, "?")
+			args = append(args, id)
+		}
+		where += ` and id not in (` + strings.Join(placeholders, ",") + `)`
+	}
+	rows, err := s.q().QueryContext(ctx, `
+		update cluster_groups
+		set status = 'closed',
+			closed_at = ?,
+			updated_at = ?
+		where `+where+`
+		returning id
+	`, args...)
+	if err != nil {
+		return fmt.Errorf("retire missing durable clusters: %w", err)
+	}
+	defer rows.Close()
+
+	var retired []int64
+	for rows.Next() {
+		var clusterID int64
+		if err := rows.Scan(&clusterID); err != nil {
+			return fmt.Errorf("scan retired durable cluster: %w", err)
+		}
+		retired = append(retired, clusterID)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate retired durable clusters: %w", err)
+	}
+	for _, clusterID := range retired {
+		if _, err := s.q().ExecContext(ctx, `
+			insert into cluster_events(cluster_id, run_id, event_type, actor_kind, payload_json, created_at)
+			values(?, ?, 'retired', 'cluster', '{"reason":"not seen in latest cluster run"}', ?)
+		`, clusterID, runID, now); err != nil {
+			return fmt.Errorf("record retired durable cluster event: %w", err)
+		}
+	}
+	return nil
 }
 
 func (s *Store) markMissingClusterMembersRemoved(ctx context.Context, clusterID int64, memberIDs []int64, now string) error {

--- a/internal/store/clusters_test.go
+++ b/internal/store/clusters_test.go
@@ -526,3 +526,82 @@ func TestSaveDurableClustersAppliesLocalOverrides(t *testing.T) {
 		t.Fatalf("excluded member should remain visible with include closed: %#v", all)
 	}
 }
+
+func TestSaveDurableClustersRetiresMissingClusters(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	repoID, threadIDs := seedVectorThreads(t, ctx, st)
+	first := DurableClusterInput{
+		StableKey:              "members:301",
+		StableSlug:             "cluster-301",
+		RepresentativeThreadID: threadIDs[0],
+		Members:                []DurableClusterMemberInput{{ThreadID: threadIDs[0], Role: "canonical"}},
+	}
+	second := DurableClusterInput{
+		StableKey:              "members:302",
+		StableSlug:             "cluster-302",
+		RepresentativeThreadID: threadIDs[1],
+		Members:                []DurableClusterMemberInput{{ThreadID: threadIDs[1], Role: "canonical"}},
+	}
+	if _, err := st.SaveDurableClusters(ctx, repoID, []DurableClusterInput{first, second}); err != nil {
+		t.Fatalf("seed durable clusters: %v", err)
+	}
+	secondID, err := st.ClusterIDForThreadNumber(ctx, repoID, 302, false)
+	if err != nil {
+		t.Fatalf("second cluster id: %v", err)
+	}
+
+	if _, err := st.SaveDurableClusters(ctx, repoID, []DurableClusterInput{first}); err != nil {
+		t.Fatalf("partial resave without second cluster: %v", err)
+	}
+	if _, err := st.ClusterIDForThreadNumber(ctx, repoID, 302, false); err != nil {
+		t.Fatalf("partial save should not retire missing cluster: %v", err)
+	}
+
+	if _, err := st.SaveCompleteDurableClusters(ctx, repoID, []DurableClusterInput{first}); err != nil {
+		t.Fatalf("complete resave without second cluster: %v", err)
+	}
+	if _, err := st.ClusterIDForThreadNumber(ctx, repoID, 302, false); err == nil {
+		t.Fatal("cluster missing from complete save should not remain active")
+	}
+	retired, err := st.DurableClusterDetail(ctx, ClusterDetailOptions{RepoID: repoID, ClusterID: secondID, IncludeClosed: true, MemberLimit: 5})
+	if err != nil {
+		t.Fatalf("retired cluster detail: %v", err)
+	}
+	if retired.Cluster.Status != "closed" || retired.Cluster.ClosedAt == "" {
+		t.Fatalf("retired cluster = %+v", retired.Cluster)
+	}
+	var retiredEvents int
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from cluster_events where cluster_id = ? and event_type = 'retired'`, secondID).Scan(&retiredEvents); err != nil {
+		t.Fatalf("count retired events: %v", err)
+	}
+	if retiredEvents != 1 {
+		t.Fatalf("retired events = %d, want 1", retiredEvents)
+	}
+
+	if _, err := st.SaveCompleteDurableClusters(ctx, repoID, []DurableClusterInput{second}); err != nil {
+		t.Fatalf("resave with second cluster: %v", err)
+	}
+	reactivated, err := st.DurableClusterDetail(ctx, ClusterDetailOptions{RepoID: repoID, ClusterID: secondID, IncludeClosed: false, MemberLimit: 5})
+	if err != nil {
+		t.Fatalf("reactivated cluster detail: %v", err)
+	}
+	if reactivated.Cluster.Status != "active" || reactivated.Cluster.ClosedAt != "" {
+		t.Fatalf("reactivated cluster = %+v", reactivated.Cluster)
+	}
+
+	if err := st.CloseClusterLocally(ctx, repoID, secondID, "not actionable"); err != nil {
+		t.Fatalf("close second cluster: %v", err)
+	}
+	if _, err := st.SaveCompleteDurableClusters(ctx, repoID, []DurableClusterInput{second}); err != nil {
+		t.Fatalf("resave locally closed cluster: %v", err)
+	}
+	if _, err := st.DurableClusterDetail(ctx, ClusterDetailOptions{RepoID: repoID, ClusterID: secondID, IncludeClosed: false, MemberLimit: 5}); err == nil {
+		t.Fatal("locally closed cluster should stay hidden after reappearing")
+	}
+}

--- a/internal/store/embedding_tasks.go
+++ b/internal/store/embedding_tasks.go
@@ -88,6 +88,15 @@ func (s *Store) ListEmbeddingTasks(ctx context.Context, options EmbeddingTaskOpt
 	return out, nil
 }
 
+func SupportsEmbeddingBasis(basis string) bool {
+	switch strings.TrimSpace(basis) {
+	case "", "title_original", "dedupe_text", "llm_key_summary":
+		return true
+	default:
+		return false
+	}
+}
+
 func embeddingTextForBasis(basis, title, body, rawText, dedupeText, keySummary string) (string, error) {
 	text, _, err := embeddingTextForBasisWithMeta(basis, title, body, rawText, dedupeText, keySummary)
 	return text, err


### PR DESCRIPTION
## Summary
- add complete-run durable cluster saves that retire active clusters absent from a full successful run
- keep partial, limited, explicit model/basis, include-closed, stale-vector, migrated-vector, and unsupported-basis runs from retiring untouched clusters
- preserve local close overrides while allowing algorithm-retired clusters to reactivate when they reappear

## Validation
- go test ./internal/cli -run 'TestClusterCommandPersistsDurableClusters|TestCompleteClusterVectorCoverageRequiresFreshVectors|TestCompleteClusterVectorCoverageAllowsUnembeddableSummaryThreads|TestClusterCommandAllowsExplicitUnsupportedBasisWithoutRetirement' -count=1
- go test ./internal/store -run 'TestSaveDurableClusters(RetiresMissingClusters|AppliesLocalOverrides)|TestDurableClusterLifecycleAndClosedSummaries' -count=1
- env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
- codex-review clean: no accepted/actionable findings reported
