### PR TITLE
fix: reject duplicate embedding indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Report duplicate OpenAI embedding response indexes explicitly instead of letting a later row overwrite an earlier vector.
 - Keep cosine similarity stable for very large finite vectors instead of dropping them after float overflow.
 - Allow cluster detail reads to target raw-run or durable-cluster IDs explicitly, avoiding collisions between the two ID namespaces.
 - Keep active durable cluster representatives on visible open members instead of closed or hidden historical members.

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -233,10 +233,15 @@ func (c *Client) embedOnce(ctx context.Context, model string, texts []string) ([
 		return nil, nil, fmt.Errorf("openai embeddings returned %d vectors for %d inputs", len(parsed.Data), len(texts))
 	}
 	out := make([][]float64, len(texts))
+	seen := make([]bool, len(texts))
 	for _, item := range parsed.Data {
 		if item.Index < 0 || item.Index >= len(texts) {
 			return nil, nil, fmt.Errorf("openai embeddings returned invalid index %d", item.Index)
 		}
+		if seen[item.Index] {
+			return nil, nil, fmt.Errorf("openai embeddings returned duplicate index %d", item.Index)
+		}
+		seen[item.Index] = true
 		out[item.Index] = item.Embedding
 	}
 	for index, vector := range out {

--- a/internal/openai/client_test.go
+++ b/internal/openai/client_test.go
@@ -158,6 +158,11 @@ func TestEmbedErrorBranches(t *testing.T) {
 				Index     int       `json:"index"`
 				Embedding []float64 `json:"embedding"`
 			}{{Index: 4, Embedding: []float64{1}}}})
+		case strings.Contains(r.URL.Path, "duplicate-index"):
+			_ = json.NewEncoder(w).Encode(embeddingResponse{Data: []struct {
+				Index     int       `json:"index"`
+				Embedding []float64 `json:"embedding"`
+			}{{Index: 0, Embedding: []float64{1}}, {Index: 0, Embedding: []float64{2}}}})
 		case strings.Contains(r.URL.Path, "empty-vector"):
 			_ = json.NewEncoder(w).Encode(embeddingResponse{Data: []struct {
 				Index     int       `json:"index"`
@@ -168,10 +173,17 @@ func TestEmbedErrorBranches(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	for _, suffix := range []string{"/api-error", "/wrong-count", "/bad-index", "/empty-vector", ""} {
-		_, err := New(Options{APIKey: "test", BaseURL: server.URL + suffix, Retry: &noRetry}).Embed(context.Background(), "model", []string{"text"})
+	for _, suffix := range []string{"/api-error", "/wrong-count", "/bad-index", "/duplicate-index", "/empty-vector", ""} {
+		inputs := []string{"text"}
+		if suffix == "/duplicate-index" {
+			inputs = []string{"first", "second"}
+		}
+		_, err := New(Options{APIKey: "test", BaseURL: server.URL + suffix, Retry: &noRetry}).Embed(context.Background(), "model", inputs)
 		if err == nil {
 			t.Fatalf("expected error for %q", suffix)
+		}
+		if suffix == "/duplicate-index" && !strings.Contains(err.Error(), "duplicate index 0") {
+			t.Fatalf("duplicate index error = %q", err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- reject duplicate OpenAI embedding response indexes before assigning response vectors
- keep existing invalid-index and empty-vector validation intact
- add regression coverage for duplicate response indexes

## Proof
- go test ./internal/openai -count=1
- env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
- codex-review --mode local --full-access --parallel-tests "go test ./internal/openai -count=1 && env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./..."
