### PR TITLE
fix: ignore cross-repo cluster references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Ignore cross-repository `owner/repo#number` references when building deterministic cluster edges for the current repository.
 - Reject non-finite CLI float options such as `NaN` before commands can mutate local cluster state.
 - Fetch all paginated GitHub check runs and workflow runs instead of only the first 100 rows.
 - Fix GitHub Enterprise pagination when API `Link` headers include the `/api/v3` base path, avoiding duplicated paths on follow-up pages.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -43,7 +43,7 @@ const (
 	bodyRefEvidencePrefixChars = 240
 )
 
-var threadReferencePattern = regexp.MustCompile(`(?i)(?:\b[\w.-]+/[\w.-]+#(\d+)|(?:issues|pull)/(\d+)|#(\d{2,}))`)
+var threadReferencePattern = regexp.MustCompile(`(?i)(?:\b([\w.-]+/[\w.-]+)#(\d+)|(?:issues|pull)/(\d+)|#(\d{2,}))`)
 var githubThreadURLPattern = regexp.MustCompile(`(?i)^https?://github\.com/([\w.-]+)/([\w.-]+)/(?:issues|pull)/(\d+)(?:[/?#].*)?$`)
 var ownerRepoThreadPattern = regexp.MustCompile(`(?i)^([\w.-]+)/([\w.-]+)#(\d+)$`)
 var pathThreadPattern = regexp.MustCompile(`(?i)(?:^|/)(?:issues|pull)/(\d+)(?:[/?#].*)?$`)
@@ -2780,7 +2780,11 @@ func buildDurableClusterInputs(ctx context.Context, st *store.Store, repoID int6
 			upsertClusterEdge(candidateByPair, leftID, rightID, score)
 		}
 	}
