### PR TITLE
fix: implement semantic search modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Make direct `gitcrawl search --mode semantic` use query embeddings and `--mode hybrid` combine semantic and keyword hits instead of relabeling keyword-only search.
 - Remove the search-only `--sync-if-stale` flag from `gitcrawl refresh` help text.
 - Ignore cross-repository `owner/repo#number` references when building deterministic cluster edges for the current repository.
 - Reject non-finite CLI float options such as `NaN` before commands can mutate local cluster state.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -43,6 +43,8 @@ const (
 	bodyRefEvidencePrefixChars = 240
 )
 
+var errNoSemanticVectors = errors.New("no semantic vectors")
+
 var threadReferencePattern = regexp.MustCompile(`(?i)(?:\b([\w.-]+/[\w.-]+)#(\d+)|(?:issues|pull)/(\d+)|#(\d{2,}))`)
 var githubThreadURLPattern = regexp.MustCompile(`(?i)^https?://github\.com/([\w.-]+)/([\w.-]+)/(?:issues|pull)/(\d+)(?:[/?#].*)?$`)
 var ownerRepoThreadPattern = regexp.MustCompile(`(?i)^([\w.-]+)/([\w.-]+)#(\d+)$`)
@@ -509,16 +511,180 @@ func (a *App) runSearch(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	hits, err := rt.Store.SearchDocuments(ctx, repo.ID, strings.TrimSpace(*query), limit)
+	queryText := strings.TrimSpace(*query)
+	hits, effectiveMode, err := a.searchDocuments(ctx, rt, repo.ID, queryText, limit, searchMode)
 	if err != nil {
 		return err
 	}
-	return a.writeOutput("search", map[string]any{
+	payload := map[string]any{
 		"repository": repo.FullName,
-		"query":      strings.TrimSpace(*query),
-		"mode":       searchMode,
+		"query":      queryText,
+		"mode":       effectiveMode,
 		"hits":       hits,
-	}, true)
+	}
+	if effectiveMode != searchMode {
+		payload["requested_mode"] = searchMode
+	}
+	return a.writeOutput("search", payload, true)
+}
+
+func (a *App) searchDocuments(ctx context.Context, rt localRuntime, repoID int64, query string, limit int, mode string) ([]store.SearchHit, string, error) {
+	switch mode {
+	case "keyword":
+		hits, err := rt.Store.SearchDocuments(ctx, repoID, query, limit)
+		return hits, "keyword", err
+	case "semantic":
+		hits, err := a.semanticSearchDocuments(ctx, rt, repoID, query, limit)
+		if errors.Is(err, errNoSemanticVectors) {
+			return nil, "semantic", nil
+		}
+		return hits, "semantic", err
+	case "hybrid":
+		keywordHits, err := rt.Store.SearchDocuments(ctx, repoID, query, limit)
+		if err != nil {
+			return nil, "", err
+		}
+		semanticHits, err := a.semanticSearchDocuments(ctx, rt, repoID, query, limit)
+		if err != nil {
+			if !canFallbackFromSemanticSearch(err) {
+				return nil, "", err
+			}
+			return keywordHits, "keyword", nil
+		}
+		return mergeHybridSearchHits(keywordHits, semanticHits, limit), "hybrid", nil
+	default:
+		return nil, "", fmt.Errorf("unsupported search mode %q", mode)
+	}
+}
+
+func canFallbackFromSemanticSearch(err error) bool {
+	return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded)
+}
+
+func (a *App) semanticSearchDocuments(ctx context.Context, rt localRuntime, repoID int64, query string, limit int) ([]store.SearchHit, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	vectorQuery := store.ThreadVectorQuery{
+		RepoID:        repoID,
+		Model:         rt.Config.OpenAI.EmbedModel,
+		Basis:         rt.Config.EmbeddingBasis,
+		IncludeClosed: true,
+	}
+	storedVectors, err := semanticSearchVectors(ctx, rt.Store, vectorQuery)
+	if err != nil {
+		return nil, err
+	}
+	if len(storedVectors) == 0 {
+		return nil, errNoSemanticVectors
+	}
+	token := config.ResolveOpenAIKey(rt.Config)
+	if token.Value == "" {
+		return nil, fmt.Errorf("semantic search requires OpenAI API key: set %s", rt.Config.OpenAI.APIKeyEnv)
+	}
+	client := openai.New(openai.Options{APIKey: token.Value, BaseURL: openAIBaseURL(), Dimensions: rt.Config.OpenAI.EmbedDimensions, Retry: embedRetryOverride()})
+	queryVectors, err := client.Embed(ctx, rt.Config.OpenAI.EmbedModel, []string{query})
+	if err != nil {
+		return nil, err
+	}
+	if len(queryVectors) == 0 {
+		return nil, nil
+	}
+	storedVectors = threadVectorsWithDimensions(storedVectors, len(queryVectors[0]))
+	if len(storedVectors) == 0 {
+		return nil, nil
+	}
+	items := make([]vector.Item, 0, len(storedVectors))
+	for _, stored := range storedVectors {
+		items = append(items, vector.Item{ThreadID: stored.ThreadID, Vector: stored.Vector})
+	}
+	neighbors := vector.Query(items, queryVectors[0], limit, 0)
+	ids := make([]int64, 0, len(neighbors))
+	scoreByThreadID := make(map[int64]float64, len(neighbors))
+	for _, neighbor := range neighbors {
+		ids = append(ids, neighbor.ThreadID)
+		scoreByThreadID[neighbor.ThreadID] = neighbor.Score
+	}
+	threads, err := rt.Store.ThreadsByIDs(ctx, repoID, ids)
+	if err != nil {
+		return nil, err
+	}
+	hits := make([]store.SearchHit, 0, len(neighbors))
+	for _, neighbor := range neighbors {
+		thread, ok := threads[neighbor.ThreadID]
+		if !ok {
+			continue
+		}
+		hits = append(hits, store.SearchHit{
+			ThreadID:    thread.ID,
+			Number:      thread.Number,
+			Kind:        thread.Kind,
+			State:       thread.State,
+			Title:       thread.Title,
+			HTMLURL:     thread.HTMLURL,
+			AuthorLogin: thread.AuthorLogin,
+			Snippet:     thread.Title,
+			Score:       scoreByThreadID[neighbor.ThreadID],
+		})
+	}
+	return hits, nil
+}
+
+func semanticSearchVectors(ctx context.Context, st *store.Store, query store.ThreadVectorQuery) ([]store.ThreadVector, error) {
+	storedVectors, err := st.ListThreadVectorsFiltered(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	if len(storedVectors) > 0 || strings.TrimSpace(query.Basis) == "" {
+		return storedVectors, nil
+	}
+	query.Basis = ""
+	return st.ListThreadVectorsFiltered(ctx, query)
+}
+
+func threadVectorsWithDimensions(vectors []store.ThreadVector, dimensions int) []store.ThreadVector {
+	out := vectors[:0]
+	for _, stored := range vectors {
+		if stored.Dimensions == dimensions && len(stored.Vector) == dimensions {
+			out = append(out, stored)
+		}
+	}
+	return out
+}
+
+func mergeHybridSearchHits(keywordHits, semanticHits []store.SearchHit, limit int) []store.SearchHit {
+	if limit <= 0 {
+		limit = 20
+	}
+	seen := make(map[int64]bool, len(keywordHits)+len(semanticHits))
+	out := make([]store.SearchHit, 0, limit)
+	maxLen := len(keywordHits)
+	if len(semanticHits) > maxLen {
+		maxLen = len(semanticHits)
+	}
+	for index := 0; index < maxLen; index++ {
+		if index < len(keywordHits) {
+			out = appendSearchHit(out, seen, keywordHits[index], limit)
+		}
+		if len(out) >= limit {
+			return out
+		}
+		if index < len(semanticHits) {
+			out = appendSearchHit(out, seen, semanticHits[index], limit)
+		}
+		if len(out) >= limit {
+			return out
+		}
+	}
+	return out
+}
+
+func appendSearchHit(out []store.SearchHit, seen map[int64]bool, hit store.SearchHit, limit int) []store.SearchHit {
+	if seen[hit.ThreadID] || len(out) >= limit {
+		return out
+	}
+	seen[hit.ThreadID] = true
+	return append(out, hit)
 }
 
 func (a *App) runNeighbors(ctx context.Context, args []string) error {
@@ -3281,8 +3447,8 @@ Usage:
 	"search": `gitcrawl search queries local thread documents, or accepts gh-shaped issue and PR search.
 
 Usage:
-  gitcrawl search owner/repo --query text [--mode keyword|semantic] [--limit N] [--json]
-  gitcrawl search issues|prs <query> -R owner/repo [--state open|closed|all] [--json fields] [--limit N]
+  gitcrawl search owner/repo --query text [--mode keyword|semantic|hybrid] [--limit N] [--json]
+  gitcrawl search issues|prs <query> -R owner/repo [--state open|closed|all] [--json fields] [--limit N] [--sync-if-stale duration]
 `,
 	"cluster": `gitcrawl cluster builds durable clusters from local thread vectors.
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1567,6 +1568,26 @@ func TestCommandFlowCoversSearchEmbedNeighborsClusterDetailRunsAndRefresh(t *tes
 		t.Fatalf("embed output = %q", stdout.String())
 	}
 
+	semanticSearch := New()
+	stdout.Reset()
+	semanticSearch.Stdout = &stdout
+	if err := semanticSearch.Run(ctx, []string{"--config", configPath, "search", "openclaw/openclaw", "--query", "semantic-only", "--mode", "semantic", "--limit", "2", "--json"}); err != nil {
+		t.Fatalf("semantic search: %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"mode": "semantic"`) || !strings.Contains(stdout.String(), `"number": 103`) {
+		t.Fatalf("semantic search output = %q", stdout.String())
+	}
+
+	hybridSearch := New()
+	stdout.Reset()
+	hybridSearch.Stdout = &stdout
+	if err := hybridSearch.Run(ctx, []string{"--config", configPath, "search", "openclaw/openclaw", "--query", "semantic-only", "--mode", "hybrid", "--limit", "2", "--json"}); err != nil {
+		t.Fatalf("hybrid search: %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"mode": "hybrid"`) || !strings.Contains(stdout.String(), `"number": 103`) {
+		t.Fatalf("hybrid search output = %q", stdout.String())
+	}
+
 	neighbors := New()
 	stdout.Reset()
 	neighbors.Stdout = &stdout
@@ -1654,6 +1675,39 @@ func TestCommandFlowCoversSearchEmbedNeighborsClusterDetailRunsAndRefresh(t *tes
 	}
 	if len(threads) != 2 {
 		t.Fatalf("threads by ids = %+v", threads)
+	}
+}
+
+func TestHybridSearchSkipsOpenAIWhenNoVectors(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	dbPath := filepath.Join(dir, "gitcrawl.db")
+	if err := New().Run(ctx, []string{"--config", configPath, "init", "--db", dbPath}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	seedCommandFlowStore(t, dbPath)
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]any{{"index": 0, "embedding": []float64{1, 0}}}})
+	}))
+	defer server.Close()
+	t.Setenv("OPENAI_API_KEY", "test-openai-key")
+	t.Setenv("GITCRAWL_OPENAI_BASE_URL", server.URL)
+
+	app := New()
+	var stdout bytes.Buffer
+	app.Stdout = &stdout
+	if err := app.Run(ctx, []string{"--config", configPath, "search", "openclaw/openclaw", "--query", "gateway websocket", "--mode", "hybrid", "--limit", "5", "--json"}); err != nil {
+		t.Fatalf("hybrid search: %v", err)
+	}
+	if atomic.LoadInt32(&calls) != 0 {
+		t.Fatalf("hybrid search made %d OpenAI calls without vectors", calls)
+	}
+	if !strings.Contains(stdout.String(), `"mode": "keyword"`) || !strings.Contains(stdout.String(), `"requested_mode": "hybrid"`) {
+		t.Fatalf("hybrid fallback output = %q", stdout.String())
 	}
 }
 
