### PR TITLE
fix: create build output directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ VERSION ?= dev
 .PHONY: build generate-sqlc test test-coverage run clean
 
 build:
+	mkdir -p bin
 	go build -ldflags "-X github.com/openclaw/gitcrawl/internal/cli.version=$(VERSION)" -o bin/$(BINARY) ./cmd/gitcrawl
 
 generate-sqlc:


### PR DESCRIPTION
## Summary
- create `bin/` in the `build` target before writing `bin/gitcrawl`

## Validation
- `make clean build`
- `env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...`
- `codex-review --mode local --full-access --parallel-tests 'make clean build && env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...'` clean
