### PR TITLE
fix: avoid tx during pr detail fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Avoid holding SQLite write transactions open while hydrating PR details from GitHub.
 - Skip PR check-run and workflow-run hydration when GitHub returns no PR head SHA, avoiding broad workflow-run fetches.
 - Ignore cluster graph edges whose endpoints are absent from the visible node set, preventing hidden nodes from merging otherwise separate clusters.
 - Make direct `gitcrawl search --mode semantic` use query embeddings and `--mode hybrid` combine semantic and keyword hits instead of relabeling keyword-only search.

--- a/internal/store/review_threads.go
+++ b/internal/store/review_threads.go
@@ -31,6 +31,15 @@ type PullRequestReviewThread struct {
 }
 
 func (s *Store) UpsertPullRequestReviewThreads(ctx context.Context, threadID int64, fetchedAt string, threads []PullRequestReviewThread) error {
+	if s.queries == nil {
+		return s.WithTx(ctx, func(tx *Store) error {
+			return tx.upsertPullRequestReviewThreads(ctx, threadID, fetchedAt, threads)
+		})
+	}
+	return s.upsertPullRequestReviewThreads(ctx, threadID, fetchedAt, threads)
+}
+
+func (s *Store) upsertPullRequestReviewThreads(ctx context.Context, threadID int64, fetchedAt string, threads []PullRequestReviewThread) error {
 	if err := s.qsql().DeletePullRequestReviewThreads(ctx, threadID); err != nil {
 		return fmt.Errorf("clear pull request review threads: %w", err)
 	}

--- a/internal/store/review_threads_test.go
+++ b/internal/store/review_threads_test.go
@@ -1,0 +1,67 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUpsertPullRequestReviewThreadsRollsBackReplacementOnInsertError(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	repoID, err := st.UpsertRepository(ctx, Repository{Owner: "openclaw", Name: "gitcrawl", FullName: "openclaw/gitcrawl", RawJSON: "{}", UpdatedAt: "2026-05-15T00:00:00Z"})
+	if err != nil {
+		t.Fatalf("upsert repo: %v", err)
+	}
+	threadID, err := st.UpsertThread(ctx, Thread{
+		RepoID: repoID, GitHubID: "1", Number: 1, Kind: "pull_request", State: "open",
+		Title: "Atomic review threads", HTMLURL: "https://github.com/openclaw/gitcrawl/pull/1",
+		LabelsJSON: "[]", AssigneesJSON: "[]", RawJSON: "{}", ContentHash: "hash", UpdatedAt: "2026-05-15T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("upsert thread: %v", err)
+	}
+	oldFetchedAt := "2026-05-15T00:00:00Z"
+	if err := st.UpsertPullRequestReviewThreads(ctx, threadID, oldFetchedAt, []PullRequestReviewThread{{
+		ReviewThreadID: "old", IsResolved: false, CommentsJSON: "[]", RawJSON: "{}", FetchedAt: oldFetchedAt,
+	}}); err != nil {
+		t.Fatalf("seed review threads: %v", err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `
+		create trigger fail_review_thread_insert
+		before insert on pull_request_review_threads
+		begin
+			select raise(fail, 'blocked review thread insert');
+		end;
+	`); err != nil {
+		t.Fatalf("create fail trigger: %v", err)
+	}
+	defer st.DB().ExecContext(ctx, `drop trigger if exists fail_review_thread_insert`)
+
+	err = st.UpsertPullRequestReviewThreads(ctx, threadID, "2026-05-15T00:01:00Z", []PullRequestReviewThread{{
+		ReviewThreadID: "new", IsResolved: true, CommentsJSON: "[]", RawJSON: "{}", FetchedAt: "2026-05-15T00:01:00Z",
+	}})
+	if err == nil || !strings.Contains(err.Error(), "blocked review thread insert") {
+		t.Fatalf("expected trigger error, got %v", err)
+	}
+	threads, err := st.PullRequestReviewThreads(ctx, threadID)
+	if err != nil {
+		t.Fatalf("list review threads: %v", err)
+	}
+	if len(threads) != 1 || threads[0].ReviewThreadID != "old" {
+		t.Fatalf("review thread replacement should roll back, got %+v", threads)
+	}
+	fetchedAt, err := st.PullRequestReviewThreadsFetchedAt(ctx, threadID)
+	if err != nil {
+		t.Fatalf("review thread fetched marker: %v", err)
+	}
+	if fetchedAt != oldFetchedAt {
+		t.Fatalf("fetched marker = %q, want %q", fetchedAt, oldFetchedAt)
+	}
+}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -215,7 +215,7 @@ func (s *Syncer) Sync(ctx context.Context, options Options) (Stats, error) {
 		}
 		return nil
 	}
-	if !options.IncludeComments {
+	if !options.IncludeComments && !options.IncludePRDetails {
 		if err := s.store.WithTx(ctx, persist); err != nil {
 			tracker.Finish(err)
 			return Stats{}, err

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -269,6 +269,32 @@ type emptyHeadPullGitHub struct {
 	runsCalled   bool
 }
 
+type txProbePullDetailsGitHub struct {
+	fakeGitHub
+	st                    *store.Store
+	sawPersistedThread    bool
+	sawPersistedThreadErr error
+}
+
+func (g *txProbePullDetailsGitHub) ListPullFiles(ctx context.Context, owner, repo string, number int, reporter gh.Reporter) ([]map[string]any, error) {
+	storedRepo, err := g.st.RepositoryByFullName(ctx, owner+"/"+repo)
+	if err != nil {
+		g.sawPersistedThreadErr = err
+		return nil, nil
+	}
+	threads, err := g.st.ListThreads(ctx, storedRepo.ID, true)
+	if err != nil {
+		g.sawPersistedThreadErr = err
+		return nil, nil
+	}
+	for _, thread := range threads {
+		if thread.Number == number && thread.Kind == "pull_request" {
+			g.sawPersistedThread = true
+		}
+	}
+	return nil, nil
+}
+
 func (emptyHeadPullGitHub) GetPull(ctx context.Context, owner, repo string, number int, reporter gh.Reporter) (map[string]any, error) {
 	return map[string]any{
 		"number":          number,
@@ -527,6 +553,27 @@ func TestSyncPullRequestDetailsSkipsCheckAndWorkflowFetchWithoutHeadSHA(t *testi
 	}
 	if client.runsCalled {
 		t.Fatal("workflow runs should not be fetched without head SHA")
+	}
+}
+
+func TestSyncPullRequestDetailsDoesNotFetchInsideTransaction(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	client := &txProbePullDetailsGitHub{st: st}
+	s := New(client, st)
+	s.now = func() time.Time { return time.Date(2026, 4, 26, 0, 0, 0, 0, time.UTC) }
+	if _, err := s.Sync(ctx, Options{Owner: "openclaw", Repo: "gitcrawl", Numbers: []int{8}, IncludePRDetails: true}); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if client.sawPersistedThreadErr != nil {
+		t.Fatalf("probe persisted thread: %v", client.sawPersistedThreadErr)
+	}
+	if !client.sawPersistedThread {
+		t.Fatal("PR detail fetch ran before the PR thread was committed")
 	}
 }
 


### PR DESCRIPTION
## Summary
- avoid wrapping PR detail hydration GitHub calls in the metadata sync transaction
- keep review-thread cache replacement atomic with a short store transaction
- add regressions for committed PR thread visibility before fetches and rollback of failed review-thread replacements

## Validation
- go test ./internal/store -run "TestUpsertPullRequestReviewThreadsRollsBackReplacementOnInsertError" -count=1
- go test ./internal/syncer -run "TestSyncPullRequestDetailsDoesNotFetchInsideTransaction|TestSyncPullRequestDetailsSkipsCheckAndWorkflowFetchWithoutHeadSHA|TestSyncHydratesPullRequestDetails" -count=1
- env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
- codex-review --mode local --full-access --parallel-tests ... clean
