### PR TITLE
fix: skip workflow fetch without head sha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Skip PR check-run and workflow-run hydration when GitHub returns no PR head SHA, avoiding broad workflow-run fetches.
 - Ignore cluster graph edges whose endpoints are absent from the visible node set, preventing hidden nodes from merging otherwise separate clusters.
 - Make direct `gitcrawl search --mode semantic` use query embeddings and `--mode hybrid` combine semantic and keyword hits instead of relabeling keyword-only search.
 - Remove the search-only `--sync-if-stale` flag from `gitcrawl refresh` help text.

--- a/internal/syncer/pull_details.go
+++ b/internal/syncer/pull_details.go
@@ -37,9 +37,12 @@ func (s *Syncer) syncPullRequestDetails(ctx context.Context, st *store.Store, op
 			return pullDetailStats{}, err
 		}
 	}
-	runsRaw, err := s.client.ListWorkflowRuns(ctx, options.Owner, options.Repo, gh.ListWorkflowRunsOptions{HeadSHA: headSHA, Limit: 20}, options.Reporter)
-	if err != nil {
-		return pullDetailStats{}, err
+	var runsRaw []map[string]any
+	if headSHA != "" {
+		runsRaw, err = s.client.ListWorkflowRuns(ctx, options.Owner, options.Repo, gh.ListWorkflowRunsOptions{HeadSHA: headSHA, Limit: 20}, options.Reporter)
+		if err != nil {
+			return pullDetailStats{}, err
+		}
 	}
 	detail := mapPullDetail(thread, pull, fetchedAt)
 	files := mapPullFiles(thread.ID, filesRaw, fetchedAt)

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -263,6 +263,31 @@ type pullDetailsGitHub struct {
 	fakeGitHub
 }
 
+type emptyHeadPullGitHub struct {
+	fakeGitHub
+	checksCalled bool
+	runsCalled   bool
+}
+
+func (emptyHeadPullGitHub) GetPull(ctx context.Context, owner, repo string, number int, reporter gh.Reporter) (map[string]any, error) {
+	return map[string]any{
+		"number":          number,
+		"head":            map[string]any{"ref": "feature", "repo": map[string]any{"full_name": "openclaw/gitcrawl"}},
+		"base":            map[string]any{"sha": "base-sha"},
+		"mergeable_state": "unknown",
+	}, nil
+}
+
+func (g *emptyHeadPullGitHub) ListCommitCheckRuns(ctx context.Context, owner, repo, ref string, reporter gh.Reporter) ([]map[string]any, error) {
+	g.checksCalled = true
+	return nil, nil
+}
+
+func (g *emptyHeadPullGitHub) ListWorkflowRuns(ctx context.Context, owner, repo string, options gh.ListWorkflowRunsOptions, reporter gh.Reporter) ([]map[string]any, error) {
+	g.runsCalled = true
+	return nil, nil
+}
+
 func (pullDetailsGitHub) ListPullReviewThreads(ctx context.Context, owner, repo string, number int, reporter gh.Reporter) ([]map[string]any, error) {
 	return pullCommentGitHub{}.ListPullReviewThreads(ctx, owner, repo, number, reporter)
 }
@@ -477,6 +502,31 @@ func TestSyncHydratesPullRequestDetails(t *testing.T) {
 	}
 	if fetchedAt == "" {
 		t.Fatal("missing review thread sync marker")
+	}
+}
+
+func TestSyncPullRequestDetailsSkipsCheckAndWorkflowFetchWithoutHeadSHA(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	client := &emptyHeadPullGitHub{}
+	s := New(client, st)
+	s.now = func() time.Time { return time.Date(2026, 4, 26, 0, 0, 0, 0, time.UTC) }
+	stats, err := s.Sync(ctx, Options{Owner: "openclaw", Repo: "gitcrawl", Numbers: []int{8}, IncludePRDetails: true})
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if stats.PRDetailsSynced != 1 || stats.PRChecksSynced != 0 || stats.WorkflowRunsSynced != 0 {
+		t.Fatalf("stats = %#v", stats)
+	}
+	if client.checksCalled {
+		t.Fatal("check runs should not be fetched without head SHA")
+	}
+	if client.runsCalled {
+		t.Fatal("workflow runs should not be fetched without head SHA")
 	}
 }
 


### PR DESCRIPTION
## Summary
- skip check-run and workflow-run hydration when PR detail has no head SHA
- add regression coverage for empty-head PR details so broad workflow run fetches cannot recur
- add changelog entry for the GitHub quota hygiene fix

## Validation
- `go test ./internal/syncer -run 'TestSyncHydratesPullRequestDetails|TestSyncPullRequestDetailsSkipsCheckAndWorkflowFetchWithoutHeadSHA' -count=1`
- `env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...`
- `codex-review --mode local --full-access --parallel-tests 'go test ./internal/syncer -run "TestSyncHydratesPullRequestDetails|TestSyncPullRequestDetailsSkipsCheckAndWorkflowFetchWithoutHeadSHA" -count=1 && env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...'` clean
