### PR TITLE
fix: paginate github run caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Fetch all paginated GitHub check runs and workflow runs instead of only the first 100 rows.
 - Fix GitHub Enterprise pagination when API `Link` headers include the `/api/v3` base path, avoiding duplicated paths on follow-up pages.
 - Retire durable clusters that disappear from a successful clustering run, while still preserving local close overrides across reclustering.
 - Derive the default vector directory from custom database paths, including `GITCRAWL_DB_PATH`, so separate stores do not share embeddings unless `vector_dir` is set explicitly.

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -162,14 +162,8 @@ func (c *Client) ListPullCommits(ctx context.Context, owner, repo string, number
 }
 
 func (c *Client) ListCommitCheckRuns(ctx context.Context, owner, repo, ref string, reporter Reporter) ([]map[string]any, error) {
-	var payload struct {
-		CheckRuns []map[string]any `json:"check_runs"`
-	}
 	path := fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs?per_page=100", pathEscape(owner), pathEscape(repo), pathEscape(ref))
-	if err := c.doJSON(ctx, http.MethodGet, path, nil, reporter, &payload); err != nil {
-		return nil, err
-	}
-	return payload.CheckRuns, nil
+	return c.paginateEnvelope(ctx, path, 0, 0, "check_runs", reporter)
 }
 
 func (c *Client) ListWorkflowRuns(ctx context.Context, owner, repo string, options ListWorkflowRunsOptions, reporter Reporter) ([]map[string]any, error) {
@@ -182,20 +176,38 @@ func (c *Client) ListWorkflowRuns(ctx context.Context, owner, repo string, optio
 		values.Set("head_sha", options.HeadSHA)
 	}
 	path := fmt.Sprintf("/repos/%s/%s/actions/runs?%s", pathEscape(owner), pathEscape(repo), values.Encode())
-	var payload struct {
-		WorkflowRuns []map[string]any `json:"workflow_runs"`
-	}
-	if err := c.doJSON(ctx, http.MethodGet, path, nil, reporter, &payload); err != nil {
-		return nil, err
-	}
-	rows := payload.WorkflowRuns
-	if options.Limit > 0 && len(rows) > options.Limit {
-		rows = rows[:options.Limit]
-	}
-	return rows, nil
+	return c.paginateEnvelope(ctx, path, options.Limit, 0, "workflow_runs", reporter)
 }
 
 func (c *Client) paginate(ctx context.Context, firstPath string, limit int, expectedItems int, reporter Reporter) ([]map[string]any, error) {
+	return c.paginatePages(ctx, firstPath, limit, expectedItems, reporter, func(resp *http.Response) ([]map[string]any, error) {
+		var rows []map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
+			return nil, fmt.Errorf("decode github page: %w", err)
+		}
+		return rows, nil
+	})
+}
+
+func (c *Client) paginateEnvelope(ctx context.Context, firstPath string, limit int, expectedItems int, field string, reporter Reporter) ([]map[string]any, error) {
+	return c.paginatePages(ctx, firstPath, limit, expectedItems, reporter, func(resp *http.Response) ([]map[string]any, error) {
+		var payload map[string]json.RawMessage
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			return nil, fmt.Errorf("decode github page: %w", err)
+		}
+		raw, ok := payload[field]
+		if !ok {
+			return nil, fmt.Errorf("decode github page: missing %q", field)
+		}
+		var rows []map[string]any
+		if err := json.Unmarshal(raw, &rows); err != nil {
+			return nil, fmt.Errorf("decode github page %q: %w", field, err)
+		}
+		return rows, nil
+	})
+}
+
+func (c *Client) paginatePages(ctx context.Context, firstPath string, limit int, expectedItems int, reporter Reporter, decode func(*http.Response) ([]map[string]any, error)) ([]map[string]any, error) {
 	var out []map[string]any
 	nextPath := firstPath
 	page := 0
@@ -205,14 +217,14 @@ func (c *Client) paginate(ctx context.Context, firstPath string, limit int, expe
 	}
 	for nextPath != "" {
 		page++
-		var rows []map[string]any
 		resp, err := c.do(ctx, http.MethodGet, nextPath, nil, reporter)
 		if err != nil {
 			return nil, err
 		}
-		if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
+		rows, err := decode(resp)
+		if err != nil {
 			_ = resp.Body.Close()
-			return nil, fmt.Errorf("decode github page: %w", err)
+			return nil, err
 		}
 		_ = resp.Body.Close()
 		if limit > 0 && len(out)+len(rows) > limit {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -207,6 +207,59 @@ func TestClientSingleResourceAndCollectionEndpoints(t *testing.T) {
 	}
 }
 
+func TestCheckRunsAndWorkflowRunsPaginate(t *testing.T) {
+	requests := map[string]int{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests[r.URL.Path]++
+		page := r.URL.Query().Get("page")
+		switch r.URL.Path {
+		case "/repos/openclaw/gitcrawl/commits/abc/check-runs":
+			switch page {
+			case "":
+				w.Header().Set("Link", `<`+serverURL(r)+`?page=2>; rel="next"`)
+				_ = json.NewEncoder(w).Encode(map[string]any{"check_runs": []map[string]any{{"name": "test-1"}, {"name": "test-2"}}})
+			case "2":
+				_ = json.NewEncoder(w).Encode(map[string]any{"check_runs": []map[string]any{{"name": "test-3"}}})
+			default:
+				t.Fatalf("unexpected check-runs page: %s", r.URL.RawQuery)
+			}
+		case "/repos/openclaw/gitcrawl/actions/runs":
+			switch page {
+			case "":
+				w.Header().Set("Link", `<`+serverURL(r)+`?page=2>; rel="next"`)
+				_ = json.NewEncoder(w).Encode(map[string]any{"workflow_runs": []map[string]any{{"id": 1}, {"id": 2}}})
+			case "2":
+				_ = json.NewEncoder(w).Encode(map[string]any{"workflow_runs": []map[string]any{{"id": 3}, {"id": 4}}})
+			default:
+				t.Fatalf("unexpected workflow-runs page: %s", r.URL.RawQuery)
+			}
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.String())
+		}
+	}))
+	defer server.Close()
+
+	client := New(Options{BaseURL: server.URL, PageDelay: -1})
+	ctx := context.Background()
+	checks, err := client.ListCommitCheckRuns(ctx, "openclaw", "gitcrawl", "abc", nil)
+	if err != nil {
+		t.Fatalf("list checks: %v", err)
+	}
+	if len(checks) != 3 || checks[2]["name"] != "test-3" {
+		t.Fatalf("checks = %#v", checks)
+	}
+	runs, err := client.ListWorkflowRuns(ctx, "openclaw", "gitcrawl", ListWorkflowRunsOptions{HeadSHA: "abc", Limit: 3}, nil)
+	if err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	if len(runs) != 3 || intValue(runs[2]["id"]) != 3 {
+		t.Fatalf("runs = %#v", runs)
+	}
+	if requests["/repos/openclaw/gitcrawl/commits/abc/check-runs"] != 2 || requests["/repos/openclaw/gitcrawl/actions/runs"] != 2 {
+		t.Fatalf("requests = %+v", requests)
+	}
+}
+
 func TestListPullReviewThreadsDecodesGraphQLEnvelope(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/graphql" {


### PR DESCRIPTION
## Summary
- reuse the pagination loop for GitHub envelope responses such as check runs and workflow runs
- keep workflow run limits applied across pages instead of after only the first page
- add regression coverage for paginated check-run and workflow-run responses

## Validation
- go test ./internal/github -run 'TestCheckRunsAndWorkflowRunsPaginate|TestClientSingleResourceAndCollectionEndpoints' -count=1
- env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
- codex-review clean: no accepted/actionable findings reported
