### PR TITLE
fix: preserve stable gh diff cache during gc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Keep `gh xcache gc` from expiring stable PR diff cache entries with the short fallback TTL while the PR head SHA is unchanged.
 - Fall back or fail for unsupported local `gh pr checks` and `gh run` JSON fields instead of silently omitting them.
 - Refuse to use the running `gitcrawl` executable as the real `gh` backend, including hard-linked shim paths, to avoid recursive gh-shim fallthrough.
 - Report duplicate OpenAI embedding response indexes explicitly instead of letting a later row overwrite an earlier vector.

--- a/internal/cli/gh_shim_cache.go
+++ b/internal/cli/gh_shim_cache.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -36,8 +37,9 @@ func (a *App) execRealGHMaybeCached(ctx context.Context, args []string, controls
 	if err != nil {
 		return a.execRealGH(ctx, args)
 	}
-	ttl := a.ghCommandCacheTTL(ctx, args)
-	entryPath := filepath.Join(cacheDir, a.ghCommandCacheKey(ctx, args)+".json")
+	stableIdentity := a.ghCommandStableIdentity(ctx, args)
+	ttl := ghCommandCacheTTLBase(args, stableIdentity != "")
+	entryPath := filepath.Join(cacheDir, a.ghCommandCacheKeyWithStableIdentity(ctx, args, stableIdentity)+".json")
 	staleEntry, hasStaleEntry := readGHCommandCacheEntry(entryPath)
 	bypassCache := false
 	if a.shouldBypassGHCacheForLiveness(ctx, args, controls) {
@@ -92,12 +94,13 @@ func (a *App) execRealGHMaybeCached(ctx context.Context, args []string, controls
 			_ = a.recordGHRateLimitFromOutput(ctx, args, stdout)
 		}
 		_ = writeGHCommandCache(entryPath, ghCommandCacheEntry{
-			CreatedAt: time.Now().UTC(),
-			Args:      append([]string(nil), args...),
-			Tags:      a.ghCommandCacheTags(ctx, args),
-			ExitCode:  exitCode,
-			Stdout:    stdout,
-			Stderr:    stderr,
+			CreatedAt:      time.Now().UTC(),
+			Args:           append([]string(nil), args...),
+			Tags:           a.ghCommandCacheTags(ctx, args),
+			StableIdentity: stableIdentity,
+			ExitCode:       exitCode,
+			Stdout:         stdout,
+			Stderr:         stderr,
 		})
 	}
 	_, _ = io.WriteString(a.Stdout, stdout)
@@ -235,12 +238,13 @@ func isGHCommandCacheEntryFile(name string) bool {
 }
 
 type ghCommandCacheEntry struct {
-	CreatedAt time.Time `json:"created_at"`
-	Args      []string  `json:"args"`
-	Tags      []string  `json:"tags,omitempty"`
-	ExitCode  int       `json:"exit_code"`
-	Stdout    string    `json:"stdout"`
-	Stderr    string    `json:"stderr"`
+	CreatedAt      time.Time `json:"created_at"`
+	Args           []string  `json:"args"`
+	Tags           []string  `json:"tags,omitempty"`
+	StableIdentity string    `json:"stable_identity,omitempty"`
+	ExitCode       int       `json:"exit_code"`
+	Stdout         string    `json:"stdout"`
+	Stderr         string    `json:"stderr"`
 }
 
 func (a *App) writeGHCommandCacheEntry(entry ghCommandCacheEntry) error {
@@ -462,13 +466,17 @@ func waitGHCommandCache(entryPath, lockPath string, ttl time.Duration, staleEntr
 }
 
 func (a *App) ghCommandCacheKey(ctx context.Context, args []string) string {
+	return a.ghCommandCacheKeyWithStableIdentity(ctx, args, a.ghCommandStableIdentity(ctx, args))
+}
+
+func (a *App) ghCommandCacheKeyWithStableIdentity(ctx context.Context, args []string, stableIdentity string) string {
 	material := strings.Join([]string{
 		"v4",
 		config.ResolvePath(a.configPath),
 		ghCommandCacheScope(args),
 		os.Getenv("GH_HOST"),
 		ghCommandCacheRepoEnv(args),
-		a.ghCommandStableIdentity(ctx, args),
+		stableIdentity,
 		strings.Join(canonicalGHCommandArgs(args), "\x00"),
 	}, "\x00")
 	sum := sha256.Sum256([]byte(material))
@@ -546,6 +554,10 @@ func (a *App) ghCommandStableIdentity(ctx context.Context, args []string) string
 	if !ok {
 		return ""
 	}
+	return a.ghStablePRDiffIdentity(ctx, repo, number)
+}
+
+func (a *App) ghStablePRDiffIdentity(ctx context.Context, repo string, number int) string {
 	thread, err := a.localGHThread(ctx, repo, "pull_request", number)
 	if err != nil {
 		return ""
@@ -569,4 +581,24 @@ func (a *App) ghCommandStableIdentity(ctx context.Context, args []string) string
 		return ""
 	}
 	return fmt.Sprintf("pr-diff:%s:%d:%s", repo, number, sha)
+}
+
+func parseStablePRDiffIdentity(value string) (repo string, number int, sha string, ok bool) {
+	rest, ok := strings.CutPrefix(value, "pr-diff:")
+	if !ok {
+		return "", 0, "", false
+	}
+	repo, rest, ok = strings.Cut(rest, ":")
+	if !ok {
+		return "", 0, "", false
+	}
+	numberRaw, sha, ok := strings.Cut(rest, ":")
+	if !ok {
+		return "", 0, "", false
+	}
+	parsed, err := strconv.Atoi(numberRaw)
+	if err != nil || repo == "" || parsed <= 0 || sha == "" {
+		return "", 0, "", false
+	}
+	return repo, parsed, sha, true
 }

--- a/internal/cli/gh_shim_cache_test.go
+++ b/internal/cli/gh_shim_cache_test.go
@@ -1412,6 +1412,111 @@ func TestGHShimXCacheGCRemovesExpiredEntries(t *testing.T) {
 	}
 }
 
+func TestGHShimXCacheGCKeepsStablePRDiffEntries(t *testing.T) {
+	ctx := context.Background()
+	configPath := seedGHShimRepo(t, ctx)
+	ghPath := filepath.Join(t.TempDir(), "gh")
+	if err := os.WriteFile(ghPath, []byte("#!/bin/sh\necho diff:$*\n"), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("GITCRAWL_GH_PATH", ghPath)
+	t.Setenv("GH_REPO", "openclaw/openclaw")
+
+	run := New()
+	var stdout bytes.Buffer
+	run.Stdout = &stdout
+	args := []string{"--config", configPath, "gh", "pr", "diff", "12"}
+	if err := run.Run(ctx, args); err != nil {
+		t.Fatalf("cache pr diff: %v", err)
+	}
+	t.Setenv("GH_REPO", "")
+	app := New()
+	app.configPath = configPath
+	cacheDir, err := app.ghCommandCacheDir()
+	if err != nil {
+		t.Fatalf("cache dir: %v", err)
+	}
+	entries, err := os.ReadDir(cacheDir)
+	if err != nil {
+		t.Fatalf("read cache dir: %v", err)
+	}
+	var entryPath string
+	for _, entry := range entries {
+		if entry.Type().IsRegular() && isGHCommandCacheEntryFile(entry.Name()) {
+			entryPath = filepath.Join(cacheDir, entry.Name())
+			break
+		}
+	}
+	if entryPath == "" {
+		t.Fatal("cached pr diff entry not found")
+	}
+	cached, ok := readGHCommandCacheEntry(entryPath)
+	if !ok {
+		t.Fatalf("read cached entry %s", entryPath)
+	}
+	if cached.StableIdentity == "" {
+		t.Fatalf("stable identity was not persisted: %+v", cached)
+	}
+	cached.CreatedAt = time.Now().Add(-10 * time.Minute)
+	data, err := json.Marshal(cached)
+	if err != nil {
+		t.Fatalf("marshal cache entry: %v", err)
+	}
+	if err := os.WriteFile(entryPath, data, 0o644); err != nil {
+		t.Fatalf("age cache entry: %v", err)
+	}
+
+	stdout.Reset()
+	if err := run.Run(ctx, []string{"--config", configPath, "gh", "xcache", "gc", "--json"}); err != nil {
+		t.Fatalf("xcache gc unchanged head: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode gc unchanged: %v\n%s", err, stdout.String())
+	}
+	if int(result["removed"].(float64)) != 0 {
+		t.Fatalf("unchanged head gc = %#v", result)
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	st, err := store.Open(ctx, cfg.DBPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	repo, err := st.RepositoryByFullName(ctx, "openclaw/openclaw")
+	if err != nil {
+		t.Fatalf("repo: %v", err)
+	}
+	if err := st.UpsertPullRequestCache(ctx, store.PullRequestDetail{
+		ThreadID:  prIDForTest(t, ctx, st, repo.ID, 12),
+		RepoID:    repo.ID,
+		Number:    12,
+		HeadSHA:   "def456",
+		RawJSON:   `{"head":{"sha":"def456"}}`,
+		FetchedAt: "2026-04-27T03:00:00Z",
+		UpdatedAt: "2026-04-27T03:00:00Z",
+	}, nil, nil, nil, nil); err != nil {
+		t.Fatalf("update pr cache head: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	stdout.Reset()
+	if err := run.Run(ctx, []string{"--config", configPath, "gh", "xcache", "gc", "--json"}); err != nil {
+		t.Fatalf("xcache gc changed head: %v", err)
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode gc changed: %v\n%s", err, stdout.String())
+	}
+	if int(result["removed"].(float64)) != 1 {
+		t.Fatalf("changed head gc = %#v", result)
+	}
+}
+
 func TestGHShimCoalescesConcurrentReadOnlyFallbacks(t *testing.T) {
 	ctx := context.Background()
 	configPath := seedGHShimRepo(t, ctx)

--- a/internal/cli/gh_shim_xcache.go
+++ b/internal/cli/gh_shim_xcache.go
@@ -405,7 +405,7 @@ func (a *App) gcGHCommandCache() (ghCommandCacheGCResult, error) {
 		if !entry.Type().IsRegular() || !isGHCommandCacheEntryFile(name) {
 			continue
 		}
-		key, ok := ghCommandCacheKeyInfoFromDirEntry(dir, entry)
+		key, ok := a.ghCommandCacheKeyInfoFromDirEntry(context.Background(), dir, entry)
 		if ok && key.Expired {
 			if err := os.Remove(path); err == nil {
 				result.Removed++
@@ -440,7 +440,7 @@ func (a *App) collectGHCommandCacheKeys(dir string) ([]ghCommandCacheKeyInfo, in
 		if !entry.Type().IsRegular() || !isGHCommandCacheEntryFile(name) {
 			continue
 		}
-		key, ok := ghCommandCacheKeyInfoFromDirEntry(dir, entry)
+		key, ok := a.ghCommandCacheKeyInfoFromDirEntry(context.Background(), dir, entry)
 		if ok {
 			keys = append(keys, key)
 		}
@@ -452,6 +452,19 @@ func (a *App) collectGHCommandCacheKeys(dir string) ([]ghCommandCacheKeyInfo, in
 }
 
 func ghCommandCacheKeyInfoFromDirEntry(dir string, entry os.DirEntry) (ghCommandCacheKeyInfo, bool) {
+	return ghCommandCacheKeyInfoFromDirEntryCached(dir, entry, nil)
+}
+
+func (a *App) ghCommandCacheKeyInfoFromDirEntry(ctx context.Context, dir string, entry os.DirEntry) (ghCommandCacheKeyInfo, bool) {
+	return ghCommandCacheKeyInfoFromDirEntryCached(dir, entry, func(cached ghCommandCacheEntry) string {
+		if repo, number, _, ok := parseStablePRDiffIdentity(cached.StableIdentity); ok {
+			return a.ghStablePRDiffIdentity(ctx, repo, number)
+		}
+		return a.ghCommandStableIdentity(ctx, cached.Args)
+	})
+}
+
+func ghCommandCacheKeyInfoFromDirEntryCached(dir string, entry os.DirEntry, currentStableIdentity func(ghCommandCacheEntry) string) (ghCommandCacheKeyInfo, bool) {
 	name := entry.Name()
 	info, err := entry.Info()
 	if err != nil {
@@ -465,7 +478,12 @@ func ghCommandCacheKeyInfoFromDirEntry(dir string, entry os.DirEntry) (ghCommand
 	if err := json.Unmarshal(data, &cached); err != nil {
 		return ghCommandCacheKeyInfo{}, false
 	}
-	ttl := ghCommandCacheTTL(cached.Args)
+	stablePRDiff := cached.StableIdentity != ""
+	stableChanged := false
+	if stablePRDiff && currentStableIdentity != nil {
+		stableChanged = currentStableIdentity(cached) != cached.StableIdentity
+	}
+	ttl := ghCommandCacheTTLBase(cached.Args, stablePRDiff)
 	age := time.Since(cached.CreatedAt)
 	return ghCommandCacheKeyInfo{
 		Key:       strings.TrimSuffix(name, ".json"),
@@ -475,6 +493,6 @@ func ghCommandCacheKeyInfoFromDirEntry(dir string, entry os.DirEntry) (ghCommand
 		Args:      cached.Args,
 		Tags:      cached.Tags,
 		Bytes:     info.Size(),
-		Expired:   cached.CreatedAt.IsZero() || age > ghCommandCacheEntryTTL(cached, ttl),
+		Expired:   stableChanged || cached.CreatedAt.IsZero() || age > ghCommandCacheEntryTTL(cached, ttl),
 	}, true
 }


### PR DESCRIPTION
## Summary
- persist the stable PR-diff identity in cached gh entries
- make `gh xcache keys/gc` use the persisted identity for the long stable PR diff TTL
- expire stable PR diff cache entries when the current PR head identity changes

## Proof
- go test ./internal/cli -run 'TestGHShimXCache(GCRemovesExpiredEntries|GCKeepsStablePRDiffEntries)|TestGHShimCachesPRDiffByHeadSHA' -count=1
- env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
- clawpatch revalidate fnd_sig-feat-cli-command-953ae34a85-_582d4bf6a2: fixed
- codex-review clean: no accepted/actionable findings reported
