### PR TITLE
fix: keep cluster representatives visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Keep active durable cluster representatives on visible open members instead of closed or hidden historical members.
 - Avoid holding SQLite write transactions open while hydrating PR details from GitHub.
 - Skip PR check-run and workflow-run hydration when GitHub returns no PR head SHA, avoiding broad workflow-run fetches.
 - Ignore cluster graph edges whose endpoints are absent from the visible node set, preventing hidden nodes from merging otherwise separate clusters.

--- a/internal/store/clusters.go
+++ b/internal/store/clusters.go
@@ -760,6 +760,11 @@ func (s *Store) saveDurableClusters(ctx context.Context, repoID int64, inputs []
 			`, repoID); err != nil {
 				return fmt.Errorf("delete legacy similarity clusters: %w", err)
 			}
+			for _, clusterID := range seenClusterIDs {
+				if err := tx.ensureActiveClusterRepresentative(ctx, repoID, clusterID, now); err != nil {
+					return err
+				}
+			}
 		}
 		if _, err := tx.q().ExecContext(ctx, `
 			update cluster_runs
@@ -1153,17 +1158,19 @@ func (s *Store) applyClusterOverrides(ctx context.Context, repoID, clusterID int
 		}
 		if _, err := s.q().ExecContext(ctx, `
 			update cluster_groups
-			set representative_thread_id = ?, updated_at = ?
+			set representative_thread_id = null, updated_at = ?
 			where repo_id = ? and id = ?
-		`, canonicalThreadID.Int64, now, repoID, clusterID); err != nil {
+				and status = 'active'
+				and closed_at is null
+		`, now, repoID, clusterID); err != nil {
 			return fmt.Errorf("apply canonical override representative: %w", err)
 		}
-		return nil
 	}
 	return s.ensureActiveClusterRepresentative(ctx, repoID, clusterID, now)
 }
 
 func (s *Store) ensureActiveClusterRepresentative(ctx context.Context, repoID, clusterID int64, now string) error {
+	visible := durableVisibleMemberPredicate("cluster_groups", "cm", "t")
 	if _, err := s.q().ExecContext(ctx, `
 		update cluster_groups
 		set representative_thread_id = (
@@ -1171,6 +1178,7 @@ func (s *Store) ensureActiveClusterRepresentative(ctx context.Context, repoID, c
 				from cluster_memberships cm
 				join threads t on t.id = cm.thread_id
 				where cm.cluster_id = cluster_groups.id and cm.state = 'active'
+					and `+visible+`
 				order by case cm.role when 'canonical' then 0 when 'representative' then 1 else 2 end,
 					coalesce(cm.score_to_representative, 0) desc,
 					t.number asc
@@ -1178,10 +1186,16 @@ func (s *Store) ensureActiveClusterRepresentative(ctx context.Context, repoID, c
 			),
 			updated_at = ?
 		where repo_id = ? and id = ?
+			and status = 'active'
+			and closed_at is null
 			and (
 				representative_thread_id is null
 				or representative_thread_id not in (
-					select thread_id from cluster_memberships where cluster_id = ? and state = 'active'
+					select cm.thread_id
+					from cluster_memberships cm
+					join threads t on t.id = cm.thread_id
+					where cm.cluster_id = ? and cm.state = 'active'
+						and `+visible+`
 				)
 			)
 	`, now, repoID, clusterID, clusterID); err != nil {

--- a/internal/store/clusters_test.go
+++ b/internal/store/clusters_test.go
@@ -527,6 +527,261 @@ func TestSaveDurableClustersAppliesLocalOverrides(t *testing.T) {
 	}
 }
 
+func TestSaveDurableClustersChoosesVisibleRepresentative(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	repoID, err := st.UpsertRepository(ctx, Repository{Owner: "openclaw", Name: "gitcrawl", FullName: "openclaw/gitcrawl", RawJSON: "{}", UpdatedAt: "2026-05-15T00:00:00Z"})
+	if err != nil {
+		t.Fatalf("repo: %v", err)
+	}
+	closedID, err := st.UpsertThread(ctx, Thread{
+		RepoID: repoID, GitHubID: "51", Number: 51, Kind: "issue", State: "closed",
+		Title: "closed representative", HTMLURL: "https://github.com/openclaw/gitcrawl/issues/51",
+		LabelsJSON: "[]", AssigneesJSON: "[]", RawJSON: "{}", ContentHash: "hash-51", UpdatedAt: "2026-05-15T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("closed thread: %v", err)
+	}
+	openID, err := st.UpsertThread(ctx, Thread{
+		RepoID: repoID, GitHubID: "52", Number: 52, Kind: "issue", State: "open",
+		Title: "open replacement", HTMLURL: "https://github.com/openclaw/gitcrawl/issues/52",
+		LabelsJSON: "[]", AssigneesJSON: "[]", RawJSON: "{}", ContentHash: "hash-52", UpdatedAt: "2026-05-15T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("open thread: %v", err)
+	}
+	score := 0.75
+	input := DurableClusterInput{
+		StableKey:              "members:51,52",
+		StableSlug:             "cluster-5152",
+		RepresentativeThreadID: closedID,
+		Title:                  "closed representative",
+		Members: []DurableClusterMemberInput{
+			{ThreadID: closedID, Role: "representative"},
+			{ThreadID: openID, Role: "member", ScoreToRepresentative: &score},
+		},
+	}
+	if _, err := st.SaveDurableClusters(ctx, repoID, []DurableClusterInput{input}); err != nil {
+		t.Fatalf("save durable clusters: %v", err)
+	}
+	detail, err := st.ClusterDetail(ctx, ClusterDetailOptions{RepoID: repoID, ClusterID: 1, IncludeClosed: false, MemberLimit: 10})
+	if err != nil {
+		t.Fatalf("cluster detail: %v", err)
+	}
+	if detail.Cluster.RepresentativeThreadID != openID || detail.Cluster.RepresentativeNumber != 52 {
+		t.Fatalf("active cluster should choose visible representative, got %#v", detail.Cluster)
+	}
+	if len(detail.Members) != 1 || detail.Members[0].Thread.ID != openID {
+		t.Fatalf("active detail should hide closed representative, got %#v", detail.Members)
+	}
+}
+
+func TestSaveCompleteDurableClustersRefreshesRepresentativeAfterRetiringStaleClusters(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	repoID, err := st.UpsertRepository(ctx, Repository{Owner: "openclaw", Name: "gitcrawl", FullName: "openclaw/gitcrawl", RawJSON: "{}", UpdatedAt: "2026-05-15T00:00:00Z"})
+	if err != nil {
+		t.Fatalf("repo: %v", err)
+	}
+	closedID, err := st.UpsertThread(ctx, Thread{
+		RepoID: repoID, GitHubID: "61", Number: 61, Kind: "issue", State: "closed",
+		Title: "closed representative", HTMLURL: "https://github.com/openclaw/gitcrawl/issues/61",
+		LabelsJSON: "[]", AssigneesJSON: "[]", RawJSON: "{}", ContentHash: "hash-61", UpdatedAt: "2026-05-15T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("closed thread: %v", err)
+	}
+	openID, err := st.UpsertThread(ctx, Thread{
+		RepoID: repoID, GitHubID: "62", Number: 62, Kind: "issue", State: "open",
+		Title: "open replacement", HTMLURL: "https://github.com/openclaw/gitcrawl/issues/62",
+		LabelsJSON: "[]", AssigneesJSON: "[]", RawJSON: "{}", ContentHash: "hash-62", UpdatedAt: "2026-05-15T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("open thread: %v", err)
+	}
+	if _, err := st.SaveDurableClusters(ctx, repoID, []DurableClusterInput{{
+		StableKey:              "old:62",
+		StableSlug:             "old-62",
+		RepresentativeThreadID: openID,
+		Title:                  "old open cluster",
+		Members:                []DurableClusterMemberInput{{ThreadID: openID, Role: "canonical"}},
+	}}); err != nil {
+		t.Fatalf("seed stale durable cluster: %v", err)
+	}
+	score := 0.75
+	if _, err := st.SaveCompleteDurableClusters(ctx, repoID, []DurableClusterInput{{
+		StableKey:              "new:61,62",
+		StableSlug:             "new-6162",
+		RepresentativeThreadID: closedID,
+		Title:                  "new cluster",
+		Members: []DurableClusterMemberInput{
+			{ThreadID: closedID, Role: "representative"},
+			{ThreadID: openID, Role: "member", ScoreToRepresentative: &score},
+		},
+	}}); err != nil {
+		t.Fatalf("save complete durable clusters: %v", err)
+	}
+	detail, err := st.ClusterDetail(ctx, ClusterDetailOptions{RepoID: repoID, ClusterID: 2, IncludeClosed: false, MemberLimit: 10})
+	if err != nil {
+		t.Fatalf("cluster detail: %v", err)
+	}
+	if detail.Cluster.RepresentativeThreadID != openID || detail.Cluster.RepresentativeNumber != 62 {
+		t.Fatalf("complete refresh should choose visible representative after retiring stale clusters, got %#v", detail.Cluster)
+	}
+}
+
+func TestSaveDurableClustersRefreshesRepresentativeAfterDeletingLegacyClusters(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	repoID, err := st.UpsertRepository(ctx, Repository{Owner: "openclaw", Name: "gitcrawl", FullName: "openclaw/gitcrawl", RawJSON: "{}", UpdatedAt: "2026-05-15T00:00:00Z"})
+	if err != nil {
+		t.Fatalf("repo: %v", err)
+	}
+	closedID, err := st.UpsertThread(ctx, Thread{
+		RepoID: repoID, GitHubID: "81", Number: 81, Kind: "issue", State: "closed",
+		Title: "closed representative", HTMLURL: "https://github.com/openclaw/gitcrawl/issues/81",
+		LabelsJSON: "[]", AssigneesJSON: "[]", RawJSON: "{}", ContentHash: "hash-81", UpdatedAt: "2026-05-15T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("closed thread: %v", err)
+	}
+	openID, err := st.UpsertThread(ctx, Thread{
+		RepoID: repoID, GitHubID: "82", Number: 82, Kind: "issue", State: "open",
+		Title: "open replacement", HTMLURL: "https://github.com/openclaw/gitcrawl/issues/82",
+		LabelsJSON: "[]", AssigneesJSON: "[]", RawJSON: "{}", ContentHash: "hash-82", UpdatedAt: "2026-05-15T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("open thread: %v", err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `
+		insert into cluster_groups(id, repo_id, stable_key, stable_slug, status, cluster_type, representative_thread_id, title, created_at, updated_at)
+		values(99, ?, 'legacy:82', 'legacy-82', 'active', 'similarity', ?, 'legacy open cluster', ?, ?)
+	`, repoID, openID, "2026-05-15T00:00:00Z", "2026-05-15T00:00:00Z"); err != nil {
+		t.Fatalf("seed legacy cluster: %v", err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `
+		insert into cluster_memberships(cluster_id, thread_id, role, state, added_by, added_reason_json, created_at, updated_at)
+		values(99, ?, 'canonical', 'active', 'system', '{}', ?, ?)
+	`, openID, "2026-05-15T00:00:00Z", "2026-05-15T00:00:00Z"); err != nil {
+		t.Fatalf("seed legacy member: %v", err)
+	}
+
+	score := 0.75
+	if _, err := st.SaveDurableClusters(ctx, repoID, []DurableClusterInput{{
+		StableKey:              "new:81,82",
+		StableSlug:             "new-8182",
+		RepresentativeThreadID: closedID,
+		Title:                  "new cluster",
+		Members: []DurableClusterMemberInput{
+			{ThreadID: closedID, Role: "representative"},
+			{ThreadID: openID, Role: "member", ScoreToRepresentative: &score},
+		},
+	}}); err != nil {
+		t.Fatalf("save durable clusters: %v", err)
+	}
+	var legacyCount int
+	if err := st.DB().QueryRowContext(ctx, `
+		select count(*)
+		from cluster_groups
+		where repo_id = ? and cluster_type = 'similarity'
+	`, repoID).Scan(&legacyCount); err != nil {
+		t.Fatalf("count legacy clusters: %v", err)
+	}
+	if legacyCount != 0 {
+		t.Fatalf("legacy similarity cluster should be deleted, got %d", legacyCount)
+	}
+	var clusterID int64
+	if err := st.DB().QueryRowContext(ctx, `
+		select id
+		from cluster_groups
+		where repo_id = ? and stable_key = 'new:81,82'
+	`, repoID).Scan(&clusterID); err != nil {
+		t.Fatalf("find durable cluster: %v", err)
+	}
+	detail, err := st.ClusterDetail(ctx, ClusterDetailOptions{RepoID: repoID, ClusterID: clusterID, IncludeClosed: false, MemberLimit: 10})
+	if err != nil {
+		t.Fatalf("cluster detail: %v", err)
+	}
+	if detail.Cluster.RepresentativeThreadID != openID || detail.Cluster.RepresentativeNumber != 82 {
+		t.Fatalf("legacy cleanup should refresh visible representative, got %#v", detail.Cluster)
+	}
+}
+
+func TestSaveDurableClustersPreservesLocallyClosedRepresentative(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	repoID, err := st.UpsertRepository(ctx, Repository{Owner: "openclaw", Name: "gitcrawl", FullName: "openclaw/gitcrawl", RawJSON: "{}", UpdatedAt: "2026-05-15T00:00:00Z"})
+	if err != nil {
+		t.Fatalf("repo: %v", err)
+	}
+	closedID, err := st.UpsertThread(ctx, Thread{
+		RepoID: repoID, GitHubID: "71", Number: 71, Kind: "issue", State: "closed",
+		Title: "closed canonical", HTMLURL: "https://github.com/openclaw/gitcrawl/issues/71",
+		LabelsJSON: "[]", AssigneesJSON: "[]", RawJSON: "{}", ContentHash: "hash-71", UpdatedAt: "2026-05-15T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("closed thread: %v", err)
+	}
+	openID, err := st.UpsertThread(ctx, Thread{
+		RepoID: repoID, GitHubID: "72", Number: 72, Kind: "issue", State: "open",
+		Title: "open related", HTMLURL: "https://github.com/openclaw/gitcrawl/issues/72",
+		LabelsJSON: "[]", AssigneesJSON: "[]", RawJSON: "{}", ContentHash: "hash-72", UpdatedAt: "2026-05-15T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("open thread: %v", err)
+	}
+	score := 0.5
+	input := DurableClusterInput{
+		StableKey:              "members:71,72",
+		StableSlug:             "cluster-7172",
+		RepresentativeThreadID: closedID,
+		Title:                  "closed canonical",
+		Members: []DurableClusterMemberInput{
+			{ThreadID: closedID, Role: "canonical"},
+			{ThreadID: openID, Role: "member", ScoreToRepresentative: &score},
+		},
+	}
+	if _, err := st.SaveDurableClusters(ctx, repoID, []DurableClusterInput{input}); err != nil {
+		t.Fatalf("save durable cluster: %v", err)
+	}
+	if _, err := st.SetClusterCanonicalLocally(ctx, repoID, 1, 71, "historical canonical"); err != nil {
+		t.Fatalf("set historical canonical: %v", err)
+	}
+	if err := st.CloseClusterLocally(ctx, repoID, 1, "done"); err != nil {
+		t.Fatalf("close cluster: %v", err)
+	}
+	if _, err := st.SaveDurableClusters(ctx, repoID, []DurableClusterInput{input}); err != nil {
+		t.Fatalf("resave locally closed durable cluster: %v", err)
+	}
+	detail, err := st.DurableClusterDetail(ctx, ClusterDetailOptions{RepoID: repoID, ClusterID: 1, IncludeClosed: true, MemberLimit: 10})
+	if err != nil {
+		t.Fatalf("closed cluster detail: %v", err)
+	}
+	if detail.Cluster.RepresentativeThreadID != closedID || detail.Cluster.RepresentativeNumber != 71 {
+		t.Fatalf("locally closed cluster should preserve historical representative, got %#v", detail.Cluster)
+	}
+}
+
 func TestSaveDurableClustersRetiresMissingClusters(t *testing.T) {
 	ctx := context.Background()
 	st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))


### PR DESCRIPTION
## Summary
- keep active durable cluster representatives on visible open members
- refresh representatives after stale cluster retirement and legacy similarity cleanup
- preserve historical representatives on locally closed clusters

## Validation
- go test ./internal/store -run 'TestSaveDurableClustersChoosesVisibleRepresentative|TestSaveCompleteDurableClustersRefreshesRepresentativeAfterRetiringStaleClusters|TestSaveDurableClustersRefreshesRepresentativeAfterDeletingLegacyClusters|TestSaveDurableClustersPreservesLocallyClosedRepresentative|TestSaveDurableClustersRetiresMissingClusters|TestDurableClusterSummariesUsePrimaryOpenMembers' -count=1
- env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
- /Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode local --full-access --parallel-tests "go test ./internal/store -run 'TestSaveDurableClustersChoosesVisibleRepresentative|TestSaveCompleteDurableClustersRefreshesRepresentativeAfterRetiringStaleClusters|TestSaveDurableClustersRefreshesRepresentativeAfterDeletingLegacyClusters|TestSaveDurableClustersPreservesLocallyClosedRepresentative|TestSaveDurableClustersRetiresMissingClusters|TestDurableClusterSummariesUsePrimaryOpenMembers' -count=1 && env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./..."