@@ -3583,6 +3637,45 @@ func TestKeepTopEdgesKeepsOneSidedNearestNeighbors(t *testing.T) {
 	}, 1)
 	if len(edges) != 2 {
 		t.Fatalf("one-sided top-k edges should be kept, got %#v", edges)
+	}
+}
+
+func TestMergeHybridSearchHitsReservesKeywordSlots(t *testing.T) {
+	got := mergeHybridSearchHits(
+		[]store.SearchHit{{ThreadID: 10, Number: 10}, {ThreadID: 20, Number: 20}},
+		[]store.SearchHit{{ThreadID: 30, Number: 30}, {ThreadID: 40, Number: 40}},
+		3,
+	)
+	want := []int{10, 30, 20}
+	if len(got) != len(want) {
+		t.Fatalf("hybrid hits = %#v, want %v", got, want)
+	}
+	for index, hit := range got {
+		if hit.Number != want[index] {
+			t.Fatalf("hybrid hit %d = #%d, want #%d; all=%#v", index, hit.Number, want[index], got)
+		}
+	}
+
+	got = mergeHybridSearchHits(
+		[]store.SearchHit{{ThreadID: 10, Number: 10}},
+		[]store.SearchHit{{ThreadID: 10, Number: 10}, {ThreadID: 30, Number: 30}},
+		3,
+	)
+	want = []int{10, 30}
+	if len(got) != len(want) || got[0].Number != want[0] || got[1].Number != want[1] {
+		t.Fatalf("deduped hybrid hits = %#v, want %v", got, want)
+	}
+}
+
+func TestCanFallbackFromSemanticSearchRejectsContextErrors(t *testing.T) {
+	if canFallbackFromSemanticSearch(context.Canceled) {
+		t.Fatal("canceled semantic search should not fall back to keyword results")
+	}
+	if canFallbackFromSemanticSearch(context.DeadlineExceeded) {
+		t.Fatal("deadline semantic search should not fall back to keyword results")
+	}
+	if !canFallbackFromSemanticSearch(errors.New("missing semantic dependency")) {
+		t.Fatal("ordinary semantic failure should allow keyword fallback")
 	}
 }
 

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -9,14 +9,15 @@ import (
 )
 
 type SearchHit struct {
-	ThreadID    int64  `json:"thread_id"`
-	Number      int    `json:"number"`
-	Kind        string `json:"kind"`
-	State       string `json:"state"`
-	Title       string `json:"title"`
-	HTMLURL     string `json:"html_url"`
-	AuthorLogin string `json:"author_login,omitempty"`
-	Snippet     string `json:"snippet"`
+	ThreadID    int64   `json:"thread_id"`
+	Number      int     `json:"number"`
+	Kind        string  `json:"kind"`
+	State       string  `json:"state"`
+	Title       string  `json:"title"`
+	HTMLURL     string  `json:"html_url"`
+	AuthorLogin string  `json:"author_login,omitempty"`
+	Snippet     string  `json:"snippet"`
+	Score       float64 `json:"score,omitempty"`
 }
 
 type ThreadSearchOptions struct {


### PR DESCRIPTION
## Summary
- make direct `gitcrawl search --mode semantic` embed the query and return vector-ranked hits
- make `--mode hybrid` merge keyword and semantic hits, with keyword fallback when semantic data is unavailable
- avoid OpenAI calls when hybrid search has no local vectors

## Validation
- `go test ./internal/cli -run 'TestCommandFlowCoversSearchEmbedNeighborsClusterDetailRunsAndRefresh|TestHybridSearchSkipsOpenAIWhenNoVectors|TestMergeHybridSearchHitsReservesKeywordSlots|TestCanFallbackFromSemanticSearchRejectsContextErrors' -count=1`
- `env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...`
- `codex-review --mode local --full-access --parallel-tests 'env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...'` clean
