### PR TITLE
fix: stabilize cosine for large vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Keep cosine similarity stable for very large finite vectors instead of dropping them after float overflow.
 - Allow cluster detail reads to target raw-run or durable-cluster IDs explicitly, avoiding collisions between the two ID namespaces.
 - Keep active durable cluster representatives on visible open members instead of closed or hidden historical members.
 - Avoid holding SQLite write transactions open while hydrating PR details from GitHub.

--- a/internal/vector/exact.go
+++ b/internal/vector/exact.go
@@ -46,14 +46,36 @@ func Cosine(left, right []float64) float64 {
 	if len(left) == 0 || len(left) != len(right) {
 		return 0
 	}
+	var leftMaxAbs, rightMaxAbs float64
+	for index := range left {
+		leftValue := left[index]
+		rightValue := right[index]
+		if math.IsNaN(leftValue) || math.IsNaN(rightValue) || math.IsInf(leftValue, 0) || math.IsInf(rightValue, 0) {
+			return 0
+		}
+		leftMaxAbs = max(leftMaxAbs, math.Abs(leftValue))
+		rightMaxAbs = max(rightMaxAbs, math.Abs(rightValue))
+	}
+	if leftMaxAbs == 0 || rightMaxAbs == 0 {
+		return 0
+	}
 	var dot, leftMag, rightMag float64
 	for index := range left {
-		dot += left[index] * right[index]
-		leftMag += left[index] * left[index]
-		rightMag += right[index] * right[index]
+		leftValue := left[index] / leftMaxAbs
+		rightValue := right[index] / rightMaxAbs
+		dot += leftValue * rightValue
+		leftMag += leftValue * leftValue
+		rightMag += rightValue * rightValue
 	}
 	if leftMag == 0 || rightMag == 0 {
 		return 0
 	}
-	return dot / (math.Sqrt(leftMag) * math.Sqrt(rightMag))
+	score := dot / (math.Sqrt(leftMag) * math.Sqrt(rightMag))
+	if score > 1 {
+		return 1
+	}
+	if score < -1 {
+		return -1
+	}
+	return score
 }

--- a/internal/vector/exact_test.go
+++ b/internal/vector/exact_test.go
@@ -14,6 +14,22 @@ func TestCosine(t *testing.T) {
 	}
 }
 
+func TestCosineLargeFiniteVectors(t *testing.T) {
+	large := math.MaxFloat64 / 4
+	if got := Cosine([]float64{large, large}, []float64{large, large}); math.Abs(got-1) > 1e-12 {
+		t.Fatalf("large same cosine = %.17g, want 1", got)
+	}
+	if got := Cosine([]float64{large, -large}, []float64{-large, large}); math.Abs(got+1) > 1e-12 {
+		t.Fatalf("large opposite cosine = %.17g, want -1", got)
+	}
+	if got := Cosine([]float64{large, 0}, []float64{0, large}); got != 0 {
+		t.Fatalf("large orthogonal cosine = %.17g, want 0", got)
+	}
+	if got := Cosine([]float64{1e-100}, []float64{1e150}); math.Abs(got-1) > 1e-12 {
+		t.Fatalf("mixed-scale cosine = %.17g, want 1", got)
+	}
+}
+
 func TestQuerySortsByScore(t *testing.T) {
 	got := Query([]Item{
 		{ThreadID: 1, Vector: []float64{1, 0}},


### PR DESCRIPTION
## Summary
- stabilize cosine similarity by scaling each finite vector before dot/norm accumulation
- keep non-finite and zero-magnitude vectors filtered out
- add regressions for huge finite vectors and mixed-scale vectors

## Proof
- go test ./internal/vector -count=1
- env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
- codex-review --mode local --full-access --parallel-tests "go test ./internal/vector -count=1 && env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./..."
