### PR TITLE
fix: disambiguate cluster detail sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Allow cluster detail reads to target raw-run or durable-cluster IDs explicitly, avoiding collisions between the two ID namespaces.
 - Keep active durable cluster representatives on visible open members instead of closed or hidden historical members.
 - Avoid holding SQLite write transactions open while hydrating PR details from GitHub.
 - Skip PR check-run and workflow-run hydration when GitHub returns no PR head SHA, avoiding broad workflow-run fetches.

--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -86,6 +86,7 @@ gitcrawl cluster-explain owner/repo --id 123    # alias
 | Flag | Default | Description |
 | --- | --- | --- |
 | `--id <n>` | _(required)_ | Cluster ID |
+| `--source auto\|run\|durable` | `auto` | Choose latest raw-run cluster IDs or durable cluster IDs when they collide |
 | `--member-limit <n>` | _(no limit)_ | Maximum members to return |
 | `--body-chars <n>` | `280` | Body snippet length per member |
 | `--hide-closed` | _(off)_ | Hide locally closed members |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -78,7 +78,7 @@ This applies to `sync --numbers`, `threads --numbers`, `embed --number`,
 | `gitcrawl cluster owner/repo [--threshold --min-size --max-cluster-size --k --cross-kind-threshold --limit --model --basis --include-closed --json]` | Build durable clusters from vectors | [Clustering](/clustering/#generate-clusters) |
 | `gitcrawl clusters owner/repo [--sort size\|recent\|oldest --min-size --limit --hide-closed --json]` | Latest-run cluster summary, merged with closed durable rows | [Clustering](/clustering/#list-clusters) |
 | `gitcrawl durable-clusters owner/repo [--include-closed --sort --min-size --limit --json]` | Strict durable-cluster audit view | [Clustering](/clustering/#list-clusters) |
-| `gitcrawl cluster-detail owner/repo --id <n> [--member-limit --body-chars --hide-closed --json]` | Cluster + members detail | [Clustering](/clustering/#inspect-a-cluster) |
+| `gitcrawl cluster-detail owner/repo --id <n> [--source auto\|run\|durable --member-limit --body-chars --hide-closed --json]` | Cluster + members detail | [Clustering](/clustering/#inspect-a-cluster) |
 | `gitcrawl cluster-explain owner/repo --id <n> [...]` | Alias for `cluster-detail` | [Clustering](/clustering/#inspect-a-cluster) |
 
 ## Governance

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1541,29 +1541,51 @@ func mergeClusterSummaries(primary, secondary []store.ClusterSummary) []store.Cl
 		return append([]store.ClusterSummary(nil), secondary...)
 	}
 	out := append([]store.ClusterSummary(nil), primary...)
-	seen := make(map[int64]bool, len(out)+len(secondary))
+	seen := make(map[string]bool, len(out)+len(secondary))
 	for _, cluster := range out {
-		seen[cluster.ID] = true
+		seen[clusterSummaryKey(cluster)] = true
 	}
 	for _, cluster := range secondary {
-		if !seen[cluster.ID] {
+		key := clusterSummaryKey(cluster)
+		if !seen[key] {
 			out = append(out, cluster)
-			seen[cluster.ID] = true
+			seen[key] = true
 		}
 	}
 	return out
+}
+
+func clusterSummaryKey(cluster store.ClusterSummary) string {
+	source := strings.TrimSpace(cluster.Source)
+	if source == "" {
+		source = "auto"
+	}
+	return source + ":" + strconv.FormatInt(cluster.ID, 10)
+}
+
+func sameClusterSummary(left, right store.ClusterSummary) bool {
+	if left.ID == 0 || right.ID == 0 || left.ID != right.ID {
+		return false
+	}
+	leftSource := strings.TrimSpace(left.Source)
+	rightSource := strings.TrimSpace(right.Source)
+	if leftSource == "" || rightSource == "" {
+		return true
+	}
+	return leftSource == rightSource
 }
 
 func (a *App) runClusterDetail(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("cluster-detail", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	clusterIDRaw := fs.String("id", "", "cluster id")
+	sourceRaw := fs.String("source", "", "cluster source: auto|run|durable")
 	memberLimitRaw := fs.String("member-limit", "", "maximum member rows")
 	bodyCharsRaw := fs.String("body-chars", "", "maximum body snippet characters")
 	includeClosed := fs.Bool("include-closed", false, "deprecated; closed cluster members are shown by default")
 	hideClosed := fs.Bool("hide-closed", false, "hide locally closed members")
 	jsonOut := fs.Bool("json", false, "write JSON output")
-	if err := fs.Parse(normalizeCommandArgs(args, map[string]bool{"id": true, "member-limit": true, "body-chars": true})); err != nil {
+	if err := fs.Parse(normalizeCommandArgs(args, map[string]bool{"id": true, "source": true, "member-limit": true, "body-chars": true})); err != nil {
 		return usageErr(err)
 	}
 	a.applyCommandJSON(*jsonOut)
@@ -1589,6 +1611,10 @@ func (a *App) runClusterDetail(ctx context.Context, args []string) error {
 	if bodyChars <= 0 {
 		bodyChars = 280
 	}
+	source, err := parseClusterDetailSource(*sourceRaw)
+	if err != nil {
+		return usageErr(err)
+	}
 
 	rt, err := a.openLocalRuntimeReadOnly(ctx)
 	if err != nil {
@@ -1602,6 +1628,7 @@ func (a *App) runClusterDetail(ctx context.Context, args []string) error {
 	detail, err := rt.Store.ClusterDetail(ctx, store.ClusterDetailOptions{
 		RepoID:        repo.ID,
 		ClusterID:     int64(clusterID),
+		Source:        source,
 		IncludeClosed: *includeClosed || !*hideClosed,
 		MemberLimit:   memberLimit,
 		BodyChars:     bodyChars,
@@ -1614,6 +1641,19 @@ func (a *App) runClusterDetail(ctx context.Context, args []string) error {
 		"cluster":    detail.Cluster,
 		"members":    detail.Members,
 	}, true)
+}
+
+func parseClusterDetailSource(source string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(source)) {
+	case "", "auto":
+		return "", nil
+	case "run", "raw", store.ClusterSourceRun:
+		return store.ClusterSourceRun, nil
+	case "durable", store.ClusterSourceDurable:
+		return store.ClusterSourceDurable, nil
+	default:
+		return "", fmt.Errorf("unsupported cluster source %q", source)
+	}
 }
 
 func (a *App) runRuns(ctx context.Context, args []string) error {
@@ -3468,7 +3508,7 @@ Usage:
 	"cluster-detail": `gitcrawl cluster-detail dumps one cluster and its member rows.
 
 Usage:
-  gitcrawl cluster-detail owner/repo --id N [--member-limit N] [--body-chars N] [--hide-closed] [--json]
+  gitcrawl cluster-detail owner/repo --id N [--source auto|run|durable] [--member-limit N] [--body-chars N] [--hide-closed] [--json]
 `,
 	"neighbors": `gitcrawl neighbors lists vector-nearest local issue and pull request rows.
 

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -147,7 +147,7 @@ type clusterBrowserModel struct {
 	wheelSeq         int
 	detailView       viewport.Model
 	searchInput      textinput.Model
-	detailCache      map[int64]store.ClusterDetail
+	detailCache      map[string]store.ClusterDetail
 	neighborCache    map[int64][]tuiNeighbor
 	detail           store.ClusterDetail
 	hasDetail        bool
@@ -316,7 +316,7 @@ func newClusterBrowserModel(ctx context.Context, st *store.Store, repoID int64, 
 		memberIndex:   -1,
 		detailView:    viewport.New(1, 1),
 		searchInput:   search,
-		detailCache:   map[int64]store.ClusterDetail{},
+		detailCache:   map[string]store.ClusterDetail{},
 		neighborCache: map[int64][]tuiNeighbor{},
 	}
 	if payload.DBSource == "remote" && payload.DBRefreshSource != "" && payload.DBRuntimePath != "" {
@@ -528,7 +528,7 @@ func (m *clusterBrowserModel) reopenRuntimeStore() error {
 		_ = m.store.Close()
 	}
 	m.store = next
-	m.detailCache = map[int64]store.ClusterDetail{}
+	m.detailCache = map[string]store.ClusterDetail{}
 	m.neighborCache = map[int64][]tuiNeighbor{}
 	return nil
 }
@@ -2916,18 +2916,23 @@ func (m *clusterBrowserModel) jumpToThreadNumber(number int) {
 		m.status = "Enter a positive issue or PR number"
 		return
 	}
-	clusterID := m.findLoadedClusterIDForThreadNumber(number)
-	if clusterID == 0 && m.store != nil && m.repoID != 0 {
+	cluster, clusterOK := m.findLoadedClusterForThreadNumber(number)
+	if !clusterOK && m.store != nil && m.repoID != 0 {
 		foundID, err := m.store.ClusterIDForThreadNumber(m.ctx, m.repoID, number, true)
 		if err != nil {
 			m.status = err.Error()
 			return
 		}
-		clusterID = foundID
-		if _, ok := m.detailCache[clusterID]; !ok {
+		cluster = store.ClusterSummary{ID: foundID, Source: store.ClusterSourceDurable}
+		cacheKey := clusterSummaryKey(cluster)
+		if cached, ok := m.detailCache[cacheKey]; ok {
+			cluster = cached.Cluster
+			m.ensureClusterInWorkingSet(cluster)
+		} else {
 			detail, err := m.store.ClusterDetail(m.ctx, store.ClusterDetailOptions{
 				RepoID:        m.repoID,
-				ClusterID:     clusterID,
+				ClusterID:     foundID,
+				Source:        store.ClusterSourceDurable,
 				IncludeClosed: true,
 				MemberLimit:   200,
 				BodyChars:     1600,
@@ -2936,16 +2941,18 @@ func (m *clusterBrowserModel) jumpToThreadNumber(number int) {
 				m.status = "Jump failed: " + err.Error()
 				return
 			}
-			m.detailCache[clusterID] = detail
+			m.detailCache[clusterSummaryKey(detail.Cluster)] = detail
 			m.ensureClusterInWorkingSet(detail.Cluster)
+			cluster = detail.Cluster
 		}
+		clusterOK = true
 	}
-	if clusterID == 0 {
+	if !clusterOK || cluster.ID == 0 {
 		m.status = fmt.Sprintf("Thread #%d was not found in loaded clusters", number)
 		return
 	}
-	if !m.selectClusterIDForJump(clusterID) {
-		m.status = fmt.Sprintf("Cluster %d is not available in this view", clusterID)
+	if !m.selectClusterForJump(cluster) {
+		m.status = fmt.Sprintf("Cluster %d is not available in this view", cluster.ID)
 		return
 	}
 	if m.selectMemberByNumber(number) {
@@ -2954,30 +2961,38 @@ func (m *clusterBrowserModel) jumpToThreadNumber(number int) {
 		return
 	}
 	m.focus = focusMembers
-	m.status = fmt.Sprintf("Jumped to cluster %d; #%d is outside loaded members", clusterID, number)
+	m.status = fmt.Sprintf("Jumped to cluster %d; #%d is outside loaded members", cluster.ID, number)
 }
 
 func (m clusterBrowserModel) findLoadedClusterIDForThreadNumber(number int) int64 {
+	cluster, ok := m.findLoadedClusterForThreadNumber(number)
+	if !ok {
+		return 0
+	}
+	return cluster.ID
+}
+
+func (m clusterBrowserModel) findLoadedClusterForThreadNumber(number int) (store.ClusterSummary, bool) {
 	if m.hasDetail {
 		for _, member := range m.detail.Members {
 			if member.Thread.Number == number {
-				return m.detail.Cluster.ID
+				return m.detail.Cluster, true
 			}
 		}
 	}
 	for _, detail := range m.detailCache {
 		for _, member := range detail.Members {
 			if member.Thread.Number == number {
-				return detail.Cluster.ID
+				return detail.Cluster, true
 			}
 		}
 	}
 	for _, cluster := range m.allClusters {
 		if cluster.RepresentativeNumber == number {
-			return cluster.ID
+			return cluster, true
 		}
 	}
-	return 0
+	return store.ClusterSummary{}, false
 }
 
 func (m *clusterBrowserModel) ensureClusterInWorkingSet(cluster store.ClusterSummary) {
@@ -2985,7 +3000,7 @@ func (m *clusterBrowserModel) ensureClusterInWorkingSet(cluster store.ClusterSum
 		return
 	}
 	for _, existing := range m.allClusters {
-		if existing.ID == cluster.ID {
+		if sameClusterSummary(existing, cluster) {
 			return
 		}
 	}
@@ -2993,10 +3008,14 @@ func (m *clusterBrowserModel) ensureClusterInWorkingSet(cluster store.ClusterSum
 }
 
 func (m *clusterBrowserModel) selectClusterIDForJump(clusterID int64) bool {
-	if m.selectVisibleClusterID(clusterID) {
+	return m.selectClusterForJump(store.ClusterSummary{ID: clusterID})
+}
+
+func (m *clusterBrowserModel) selectClusterForJump(cluster store.ClusterSummary) bool {
+	if m.selectVisibleCluster(cluster) {
 		return true
 	}
-	cluster, ok := m.clusterFromWorkingSet(clusterID)
+	cluster, ok := m.clusterSummaryFromWorkingSet(cluster)
 	if !ok {
 		return false
 	}
@@ -3011,12 +3030,16 @@ func (m *clusterBrowserModel) selectClusterIDForJump(clusterID int64) bool {
 		m.payload.Limit = len(m.allClusters)
 	}
 	m.applyClusterFilters()
-	return m.selectVisibleClusterID(clusterID)
+	return m.selectVisibleCluster(cluster)
 }
 
 func (m *clusterBrowserModel) selectVisibleClusterID(clusterID int64) bool {
+	return m.selectVisibleCluster(store.ClusterSummary{ID: clusterID})
+}
+
+func (m *clusterBrowserModel) selectVisibleCluster(target store.ClusterSummary) bool {
 	for index, cluster := range m.payload.Clusters {
-		if cluster.ID == clusterID {
+		if sameClusterSummary(cluster, target) {
 			m.selected = index
 			m.loadSelectedCluster()
 			return true
@@ -3026,8 +3049,12 @@ func (m *clusterBrowserModel) selectVisibleClusterID(clusterID int64) bool {
 }
 
 func (m clusterBrowserModel) clusterFromWorkingSet(clusterID int64) (store.ClusterSummary, bool) {
+	return m.clusterSummaryFromWorkingSet(store.ClusterSummary{ID: clusterID})
+}
+
+func (m clusterBrowserModel) clusterSummaryFromWorkingSet(target store.ClusterSummary) (store.ClusterSummary, bool) {
 	for _, cluster := range m.allClusters {
-		if cluster.ID == clusterID {
+		if sameClusterSummary(cluster, target) {
 			return cluster, true
 		}
 	}
@@ -3055,7 +3082,7 @@ func (m *clusterBrowserModel) refreshFromStore() {
 		m.status = "Refresh failed: " + err.Error()
 		return
 	}
-	relaxedFilters := m.applyClusterRefresh(clusters, m.currentClusterID())
+	relaxedFilters := m.applyClusterRefresh(clusters, m.currentClusterKey())
 	m.status = fmt.Sprintf("Refreshed %d cluster(s)", len(m.payload.Clusters))
 	if relaxedFilters {
 		m.status += " (filters relaxed)"
@@ -3084,7 +3111,7 @@ func (m *clusterBrowserModel) autoRefreshFromStore() {
 	if clusterSummariesSignature(clusters) == m.clusterSignature() {
 		return
 	}
-	m.applyClusterRefresh(clusters, m.currentClusterID())
+	m.applyClusterRefresh(clusters, m.currentClusterKey())
 	m.status = fmt.Sprintf("Auto refreshed %d cluster(s)", len(m.payload.Clusters))
 }
 
@@ -3098,7 +3125,7 @@ func clusterSummariesSignature(clusters []store.ClusterSummary) string {
 	}
 	parts := make([]string, 0, len(clusters))
 	for _, cluster := range clusters {
-		parts = append(parts, fmt.Sprintf("%d:%d:%s", cluster.ID, cluster.MemberCount, cluster.UpdatedAt))
+		parts = append(parts, fmt.Sprintf("%s:%d:%s", clusterSummaryKey(cluster), cluster.MemberCount, cluster.UpdatedAt))
 	}
 	return strings.Join(parts, "|")
 }
@@ -3108,6 +3135,13 @@ func (m clusterBrowserModel) currentClusterID() int64 {
 		return 0
 	}
 	return m.payload.Clusters[m.selected].ID
+}
+
+func (m clusterBrowserModel) currentClusterKey() string {
+	if len(m.payload.Clusters) == 0 || m.selected < 0 || m.selected >= len(m.payload.Clusters) {
+		return ""
+	}
+	return clusterSummaryKey(m.payload.Clusters[m.selected])
 }
 
 func (m clusterBrowserModel) clusterRefreshLimit() int {
@@ -3142,21 +3176,21 @@ func (m *clusterBrowserModel) loadClusterSummariesFromStore() ([]store.ClusterSu
 	return mergeClusterSummaries(clusters, workingSet), nil
 }
 
-func (m *clusterBrowserModel) applyClusterRefresh(clusters []store.ClusterSummary, currentID int64) bool {
+func (m *clusterBrowserModel) applyClusterRefresh(clusters []store.ClusterSummary, currentKey string) bool {
 	if clusters == nil {
 		clusters = []store.ClusterSummary{}
 	}
 	if m.payload.Limit <= 0 && len(clusters) > 0 && len(clusters) < len(m.allClusters) {
 		clusters = mergeClusterSummaries(clusters, m.allClusters)
 	}
-	m.detailCache = map[int64]store.ClusterDetail{}
+	m.detailCache = map[string]store.ClusterDetail{}
 	m.allClusters = append([]store.ClusterSummary(nil), clusters...)
 	m.payload.Clusters = append([]store.ClusterSummary(nil), clusters...)
 	m.applyClusterFilters()
 	relaxedFilters := m.relaxFiltersIfEmpty()
-	if currentID != 0 {
+	if currentKey != "" {
 		for index, cluster := range m.payload.Clusters {
-			if cluster.ID == currentID {
+			if clusterSummaryKey(cluster) == currentKey {
 				m.selected = index
 				m.loadSelectedCluster()
 				break
@@ -3210,7 +3244,7 @@ func (m *clusterBrowserModel) switchRepository(fullName string) {
 	m.repoID = repo.ID
 	m.payload.Repository = repo.FullName
 	m.payload.InferredRepository = false
-	m.detailCache = map[int64]store.ClusterDetail{}
+	m.detailCache = map[string]store.ClusterDetail{}
 	m.neighborCache = map[int64][]tuiNeighbor{}
 	m.allClusters = append([]store.ClusterSummary(nil), clusters...)
 	m.payload.Clusters = append([]store.ClusterSummary(nil), clusters...)
@@ -3312,7 +3346,8 @@ func (m *clusterBrowserModel) loadSelectedCluster() {
 		return
 	}
 	cluster := m.payload.Clusters[m.selected]
-	if cached, ok := m.detailCache[cluster.ID]; ok {
+	cacheKey := clusterSummaryKey(cluster)
+	if cached, ok := m.detailCache[cacheKey]; ok {
 		m.applyClusterDetail(cached)
 		return
 	}
@@ -3322,6 +3357,7 @@ func (m *clusterBrowserModel) loadSelectedCluster() {
 	detail, err := m.store.ClusterDetail(m.ctx, store.ClusterDetailOptions{
 		RepoID:        m.repoID,
 		ClusterID:     cluster.ID,
+		Source:        cluster.Source,
 		IncludeClosed: true,
 		MemberLimit:   200,
 		BodyChars:     1600,
@@ -3330,7 +3366,7 @@ func (m *clusterBrowserModel) loadSelectedCluster() {
 		m.status = err.Error()
 		return
 	}
-	m.detailCache[cluster.ID] = detail
+	m.detailCache[clusterSummaryKey(detail.Cluster)] = detail
 	m.applyClusterDetail(detail)
 }
 

--- a/internal/cli/tui_coverage_extra_test.go
+++ b/internal/cli/tui_coverage_extra_test.go
@@ -36,7 +36,7 @@ func TestTUIRemainingActionAndErrorBranches(t *testing.T) {
 		MinSize:    1,
 		Clusters:   []store.ClusterSummary{cluster},
 	})
-	model.detailCache[7] = detail
+	model.detailCache[clusterSummaryKey(cluster)] = detail
 	model.loadSelectedCluster()
 	model.memberIndex = 0
 	model.neighborCache[thread.ID] = []tuiNeighbor{{Thread: thread, Score: 0.9}}
@@ -126,7 +126,7 @@ func TestTUIRemainingHelperBranches(t *testing.T) {
 	if _, ok := model.clusterFromWorkingSet(999); ok {
 		t.Fatal("missing working-set cluster should not resolve")
 	}
-	model.applyClusterRefresh(nil, 0)
+	model.applyClusterRefresh(nil, "")
 	if model.payload.Clusters == nil {
 		t.Fatal("nil refresh should normalize clusters")
 	}

--- a/internal/cli/tui_render_extra_test.go
+++ b/internal/cli/tui_render_extra_test.go
@@ -187,8 +187,8 @@ func TestTUISelectionAndVisibilityHelperBranches(t *testing.T) {
 				Thread: store.Thread{Number: 909, State: "open"},
 			}},
 		},
-		detailCache: map[int64]store.ClusterDetail{
-			8: {Cluster: store.ClusterSummary{ID: 8}, Members: []store.ClusterMemberDetail{{Thread: store.Thread{Number: 808, State: "open"}}}},
+		detailCache: map[string]store.ClusterDetail{
+			clusterSummaryKey(store.ClusterSummary{ID: 8}): {Cluster: store.ClusterSummary{ID: 8}, Members: []store.ClusterMemberDetail{{Thread: store.Thread{Number: 808, State: "open"}}}},
 		},
 		memberRows: []memberRow{
 			{label: "header"},
@@ -247,7 +247,7 @@ func TestTUIJumpToThreadNumberLoadsClusterFromStore(t *testing.T) {
 		ctx:         context.Background(),
 		store:       st,
 		repoID:      repoID,
-		detailCache: map[int64]store.ClusterDetail{},
+		detailCache: map[string]store.ClusterDetail{},
 		payload:     clusterBrowserPayload{Limit: 1, Sort: "recent"},
 		minSize:     99,
 	}
@@ -265,12 +265,37 @@ func TestTUIJumpToThreadNumberLoadsClusterFromStore(t *testing.T) {
 	if model.memberIndex < 0 || model.memberRows[model.memberIndex].thread().Number != 202 {
 		t.Fatalf("member rows index=%d rows=%+v", model.memberIndex, model.memberRows)
 	}
-	if _, ok := model.detailCache[clusterID]; !ok {
+	if _, ok := model.detailCache[clusterSummaryKey(store.ClusterSummary{ID: clusterID, Source: store.ClusterSourceDurable})]; !ok {
 		t.Fatalf("detail cache missing cluster %d", clusterID)
 	}
 	model.jumpToThreadNumber(999)
 	if model.status == "" || strings.Contains(model.status, "Jumped") {
 		t.Fatalf("missing jump status = %q", model.status)
+	}
+}
+
+func TestTUISameNumericClusterIDsStaySourceScoped(t *testing.T) {
+	raw := store.ClusterSummary{ID: 7, Source: store.ClusterSourceRun, RepresentativeNumber: 101, MemberCount: 2}
+	durable := store.ClusterSummary{ID: 7, Source: store.ClusterSourceDurable, RepresentativeNumber: 201, MemberCount: 1}
+	model := newClusterBrowserModel(context.Background(), nil, 0, clusterBrowserPayload{
+		Clusters: []store.ClusterSummary{raw, durable},
+	})
+	model.detailCache[clusterSummaryKey(raw)] = store.ClusterDetail{
+		Cluster: raw,
+		Members: []store.ClusterMemberDetail{{Thread: store.Thread{Number: 101, State: "open"}}},
+	}
+	model.detailCache[clusterSummaryKey(durable)] = store.ClusterDetail{
+		Cluster: durable,
+		Members: []store.ClusterMemberDetail{{Thread: store.Thread{Number: 201, State: "open"}}},
+	}
+
+	model.selected = 1
+	model.loadSelectedCluster()
+	if model.detail.Cluster.Source != store.ClusterSourceDurable || len(model.detail.Members) != 1 || model.detail.Members[0].Thread.Number != 201 {
+		t.Fatalf("durable selection loaded wrong same-ID detail: %#v", model.detail)
+	}
+	if !model.selectClusterForJump(durable) || model.selected != 1 {
+		t.Fatalf("source-qualified jump selected index %d detail=%#v", model.selected, model.detail.Cluster)
 	}
 }
 
@@ -289,7 +314,7 @@ func TestTUIJumpKeyAndRefreshCommandBranches(t *testing.T) {
 		jumping:     true,
 		payload:     clusterBrowserPayload{Clusters: []store.ClusterSummary{{ID: 1, RepresentativeNumber: 123}}},
 		allClusters: []store.ClusterSummary{{ID: 1, RepresentativeNumber: 123}},
-		detailCache: map[int64]store.ClusterDetail{},
+		detailCache: map[string]store.ClusterDetail{},
 	}
 	next, cmd = model.handleJumpKey(tea.KeyMsg{Type: tea.KeyEnter})
 	if cmd != nil || next.jumping || !strings.Contains(next.status, "outside loaded members") {

--- a/internal/cli/tui_test.go
+++ b/internal/cli/tui_test.go
@@ -938,7 +938,7 @@ func TestTUIRefreshPreservesUnlimitedWorkingSet(t *testing.T) {
 
 	model.applyClusterRefresh([]store.ClusterSummary{
 		{ID: 2, Status: "active", MemberCount: 7, UpdatedAt: "2026-04-28T00:00:00Z"},
-	}, 2)
+	}, clusterSummaryKey(store.ClusterSummary{ID: 2}))
 
 	if len(model.payload.Clusters) != 3 {
 		t.Fatalf("refresh collapsed working set to %d clusters: %#v", len(model.payload.Clusters), model.payload.Clusters)
@@ -961,7 +961,7 @@ func TestTUIRefreshHonorsExplicitClusterLimit(t *testing.T) {
 
 	model.applyClusterRefresh([]store.ClusterSummary{
 		{ID: 2, Status: "active", MemberCount: 7, UpdatedAt: "2026-04-28T00:00:00Z"},
-	}, 2)
+	}, clusterSummaryKey(store.ClusterSummary{ID: 2}))
 
 	if len(model.payload.Clusters) != 1 || model.payload.Clusters[0].ID != 2 {
 		t.Fatalf("explicit limit was not honored: %#v", model.payload.Clusters)
@@ -2335,7 +2335,7 @@ func TestTUIJumpToLoadedThreadNumber(t *testing.T) {
 		Sort:       "recent",
 		Clusters:   clusters,
 	})
-	model.detailCache[1] = store.ClusterDetail{
+	model.detailCache[clusterSummaryKey(clusters[0])] = store.ClusterDetail{
 		Cluster: clusters[0],
 		Members: []store.ClusterMemberDetail{{
 			Thread: store.Thread{
@@ -3644,12 +3644,13 @@ func TestTUIAutoRefreshIsQuietUntilClustersChange(t *testing.T) {
 		Clusters:   clusters,
 	})
 	model.status = "Reading detail"
-	model.detailCache[40] = store.ClusterDetail{Cluster: clusters[0]}
+	cacheKey := clusterSummaryKey(clusters[0])
+	model.detailCache[cacheKey] = store.ClusterDetail{Cluster: clusters[0]}
 	model.autoRefreshFromStore()
 	if model.status != "Reading detail" {
 		t.Fatalf("unchanged auto refresh status = %q", model.status)
 	}
-	if _, ok := model.detailCache[40]; !ok {
+	if _, ok := model.detailCache[cacheKey]; !ok {
 		t.Fatal("unchanged auto refresh should not clear detail cache")
 	}
 

--- a/internal/store/clusters.go
+++ b/internal/store/clusters.go
@@ -42,6 +42,7 @@ type ClusterSummaryOptions struct {
 type ClusterDetailOptions struct {
 	RepoID        int64
 	ClusterID     int64
+	Source        string
 	IncludeClosed bool
 	MemberLimit   int
 	BodyChars     int
@@ -449,6 +450,16 @@ func idSetOverlapRatio(left, right map[int64]bool) float64 {
 }
 
 func (s *Store) ClusterDetail(ctx context.Context, options ClusterDetailOptions) (ClusterDetail, error) {
+	source, err := normalizeClusterDetailSource(options.Source)
+	if err != nil {
+		return ClusterDetail{}, err
+	}
+	switch source {
+	case ClusterSourceRun:
+		return s.RunClusterDetail(ctx, options)
+	case ClusterSourceDurable:
+		return s.DurableClusterDetail(ctx, options)
+	}
 	detail, err := s.RunClusterDetail(ctx, options)
 	if err == nil {
 		return detail, nil
@@ -457,6 +468,19 @@ func (s *Store) ClusterDetail(ctx context.Context, options ClusterDetailOptions)
 		return ClusterDetail{}, err
 	}
 	return s.DurableClusterDetail(ctx, options)
+}
+
+func normalizeClusterDetailSource(source string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(source)) {
+	case "", "auto":
+		return "", nil
+	case "run", "raw", ClusterSourceRun:
+		return ClusterSourceRun, nil
+	case "durable", ClusterSourceDurable:
+		return ClusterSourceDurable, nil
+	default:
+		return "", fmt.Errorf("unsupported cluster source %q", source)
+	}
 }
 
 func (s *Store) DurableClusterDetail(ctx context.Context, options ClusterDetailOptions) (ClusterDetail, error) {

--- a/internal/store/clusters_test.go
+++ b/internal/store/clusters_test.go
@@ -236,11 +236,15 @@ func TestListDisplayClusterSummariesPrefersLatestRawRun(t *testing.T) {
 	}
 	if _, err := st.DB().ExecContext(ctx, `
 		insert into cluster_groups(id, repo_id, stable_key, stable_slug, status, representative_thread_id, title, created_at, updated_at)
-		values(700, ?, 'durable-key', 'durable-slug', 'active', ?, 'Durable title', '2026-04-26T00:00:00Z', '2026-04-26T00:03:00Z');
-		insert into cluster_memberships(cluster_id, thread_id, role, state, added_by, added_reason_json, created_at, updated_at)
-		values(700, ?, 'member', 'active', 'system', '{}', '2026-04-26T00:00:00Z', '2026-04-26T00:00:00Z');
-	`, repoID, durableID, durableID); err != nil {
+		values(70, ?, 'durable-key', 'durable-slug', 'active', ?, 'Durable title', '2026-04-26T00:00:00Z', '2026-04-26T00:03:00Z')
+	`, repoID, durableID); err != nil {
 		t.Fatalf("seed durable cluster: %v", err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `
+		insert into cluster_memberships(cluster_id, thread_id, role, state, added_by, added_reason_json, created_at, updated_at)
+		values(70, ?, 'member', 'active', 'system', '{}', '2026-04-26T00:00:00Z', '2026-04-26T00:00:00Z')
+	`, durableID); err != nil {
+		t.Fatalf("seed durable member: %v", err)
 	}
 
 	activeDisplay, err := st.ListDisplayClusterSummaries(ctx, ClusterSummaryOptions{RepoID: repoID, IncludeClosed: false, MinSize: 1, Limit: 20, Sort: "size"})
@@ -276,8 +280,15 @@ func TestListDisplayClusterSummariesPrefersLatestRawRun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list durable clusters: %v", err)
 	}
-	if len(durable) != 1 || durable[0].ID != 700 || durable[0].Source != ClusterSourceDurable {
+	if len(durable) != 1 || durable[0].ID != 70 || durable[0].Source != ClusterSourceDurable {
 		t.Fatalf("durable clusters should remain available, got %#v", durable)
+	}
+	durableDetail, err := st.ClusterDetail(ctx, ClusterDetailOptions{RepoID: repoID, ClusterID: 70, Source: ClusterSourceDurable, IncludeClosed: true, MemberLimit: 10})
+	if err != nil {
+		t.Fatalf("durable detail: %v", err)
+	}
+	if durableDetail.Cluster.Source != ClusterSourceDurable || len(durableDetail.Members) != 1 || durableDetail.Members[0].Thread.Number != 201 {
+		t.Fatalf("source-qualified durable detail should not return raw cluster, got %#v", durableDetail)
 	}
 
 	detail, err := st.ClusterDetail(ctx, ClusterDetailOptions{RepoID: repoID, ClusterID: 70, IncludeClosed: true, MemberLimit: 10})


### PR DESCRIPTION
## Summary
- add source-qualified cluster detail lookup for raw-run vs durable cluster IDs
- expose `cluster-detail --source auto|run|durable`
- make TUI detail cache, merged working sets, and refresh selection source-aware

## Validation
- go test ./internal/cli -run 'TestTUISameNumericClusterIDsStaySourceScoped|TestTUIJumpToThreadNumberLoadsClusterFromStore|TestTUIJumpToLoadedThreadNumber|TestTUIRefreshPreservesUnlimitedWorkingSet|TestTUIRefreshHonorsExplicitClusterLimit|TestTUIAutoRefreshIsQuietUntilClustersChange' -count=1
- go test ./internal/store -run 'TestListDisplayClusterSummariesPrefersLatestRawRun|TestListClusterSummaries' -count=1
- env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
- /Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode local --full-access --parallel-tests "go test ./internal/cli -run 'TestTUISameNumericClusterIDsStaySourceScoped|TestTUIJumpToThreadNumberLoadsClusterFromStore|TestTUIJumpToLoadedThreadNumber|TestTUIRefreshPreservesUnlimitedWorkingSet|TestTUIRefreshHonorsExplicitClusterLimit|TestTUIAutoRefreshIsQuietUntilClustersChange' -count=1 && go test ./internal/store -run 'TestListDisplayClusterSummariesPrefersLatestRawRun|TestListClusterSummaries' -count=1 && env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./..."
