### PR TITLE
fix: remove stale refresh help flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Remove the search-only `--sync-if-stale` flag from `gitcrawl refresh` help text.
 - Ignore cross-repository `owner/repo#number` references when building deterministic cluster edges for the current repository.
 - Reject non-finite CLI float options such as `NaN` before commands can mutate local cluster state.
 - Fetch all paginated GitHub check runs and workflow runs instead of only the first 100 rows.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -3266,7 +3266,7 @@ Usage:
 	"refresh": `gitcrawl refresh runs sync, enrichment, embedding, and clustering.
 
 Usage:
-  gitcrawl refresh owner/repo [--state open|closed|all] [--sync-if-stale duration] [--no-sync] [--no-embed] [--no-cluster] [--json]
+  gitcrawl refresh owner/repo [--state open|closed|all] [--no-sync] [--no-embed] [--no-cluster] [--json]
 `,
 	"embed": `gitcrawl embed generates OpenAI embeddings for local thread documents.
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -173,6 +173,13 @@ func TestMetadataStatusAndControlStatusJSON(t *testing.T) {
 			t.Fatalf("%s help output = %q", topic, helpOut.String())
 		}
 	}
+	helpOut.Reset()
+	if err := help.printCommandUsage("refresh"); err != nil {
+		t.Fatalf("refresh help: %v", err)
+	}
+	if strings.Contains(helpOut.String(), "--sync-if-stale") {
+		t.Fatalf("refresh help should not advertise search-only --sync-if-stale: %q", helpOut.String())
+	}
 	if err := New().Run(ctx, []string{"--config", configPath, "status", "extra"}); err == nil {
 		t.Fatal("status extra arg should fail")
 	}


### PR DESCRIPTION
## Summary
- remove stale search-only `--sync-if-stale` from `gitcrawl refresh` command usage
- add a help regression so refresh usage stays aligned with implemented flags
- add changelog note

## Validation
- `go test ./internal/cli -run TestMetadataStatusAndControlStatusJSON -count=1`
- `env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...`
- `codex-review clean: no accepted/actionable findings reported`
