### PR TITLE
fix: reject unsupported gh json fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Fall back or fail for unsupported local `gh pr checks` and `gh run` JSON fields instead of silently omitting them.
 - Refuse to use the running `gitcrawl` executable as the real `gh` backend, including hard-linked shim paths, to avoid recursive gh-shim fallthrough.
 - Report duplicate OpenAI embedding response indexes explicitly instead of letting a later row overwrite an earlier vector.
 - Keep cosine similarity stable for very large finite vectors instead of dropping them after float overflow.

--- a/internal/cli/gh_shim_coverage_extra_test.go
+++ b/internal/cli/gh_shim_coverage_extra_test.go
@@ -313,7 +313,10 @@ func TestGHMetricsSearchRunsAndXCacheBranches(t *testing.T) {
 		HTMLURL: "https://example.com/run", Event: "push", HeadBranch: "main", HeadSHA: "abc",
 		CreatedAtGH: "2026-05-08T00:00:00Z", UpdatedAtGH: "2026-05-08T00:01:00Z",
 	}, {RunID: "not-number", WorkflowName: "Deploy"}}
-	runRows := ghWorkflowRunJSONRows(runs, "databaseId,id,number,workflowName,name,displayTitle,status,conclusion,url,event,headBranch,headSha,createdAt,updatedAt")
+	runRows, err := ghWorkflowRunJSONRows(runs, "databaseId,id,number,workflowName,name,displayTitle,status,conclusion,url,event,headBranch,headSha,createdAt,updatedAt")
+	if err != nil {
+		t.Fatalf("run rows: %v", err)
+	}
 	if runRows[0]["databaseId"] != int64(99) || runRows[1]["databaseId"] != "not-number" {
 		t.Fatalf("run rows = %+v", runRows)
 	}

