### PR TITLE
fix: normalize enterprise pagination links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Fix GitHub Enterprise pagination when API `Link` headers include the `/api/v3` base path, avoiding duplicated paths on follow-up pages.
 - Retire durable clusters that disappear from a successful clustering run, while still preserving local close overrides across reclustering.
 - Derive the default vector directory from custom database paths, including `GITCRAWL_DB_PATH`, so separate stores do not share embeddings unless `vector_dir` is set explicitly.
 - Refuse to refresh a portable store checkout when its Git remote does not match the requested portable store, avoiding accidental resets of unrelated working trees.

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -234,7 +234,7 @@ func (c *Client) paginate(ctx context.Context, firstPath string, limit int, expe
 		if limit > 0 && len(out) >= limit {
 			break
 		}
-		nextPath = nextPage(linkHeader)
+		nextPath = nextPage(linkHeader, c.baseURL)
 		if nextPath != "" && c.pageDelay > 0 {
 			select {
 			case <-ctx.Done():
@@ -374,7 +374,7 @@ func rateLimitWait(err error) (time.Duration, bool) {
 	return time.Second, true
 }
 
-func nextPage(linkHeader string) string {
+func nextPage(linkHeader, baseURL string) string {
 	for _, part := range strings.Split(linkHeader, ",") {
 		sections := strings.Split(part, ";")
 		if len(sections) < 2 {
@@ -388,12 +388,27 @@ func nextPage(linkHeader string) string {
 		if err != nil {
 			return ""
 		}
-		if parsed.RawQuery == "" {
-			return parsed.Path
-		}
-		return parsed.Path + "?" + parsed.RawQuery
+		return requestPathFromLink(parsed, baseURL)
 	}
 	return ""
+}
+
+func requestPathFromLink(parsed *url.URL, baseURL string) string {
+	path := parsed.EscapedPath()
+	base, err := url.Parse(strings.TrimRight(strings.TrimSpace(baseURL), "/"))
+	if err == nil && parsed.Host != "" && strings.EqualFold(parsed.Host, base.Host) {
+		basePath := strings.TrimRight(base.EscapedPath(), "/")
+		if basePath != "" && (path == basePath || strings.HasPrefix(path, basePath+"/")) {
+			path = strings.TrimPrefix(path, basePath)
+			if path == "" {
+				path = "/"
+			}
+		}
+	}
+	if parsed.RawQuery == "" {
+		return path
+	}
+	return path + "?" + parsed.RawQuery
 }
 
 func lastPage(linkHeader string) int {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -243,10 +243,14 @@ func TestListPullReviewThreadsDecodesGraphQLEnvelope(t *testing.T) {
 
 func TestNextPageAndReporterBranches(t *testing.T) {
 	header := `<https://api.github.test/repos/o/r/issues?page=2&state=open>; rel="next", <https://api.github.test/repos/o/r/issues?page=9>; rel="last"`
-	if got := nextPage(header); got != "/repos/o/r/issues?page=2&state=open" {
+	if got := nextPage(header, "https://api.github.test"); got != "/repos/o/r/issues?page=2&state=open" {
 		t.Fatalf("next page = %q", got)
 	}
-	if got := nextPage(`<bad-url>; rel="last"`); got != "" {
+	gheHeader := `<https://ghe.example/api/v3/repos/o/r/issues?page=2>; rel="next"`
+	if got := nextPage(gheHeader, "https://ghe.example/api/v3"); got != "/repos/o/r/issues?page=2" {
+		t.Fatalf("ghe next page = %q", got)
+	}
+	if got := nextPage(`<bad-url>; rel="last"`, "https://api.github.test"); got != "" {
 		t.Fatalf("bad next page = %q", got)
 	}
 	if got := lastPage(header); got != 9 {


### PR DESCRIPTION
## Summary
- strip the configured API base path from absolute pagination `Link` URLs before issuing follow-up requests
- keep normal github.com pagination paths unchanged
- document the GitHub Enterprise pagination fix in the changelog

## Validation
- go test ./internal/github -run 'TestNextPageAndReporterBranches|TestListRepositoryIssuesPaginatesAndLimits' -count=1
- env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
- codex-review clean: no accepted/actionable findings reported
