### PR TITLE
fix: reject recursive gh shim backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Refuse to use the running `gitcrawl` executable as the real `gh` backend, including hard-linked shim paths, to avoid recursive gh-shim fallthrough.
 - Report duplicate OpenAI embedding response indexes explicitly instead of letting a later row overwrite an earlier vector.
 - Keep cosine similarity stable for very large finite vectors instead of dropping them after float overflow.
 - Allow cluster detail reads to target raw-run or durable-cluster IDs explicitly, avoiding collisions between the two ID namespaces.

--- a/internal/cli/gh_path.go
+++ b/internal/cli/gh_path.go
@@ -1,10 +1,13 @@
 package cli
 
 import (
+	"crypto/sha256"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -44,6 +47,12 @@ func resolveRealGHPath() (string, error) {
 			}
 			continue
 		}
+		if !usableRealGHPath(candidate) {
+			if envPath != "" && candidate == envPath {
+				return "", fmt.Errorf("GITCRAWL_GH_PATH points to the gitcrawl shim (%s); set it to the real gh binary", envPath)
+			}
+			continue
+		}
 		return candidate, nil
 	}
 	return "", fmt.Errorf("real gh not found; set GITCRAWL_GH_PATH")
@@ -64,4 +73,59 @@ func isGitcrawlShimPath(path string) bool {
 		}
 	}
 	return false
+}
+
+func usableRealGHPath(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() || !ghBackendModeUsable(info.Mode(), runtime.GOOS) {
+		return false
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return true
+	}
+	exeInfo, exeInfoErr := os.Stat(exe)
+	if exeInfoErr == nil && os.SameFile(info, exeInfo) {
+		return false
+	}
+	candidateReal, candidateErr := filepath.EvalSymlinks(path)
+	exeReal, exeErr := filepath.EvalSymlinks(exe)
+	if candidateErr == nil && exeErr == nil && candidateReal == exeReal {
+		return false
+	}
+	return !sameExecutableContents(path, exe, info, exeInfo)
+}
+
+func ghBackendModeUsable(mode os.FileMode, goos string) bool {
+	return goos == "windows" || mode&0111 != 0
+}
+
+func sameExecutableContents(candidate, exe string, candidateInfo, exeInfo os.FileInfo) bool {
+	if candidateInfo == nil || exeInfo == nil || candidateInfo.Size() != exeInfo.Size() {
+		return false
+	}
+	candidateHash, err := fileSHA256(candidate)
+	if err != nil {
+		return false
+	}
+	exeHash, err := fileSHA256(exe)
+	if err != nil {
+		return false
+	}
+	return candidateHash == exeHash
+}
+
+func fileSHA256(path string) ([32]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	defer file.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return [32]byte{}, err
+	}
+	var out [32]byte
+	copy(out[:], hash.Sum(nil))
+	return out, nil
 }

--- a/internal/cli/gh_shim_policy_extra_test.go
+++ b/internal/cli/gh_shim_policy_extra_test.go
@@ -250,6 +250,40 @@ func TestGHShimCachePolicyExtraBranches(t *testing.T) {
 	if _, err := resolveRealGHPath(); err == nil || !strings.Contains(err.Error(), "gitcrawl shim") {
 		t.Fatalf("shim path should fail fast, err=%v", err)
 	}
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("executable: %v", err)
+	}
+	t.Setenv("GITCRAWL_GH_PATH", exe)
+	if _, err := resolveRealGHPath(); err == nil || !strings.Contains(err.Error(), "gitcrawl shim") {
+		t.Fatalf("current executable backend should fail fast, err=%v", err)
+	}
+	hardLink := filepath.Join(t.TempDir(), "gh")
+	if err := os.Link(exe, hardLink); err != nil {
+		t.Fatalf("hard-link executable: %v", err)
+	}
+	t.Setenv("GITCRAWL_GH_PATH", hardLink)
+	if _, err := resolveRealGHPath(); err == nil || !strings.Contains(err.Error(), "gitcrawl shim") {
+		t.Fatalf("hard-linked executable backend should fail fast, err=%v", err)
+	}
+	copiedPath := filepath.Join(t.TempDir(), "gh")
+	copiedBytes, err := os.ReadFile(exe)
+	if err != nil {
+		t.Fatalf("read executable: %v", err)
+	}
+	if err := os.WriteFile(copiedPath, copiedBytes, 0o755); err != nil {
+		t.Fatalf("copy executable: %v", err)
+	}
+	t.Setenv("GITCRAWL_GH_PATH", copiedPath)
+	if _, err := resolveRealGHPath(); err == nil || !strings.Contains(err.Error(), "gitcrawl shim") {
+		t.Fatalf("copied executable backend should fail fast, err=%v", err)
+	}
+	if ghBackendModeUsable(0o666, "darwin") {
+		t.Fatal("unix backend without execute bits should be unusable")
+	}
+	if !ghBackendModeUsable(0o666, "windows") {
+		t.Fatal("windows backend should not require unix execute bits")
+	}
 	t.Setenv("GITCRAWL_GH_STALE_GRACE", "3m")
 	if got := ghCommandCacheStaleGrace([]string{"api", "users/octocat"}); got != 3*time.Minute {
 		t.Fatalf("env stale grace = %s", got)

--- a/internal/cli/github_token.go
+++ b/internal/cli/github_token.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -70,21 +69,4 @@ func candidateRealGHPaths() []string {
 		}
 	}
 	return unique
-}
-
-func usableRealGHPath(path string) bool {
-	info, err := os.Stat(path)
-	if err != nil || info.IsDir() || info.Mode()&0111 == 0 {
-		return false
-	}
-	exe, err := os.Executable()
-	if err != nil {
-		return true
-	}
-	candidateReal, candidateErr := filepath.EvalSymlinks(path)
-	exeReal, exeErr := filepath.EvalSymlinks(exe)
-	if candidateErr == nil && exeErr == nil && candidateReal == exeReal {
-		return false
-	}
-	return true
 }


### PR DESCRIPTION
## Summary
- reject gh fallthrough backends that are the running gitcrawl binary, symlinks, hard links, or copied shim binaries
- keep Windows gh.exe backends usable without Unix execute bits
- share the real-gh usability guard between gh fallthrough and gh auth token lookup

## Clawpatch
- found: fnd_sig-feat-cli-command-0550d7dd80-_89e31207a9
- revalidated: fixed

## Proof
- go test ./internal/cli -run 'TestGHShimCachePolicyExtraBranches' -count=1
- env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
- clawpatch revalidate --finding fnd_sig-feat-cli-command-0550d7dd80-_89e31207a9 --provider codex
- codex-review --mode local --full-access --parallel-tests "go test ./internal/cli -run 'TestGHShimCachePolicyExtraBranches' -count=1 && env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./..."
