### PR TITLE
fix: reject non-finite float options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Reject non-finite CLI float options such as `NaN` before commands can mutate local cluster state.
 - Fetch all paginated GitHub check runs and workflow runs instead of only the first 100 rows.
 - Fix GitHub Enterprise pagination when API `Link` headers include the `/api/v3` base path, avoiding duplicated paths on follow-up pages.
 - Retire durable clusters that disappear from a successful clustering run, while still preserving local close overrides across reclustering.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net/url"
 	"os"
 	"os/exec"
@@ -3034,6 +3035,9 @@ func parseOptionalFloat(value string) (float64, error) {
 	parsed, err := strconv.ParseFloat(value, 64)
 	if err != nil {
 		return 0, fmt.Errorf("expected number, got %q", value)
+	}
+	if math.IsNaN(parsed) || math.IsInf(parsed, 0) {
+		return 0, fmt.Errorf("expected finite number, got %q", value)
 	}
 	return parsed, nil
 }

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -3070,6 +3070,66 @@ func TestClusterCommandAllowsExplicitUnsupportedBasisWithoutRetirement(t *testin
 	}
 }
 
+func TestClusterCommandRejectsNonFiniteThresholdBeforeMutation(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	dbPath := filepath.Join(dir, "gitcrawl.db")
+	app := New()
+	if err := app.Run(ctx, []string{"--config", configPath, "init", "--db", dbPath}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	st, err := store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	repoID, err := st.UpsertRepository(ctx, store.Repository{Owner: "openclaw", Name: "openclaw", FullName: "openclaw/openclaw", RawJSON: "{}", UpdatedAt: now})
+	if err != nil {
+		t.Fatalf("seed repository: %v", err)
+	}
+	for number, vector := range map[int][]float64{701: {1, 0}, 702: {0.95, 0.05}} {
+		threadID, err := st.UpsertThread(ctx, store.Thread{
+			RepoID: repoID, GitHubID: strconv.Itoa(number), Number: number, Kind: "issue", State: "open",
+			Title: "Non finite threshold", HTMLURL: fmt.Sprintf("https://github.com/openclaw/openclaw/issues/%d", number),
+			LabelsJSON: "[]", AssigneesJSON: "[]", RawJSON: "{}", ContentHash: fmt.Sprintf("hash-%d", number), UpdatedAt: now,
+		})
+		if err != nil {
+			t.Fatalf("seed thread %d: %v", number, err)
+		}
+		if err := st.UpsertThreadVector(ctx, store.ThreadVector{
+			ThreadID: threadID, Basis: "title_original", Model: "text-embedding-3-small", Dimensions: 2,
+			ContentHash: fmt.Sprintf("hash-%d", number), Vector: vector, CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("upsert vector %d: %v", number, err)
+		}
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	run := New()
+	var stdout bytes.Buffer
+	run.Stdout = &stdout
+	if err := run.Run(ctx, []string{"--config", configPath, "cluster", "openclaw/openclaw", "--threshold", "NaN", "--json"}); err == nil {
+		t.Fatal("cluster with NaN threshold should fail")
+	}
+	st, err = store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer st.Close()
+	for _, table := range []string{"cluster_runs", "cluster_groups"} {
+		var count int
+		if err := st.DB().QueryRowContext(ctx, `select count(*) from `+table).Scan(&count); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		if count != 0 {
+			t.Fatalf("%s count = %d, want 0", table, count)
+		}
+	}
+}
+
 func TestBuildDurableClusterInputsPrunesWeakCrossKindEdges(t *testing.T) {
 	ctx := context.Background()
 	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))


### PR DESCRIPTION
## Summary
- reject `NaN` and infinity values in the shared CLI float parser
- add a cluster regression proving a non-finite threshold fails before writing cluster state
- document the CLI validation fix in the changelog

## Validation
- go test ./internal/cli -run 'TestClusterCommandRejectsNonFiniteThresholdBeforeMutation|TestAppOutputModesAndUsageBranches' -count=1
- env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
- codex-review clean: no accepted/actionable findings reported