--- a/internal/cli/gh_shim_detail_test.go
+++ b/internal/cli/gh_shim_detail_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -145,6 +147,89 @@ func TestGHShimViewAndListUseLocalCache(t *testing.T) {
 	}
 	if got := stdout.String(); !strings.Contains(got, "12\tManifest cache update") {
 		t.Fatalf("human pr list = %q", got)
+	}
+}
+
+func TestGHShimUnsupportedChecksAndRunJSONFieldsFallback(t *testing.T) {
+	ctx := context.Background()
+	configPath := seedGHShimRepo(t, ctx)
+	ghPath := filepath.Join(t.TempDir(), "gh")
+	if err := os.WriteFile(ghPath, []byte("#!/bin/sh\necho fallback:$*\n"), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("GITCRAWL_GH_PATH", ghPath)
+
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "pr checks",
+			args: []string{"--config", configPath, "gh", "pr", "checks", "12", "-R", "openclaw/openclaw", "--json", "missingField"},
+			want: "fallback:pr checks 12 -R openclaw/openclaw --json missingField",
+		},
+		{
+			name: "run list",
+			args: []string{"--config", configPath, "gh", "run", "list", "-R", "openclaw/openclaw", "--branch", "manifest-cache", "--json", "missingField"},
+			want: "fallback:run list -R openclaw/openclaw --branch manifest-cache --json missingField",
+		},
+		{
+			name: "run view",
+			args: []string{"--config", configPath, "gh", "run", "view", "99", "-R", "openclaw/openclaw", "--json", "missingField"},
+			want: "fallback:run view 99 -R openclaw/openclaw --json missingField",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			run := New()
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			run.Stdout = &stdout
+			run.Stderr = &stderr
+			if err := run.Run(ctx, tc.args); err != nil {
+				t.Fatalf("fallback: %v", err)
+			}
+			if got := strings.TrimSpace(stdout.String()); got != tc.want {
+				t.Fatalf("fallback output = %q, want %q", got, tc.want)
+			}
+			if got := strings.TrimSpace(stderr.String()); got != "" {
+				t.Fatalf("fallback stderr = %q", got)
+			}
+		})
+	}
+}
+
+func TestGHShimCachedUnsupportedChecksAndRunJSONFieldsFail(t *testing.T) {
+	ctx := context.Background()
+	configPath := seedGHShimRepo(t, ctx)
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "pr checks",
+			args: []string{"--config", configPath, "gh", "--cached", "pr", "checks", "12", "-R", "openclaw/openclaw", "--json", "missingField"},
+		},
+		{
+			name: "run list",
+			args: []string{"--config", configPath, "gh", "--cached", "run", "list", "-R", "openclaw/openclaw", "--branch", "manifest-cache", "--json", "missingField"},
+		},
+		{
+			name: "run view",
+			args: []string{"--config", configPath, "gh", "--cached", "run", "view", "99", "-R", "openclaw/openclaw", "--json", "missingField"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := New().Run(ctx, tc.args)
+			if err == nil {
+				t.Fatal("unsupported cached --json field should fail")
+			}
+			if !isLocalGHUnsupported(err) || !strings.Contains(err.Error(), "missingField") {
+				t.Fatalf("error = %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/gh_shim_prcache.go
+++ b/internal/cli/gh_shim_prcache.go
@@ -232,7 +232,10 @@ func (a *App) runGHPRChecks(ctx context.Context, args []string) error {
 	}
 	if strings.TrimSpace(*jsonFieldsRaw) != "" || strings.TrimSpace(*jqRaw) != "" || a.format == FormatJSON {
 		fields := firstNonEmpty(strings.TrimSpace(*jsonFieldsRaw), "name,state,conclusion,detailsUrl,workflow")
-		rows := ghPRChecksJSONRows(cache.Checks, fields)
+		rows, err := ghPRChecksJSONRows(cache.Checks, fields)
+		if err != nil {
+			return localGHUnsupported(err)
+		}
 		return a.writeJSONValue(rows, strings.TrimSpace(*jqRaw))
 	}
 	for _, check := range cache.Checks {
@@ -243,7 +246,7 @@ func (a *App) runGHPRChecks(ctx context.Context, args []string) error {
 	return nil
 }
 
-func ghPRChecksJSONRows(checks []store.PullRequestCheck, fieldsRaw string) []map[string]any {
+func ghPRChecksJSONRows(checks []store.PullRequestCheck, fieldsRaw string) ([]map[string]any, error) {
 	fields := parseJSONFields(fieldsRaw)
 	rows := make([]map[string]any, 0, len(checks))
 	for _, check := range checks {
@@ -266,9 +269,11 @@ func ghPRChecksJSONRows(checks []store.PullRequestCheck, fieldsRaw string) []map
 				row[field] = check.StartedAt
 			case "completedAt":
 				row[field] = check.CompletedAt
+			default:
+				return nil, fmt.Errorf("unsupported gh pr checks --json field %q", field)
 			}
 		}
 		rows = append(rows, row)
 	}
-	return rows
+	return rows, nil
 }

--- a/internal/cli/gh_shim_runs.go
+++ b/internal/cli/gh_shim_runs.go
@@ -69,11 +69,16 @@ func (a *App) runGHRunList(ctx context.Context, args []string, controls ghShimCo
 	if len(runs) == 0 {
 		return localGHUnsupported(fmt.Errorf("no cached workflow runs"))
 	}
-	a.writeGHLocalRunNotice()
 	if strings.TrimSpace(*jsonFieldsRaw) != "" || strings.TrimSpace(*jqRaw) != "" || a.format == FormatJSON {
 		fields := firstNonEmpty(strings.TrimSpace(*jsonFieldsRaw), "databaseId,workflowName,status,conclusion,url,createdAt,updatedAt")
-		return a.writeJSONValue(ghWorkflowRunJSONRows(runs, fields), strings.TrimSpace(*jqRaw))
+		rows, err := ghWorkflowRunJSONRows(runs, fields)
+		if err != nil {
+			return localGHUnsupported(err)
+		}
+		a.writeGHLocalRunNotice()
+		return a.writeJSONValue(rows, strings.TrimSpace(*jqRaw))
 	}
+	a.writeGHLocalRunNotice()
 	for _, run := range runs {
 		if _, err := fmt.Fprintf(a.Stdout, "%s\t%s\t%s\t%s\n", run.RunID, run.WorkflowName, run.Status, run.HTMLURL); err != nil {
 			return err
@@ -115,11 +120,16 @@ func (a *App) runGHRunView(ctx context.Context, args []string) error {
 		if run.RunID != runID {
 			continue
 		}
-		a.writeGHLocalRunNotice()
 		if strings.TrimSpace(*jsonFieldsRaw) != "" || strings.TrimSpace(*jqRaw) != "" || a.format == FormatJSON {
 			fields := firstNonEmpty(strings.TrimSpace(*jsonFieldsRaw), "databaseId,workflowName,status,conclusion,url,createdAt,updatedAt")
-			return a.writeJSONValue(ghWorkflowRunJSONRows([]store.WorkflowRun{run}, fields)[0], strings.TrimSpace(*jqRaw))
+			rows, err := ghWorkflowRunJSONRows([]store.WorkflowRun{run}, fields)
+			if err != nil {
+				return localGHUnsupported(err)
+			}
+			a.writeGHLocalRunNotice()
+			return a.writeJSONValue(rows[0], strings.TrimSpace(*jqRaw))
 		}
+		a.writeGHLocalRunNotice()
 		_, err := fmt.Fprintf(a.Stdout, "run: %s\nworkflow: %s\nstatus: %s\nurl: %s\n", run.RunID, run.WorkflowName, run.Status, run.HTMLURL)
 		return err
 	}
@@ -147,7 +157,7 @@ func (a *App) localGHWorkflowRuns(ctx context.Context, repoValue string, options
 	return rt.Store.ListWorkflowRuns(ctx, repo.ID, options)
 }
 
-func ghWorkflowRunJSONRows(runs []store.WorkflowRun, fieldsRaw string) []map[string]any {
+func ghWorkflowRunJSONRows(runs []store.WorkflowRun, fieldsRaw string) ([]map[string]any, error) {
 	fields := parseJSONFields(fieldsRaw)
 	rows := make([]map[string]any, 0, len(runs))
 	for _, run := range runs {
@@ -180,9 +190,11 @@ func ghWorkflowRunJSONRows(runs []store.WorkflowRun, fieldsRaw string) []map[str
 				row[field] = run.CreatedAtGH
 			case "updatedAt":
 				row[field] = run.UpdatedAtGH
+			default:
+				return nil, fmt.Errorf("unsupported gh run --json field %q", field)
 			}
 		}
 		rows = append(rows, row)
 	}
-	return rows
+	return rows, nil
 }


### PR DESCRIPTION
## Summary
- reject unsupported local `gh pr checks --json` fields instead of silently omitting them
- reject unsupported local `gh run list/view --json` fields and fall back to real `gh` when not forced cached
- keep `--cached` local-only by surfacing the unsupported-field error, with regression coverage for checks/list/view

## Proof
- go test ./internal/cli -run 'TestGHShim(UnsupportedChecksAndRunJSONFieldsFallback|CachedUnsupportedChecksAndRunJSONFieldsFail|ViewAndListUseLocalCache)$' -count=1
- env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
- clawpatch revalidate fnd_sig-feat-cli-command-953ae34a85-_5c6bd8a305: fixed
- codex-review clean: no accepted/actionable findings reported
