### PR TITLE
fix: ignore cluster edges with missing endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Ignore cluster graph edges whose endpoints are absent from the visible node set, preventing hidden nodes from merging otherwise separate clusters.
 - Make direct `gitcrawl search --mode semantic` use query embeddings and `--mode hybrid` combine semantic and keyword hits instead of relabeling keyword-only search.
 - Remove the search-only `--sync-if-stale` flag from `gitcrawl refresh` help text.
 - Ignore cross-repository `owner/repo#number` references when building deterministic cluster edges for the current repository.

--- a/internal/cluster/build.go
+++ b/internal/cluster/build.go
@@ -29,13 +29,16 @@ func Build(nodes []Node, edges []Edge) []Cluster {
 
 func BuildWithOptions(nodes []Node, edges []Edge, options Options) []Cluster {
 	uf := newUnionFind()
+	nodeIDs := make(map[int64]struct{}, len(nodes))
 	for _, node := range nodes {
 		uf.add(node.ThreadID)
+		nodeIDs[node.ThreadID] = struct{}{}
 	}
-	keptEdges := edges
+	filteredEdges := filterEdgesByNodes(edges, nodeIDs)
+	keptEdges := filteredEdges
 	if options.MaxSize > 0 {
-		keptEdges = make([]Edge, 0, len(edges))
-		sortedEdges := append([]Edge(nil), edges...)
+		keptEdges = make([]Edge, 0, len(filteredEdges))
+		sortedEdges := append([]Edge(nil), filteredEdges...)
 		sort.SliceStable(sortedEdges, func(i, j int) bool {
 			if sortedEdges[i].Score == sortedEdges[j].Score {
 				if sortedEdges[i].LeftThreadID == sortedEdges[j].LeftThreadID {
@@ -51,7 +54,7 @@ func BuildWithOptions(nodes []Node, edges []Edge, options Options) []Cluster {
 			}
 		}
 	} else {
-		for _, edge := range edges {
+		for _, edge := range filteredEdges {
 			uf.union(edge.LeftThreadID, edge.RightThreadID)
 		}
 	}
@@ -62,6 +65,20 @@ func BuildWithOptions(nodes []Node, edges []Edge, options Options) []Cluster {
 		byRoot[root] = append(byRoot[root], node.ThreadID)
 	}
 	return format(nodes, keptEdges, byRoot)
+}
+
+func filterEdgesByNodes(edges []Edge, nodeIDs map[int64]struct{}) []Edge {
+	filtered := make([]Edge, 0, len(edges))
+	for _, edge := range edges {
+		if _, ok := nodeIDs[edge.LeftThreadID]; !ok {
+			continue
+		}
+		if _, ok := nodeIDs[edge.RightThreadID]; !ok {
+			continue
+		}
+		filtered = append(filtered, edge)
+	}
+	return filtered
 }
 
 func format(nodes []Node, edges []Edge, byRoot map[int64][]int64) []Cluster {

--- a/internal/cluster/build_test.go
+++ b/internal/cluster/build_test.go
@@ -47,6 +47,30 @@ func TestBuildWithOptionsKeepsStrongBoundedComponents(t *testing.T) {
 	}
 }
 
+func TestBuildIgnoresEdgesWithMissingEndpoints(t *testing.T) {
+	nodes := []Node{
+		{ThreadID: 1, Number: 10},
+		{ThreadID: 2, Number: 11},
+	}
+	edges := []Edge{
+		{LeftThreadID: 1, RightThreadID: 99, Score: 0.99},
+		{LeftThreadID: 99, RightThreadID: 2, Score: 0.99},
+	}
+	for name, clusters := range map[string][]Cluster{
+		"unbounded": Build(nodes, edges),
+		"bounded":   BuildWithOptions(nodes, edges, Options{MaxSize: 2}),
+	} {
+		if len(clusters) != 2 {
+			t.Fatalf("%s clusters: got %d want 2: %#v", name, len(clusters), clusters)
+		}
+		for _, cluster := range clusters {
+			if len(cluster.Members) != 1 {
+				t.Fatalf("%s cluster should not merge through absent endpoint: %#v", name, clusters)
+			}
+		}
+	}
+}
+
 func TestUnionFindAndRepresentativeTieBranches(t *testing.T) {
 	uf := newUnionFind()
 	uf.union(1, 2)


### PR DESCRIPTION
## Summary
- filter cluster graph edges to the visible node set before unioning components
- cover bounded and unbounded builds so missing endpoints cannot bridge visible nodes
- add changelog entry for the clustering behavior fix

## Validation
- `go test ./internal/cluster -count=1`
- `env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...`
- `codex-review --mode local --full-access --parallel-tests 'go test ./internal/cluster -count=1 && env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...'` clean