-	addDeterministicReferenceEdges(candidateByPair, nodes, threads)
+	repoFullName, err := repositoryFullNameByID(ctx, st, repoID)
+	if err != nil {
+		return nil, 0, err
+	}
+	addDeterministicReferenceEdges(candidateByPair, nodes, threads, repoFullName)
 	candidates := make([]clusterer.Edge, 0, len(candidateByPair))
 	for _, edge := range candidateByPair {
 		candidates = append(candidates, edge)
@@ -2846,7 +2850,20 @@ func upsertClusterEdge(edges map[string]clusterer.Edge, leftID, rightID int64, s
 	edges[key] = clusterer.Edge{LeftThreadID: leftID, RightThreadID: rightID, Score: score}
 }
 
-func addDeterministicReferenceEdges(edges map[string]clusterer.Edge, nodes []clusterer.Node, threads map[int64]store.Thread) {
+func repositoryFullNameByID(ctx context.Context, st *store.Store, repoID int64) (string, error) {
+	repositories, err := st.ListRepositories(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, repo := range repositories {
+		if repo.ID == repoID {
+			return repo.FullName, nil
+		}
+	}
+	return "", fmt.Errorf("repository id %d not found", repoID)
+}
+
+func addDeterministicReferenceEdges(edges map[string]clusterer.Edge, nodes []clusterer.Node, threads map[int64]store.Thread, repoFullName string) {
 	threadIDByNumber := make(map[int]int64, len(nodes))
 	for _, node := range nodes {
 		thread := threads[node.ThreadID]
@@ -2855,7 +2872,7 @@ func addDeterministicReferenceEdges(edges map[string]clusterer.Edge, nodes []clu
 	refIDsByThreadID := make(map[int64]map[int64]bool, len(nodes))
 	for _, node := range nodes {
 		thread := threads[node.ThreadID]
-		refNumbers := referencedThreadNumbersByLocation(thread)
+		refNumbers := referencedThreadNumbersByLocation(thread, repoFullName)
 		refIDs := map[int64]bool{}
 		for number, evidence := range refNumbers {
 			if referencedID, ok := threadIDByNumber[number]; ok && referencedID != node.ThreadID {
@@ -2874,21 +2891,26 @@ func addDeterministicReferenceEdges(edges map[string]clusterer.Edge, nodes []clu
 	}
 }
 
-func referencedThreadNumbersByLocation(thread store.Thread) map[int]referenceEvidence {
+func referencedThreadNumbersByLocation(thread store.Thread, repoFullName string) map[int]referenceEvidence {
 	refs := map[int]referenceEvidence{}
-	collectReferencedThreadNumbers(refs, thread.Number, thread.Body, false)
-	collectReferencedThreadNumbers(refs, thread.Number, thread.Title, true)
+	collectReferencedThreadNumbers(refs, thread.Number, thread.Body, false, repoFullName)
+	collectReferencedThreadNumbers(refs, thread.Number, thread.Title, true, repoFullName)
 	return refs
 }
 
-func collectReferencedThreadNumbers(refs map[int]referenceEvidence, threadNumber int, value string, titleRef bool) {
+func collectReferencedThreadNumbers(refs map[int]referenceEvidence, threadNumber int, value string, titleRef bool, repoFullName string) {
 	for _, match := range threadReferencePattern.FindAllStringSubmatchIndex(value, -1) {
 		numberText := ""
-		for index := 2; index+1 < len(match); index += 2 {
-			if match[index] >= 0 {
-				numberText = value[match[index]:match[index+1]]
-				break
+		if match[2] >= 0 {
+			refRepo := value[match[2]:match[3]]
+			if !strings.EqualFold(refRepo, repoFullName) {
+				continue
 			}
+			numberText = value[match[4]:match[5]]
+		} else if match[6] >= 0 {
+			numberText = value[match[6]:match[7]]
+		} else if match[8] >= 0 {
+			numberText = value[match[8]:match[9]]
 		}
 		number, err := strconv.Atoi(numberText)
 		if err != nil || number <= 0 || number == threadNumber {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -3285,6 +3285,78 @@ func TestBuildDurableClusterInputsKeepsDeterministicReferenceEdges(t *testing.T)
 	}
 }
 
+func TestBuildDurableClusterInputsIgnoresCrossRepoQualifiedReferences(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	repoID, err := st.UpsertRepository(ctx, store.Repository{
+		Owner:     "openclaw",
+		Name:      "openclaw",
+		FullName:  "openclaw/openclaw",
+		RawJSON:   "{}",
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		t.Fatalf("seed repository: %v", err)
+	}
+	issueID, err := st.UpsertThread(ctx, store.Thread{
+		RepoID:        repoID,
+		GitHubID:      "901",
+		Number:        901,
+		Kind:          "issue",
+		State:         "open",
+		Title:         "Gateway token regression",
+		Body:          "Users cannot authorize device tokens.",
+		HTMLURL:       "https://github.com/openclaw/openclaw/issues/901",
+		LabelsJSON:    "[]",
+		AssigneesJSON: "[]",
+		RawJSON:       "{}",
+		ContentHash:   "hash-901",
+		UpdatedAt:     time.Now().UTC().Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		t.Fatalf("seed issue: %v", err)
+	}
+	prID, err := st.UpsertThread(ctx, store.Thread{
+		RepoID:        repoID,
+		GitHubID:      "902",
+		Number:        902,
+		Kind:          "pull_request",
+		State:         "open",
+		Title:         "Repair auth scope migration",
+		Body:          "Fixes otherorg/other#901 by preserving the device-token scope during upgrade.",
+		HTMLURL:       "https://github.com/openclaw/openclaw/pull/902",
+		LabelsJSON:    "[]",
+		AssigneesJSON: "[]",
+		RawJSON:       "{}",
+		ContentHash:   "hash-902",
+		UpdatedAt:     time.Now().UTC().Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		t.Fatalf("seed pull request: %v", err)
+	}
+	vectors := []store.ThreadVector{
+		{ThreadID: issueID, Vector: []float64{1, 0}},
+		{ThreadID: prID, Vector: []float64{0, 1}},
+	}
+	inputs, edgeCount, err := buildDurableClusterInputs(ctx, st, repoID, vectors, clusterBuildOptions{
+		Threshold:          0.99,
+		MinSize:            2,
+		MaxClusterSize:     defaultClusterMaxSize,
+		Fanout:             16,
+		CrossKindThreshold: 0.99,
+	})
+	if err != nil {
+		t.Fatalf("build inputs: %v", err)
+	}
+	if edgeCount != 0 || len(inputs) != 0 {
+		t.Fatalf("cross-repo qualified refs should not form evidence edges, edges=%d inputs=%#v", edgeCount, inputs)
+	}
+}
+
 func TestBuildDurableClusterInputsIgnoresBareOneDigitProseRefs(t *testing.T) {
 	ctx := context.Background()
 	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))


### PR DESCRIPTION
## Summary
- keep repo-qualified thread references as repo-qualified during deterministic cluster edge extraction
- ignore `owner/repo#number` references that point outside the current repository
- add regression coverage for cross-repo qualified refs plus changelog note

## Validation
- `go test ./internal/cli -run 'TestBuildDurableClusterInputs(KeepsDeterministicReferenceEdges|IgnoresCrossRepoQualifiedReferences|IgnoresBareOneDigitProseRefs|PrunesBodyOnlyUnrelatedReferences)' -count=1`
- `env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...`
- `codex-review clean: no accepted/actionable findings reported`
