### PR TITLE
fix: paginate review thread comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Fetch all paginated GitHub review-thread comments instead of keeping only the first review-thread comment page.
 - Keep `gh xcache gc` from expiring stable PR diff cache entries with the short fallback TTL while the PR head SHA is unchanged.
 - Fall back or fail for unsupported local `gh pr checks` and `gh run` JSON fields instead of silently omitting them.
 - Refuse to use the running `gitcrawl` executable as the real `gh` backend, including hard-linked shim paths, to avoid recursive gh-shim fallthrough.

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -294,6 +294,74 @@ func TestListPullReviewThreadsDecodesGraphQLEnvelope(t *testing.T) {
 	}
 }
 
+func TestListPullReviewThreadsPaginatesReviewThreadComments(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.URL.Path != "/graphql" {
+			t.Fatalf("unexpected path: %s", r.URL.String())
+		}
+		var body graphqlEnvelope
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		switch calls {
+		case 1:
+			if body.Variables["threadID"] != nil {
+				t.Fatalf("first request should fetch review threads, variables=%+v", body.Variables)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"repository": map[string]any{"pullRequest": map[string]any{
+				"reviewThreads": map[string]any{
+					"nodes": []map[string]any{{
+						"id":         "PRRT_1",
+						"isResolved": false,
+						"comments": map[string]any{
+							"nodes":    []map[string]any{{"id": "PRRC_1"}},
+							"pageInfo": map[string]any{"hasNextPage": true, "endCursor": "comment-cursor-1"},
+						},
+					}},
+					"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+				},
+			}}}})
+		case 2:
+			if body.Variables["threadID"] != "PRRT_1" || body.Variables["cursor"] != "comment-cursor-1" {
+				t.Fatalf("comment page variables = %+v", body.Variables)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{
+				"node": map[string]any{
+					"comments": map[string]any{
+						"nodes":    []map[string]any{{"id": "PRRC_2"}},
+						"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+					},
+				},
+			}})
+		default:
+			t.Fatalf("unexpected graphql call %d", calls)
+		}
+	}))
+	defer server.Close()
+
+	client := New(Options{BaseURL: server.URL, PageDelay: -1})
+	rows, err := client.ListPullReviewThreads(context.Background(), "openclaw", "gitcrawl", 8, nil)
+	if err != nil {
+		t.Fatalf("list review threads: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d", calls)
+	}
+	if len(rows) != 1 || rows[0]["id"] != "PRRT_1" {
+		t.Fatalf("rows = %#v", rows)
+	}
+	comments, ok := rows[0]["comments"].(map[string]any)
+	if !ok {
+		t.Fatalf("comments = %#v", rows[0]["comments"])
+	}
+	nodes, ok := comments["nodes"].([]map[string]any)
+	if !ok || len(nodes) != 2 || nodes[1]["id"] != "PRRC_2" {
+		t.Fatalf("comment nodes = %#v", comments["nodes"])
+	}
+}
+
 func TestNextPageAndReporterBranches(t *testing.T) {
 	header := `<https://api.github.test/repos/o/r/issues?page=2&state=open>; rel="next", <https://api.github.test/repos/o/r/issues?page=9>; rel="last"`
 	if got := nextPage(header, "https://api.github.test"); got != "/repos/o/r/issues?page=2&state=open" {

--- a/internal/github/review_threads.go
+++ b/internal/github/review_threads.go
@@ -24,7 +24,7 @@ query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
           viewerCanResolve
           viewerCanUnresolve
           viewerCanReply
-          comments(first: 50) {
+          comments(first: 100) {
             nodes {
               id
               databaseId
@@ -36,7 +36,37 @@ query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
               updatedAt
               url
             }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
           }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+`
+
+const pullReviewThreadCommentsQuery = `
+query($threadID: ID!, $cursor: String) {
+  node(id: $threadID) {
+    ... on PullRequestReviewThread {
+      comments(first: 100, after: $cursor) {
+        nodes {
+          id
+          databaseId
+          body
+          author { login __typename }
+          path
+          diffHunk
+          createdAt
+          updatedAt
+          url
         }
         pageInfo {
           hasNextPage
@@ -60,6 +90,20 @@ type pullReviewThreadsResponse struct {
 			} `json:"reviewThreads"`
 		} `json:"pullRequest"`
 	} `json:"repository"`
+}
+
+type pullReviewThreadCommentsResponse struct {
+	Node *struct {
+		Comments reviewThreadCommentsConnection `json:"comments"`
+	} `json:"node"`
+}
+
+type reviewThreadCommentsConnection struct {
+	Nodes    []map[string]any `json:"nodes"`
+	PageInfo struct {
+		HasNextPage bool   `json:"hasNextPage"`
+		EndCursor   string `json:"endCursor"`
+	} `json:"pageInfo"`
 }
 
 type graphqlEnvelope struct {
@@ -95,6 +139,11 @@ func (c *Client) ListPullReviewThreads(ctx context.Context, owner, repo string, 
 			return nil, fmt.Errorf("pull request #%d not found in %s/%s", number, owner, repo)
 		}
 		page := resp.Repository.PullRequest.ReviewThreads
+		for _, thread := range page.Nodes {
+			if err := c.completeReviewThreadComments(ctx, thread, reporter); err != nil {
+				return nil, err
+			}
+		}
 		out = append(out, page.Nodes...)
 		if !page.PageInfo.HasNextPage {
 			break
@@ -102,6 +151,68 @@ func (c *Client) ListPullReviewThreads(ctx context.Context, owner, repo string, 
 		cursor = page.PageInfo.EndCursor
 	}
 	return out, nil
+}
+
+func (c *Client) completeReviewThreadComments(ctx context.Context, thread map[string]any, reporter Reporter) error {
+	threadID, _ := thread["id"].(string)
+	if threadID == "" {
+		return nil
+	}
+	comments := reviewThreadCommentsFromMap(thread["comments"])
+	if !comments.PageInfo.HasNextPage {
+		return nil
+	}
+	for comments.PageInfo.HasNextPage {
+		cursor := comments.PageInfo.EndCursor
+		if cursor == "" {
+			return fmt.Errorf("review thread %s comments page missing endCursor", threadID)
+		}
+		vars := map[string]any{"threadID": threadID, "cursor": cursor}
+		var resp pullReviewThreadCommentsResponse
+		if err := c.doGraphQL(ctx, pullReviewThreadCommentsQuery, vars, reporter, &resp); err != nil {
+			return err
+		}
+		if resp.Node == nil {
+			return fmt.Errorf("review thread %s not found", threadID)
+		}
+		comments.Nodes = append(comments.Nodes, resp.Node.Comments.Nodes...)
+		comments.PageInfo = resp.Node.Comments.PageInfo
+	}
+	thread["comments"] = map[string]any{
+		"nodes": comments.Nodes,
+		"pageInfo": map[string]any{
+			"hasNextPage": comments.PageInfo.HasNextPage,
+			"endCursor":   comments.PageInfo.EndCursor,
+		},
+	}
+	return nil
+}
+
+func reviewThreadCommentsFromMap(value any) reviewThreadCommentsConnection {
+	var out reviewThreadCommentsConnection
+	raw, ok := value.(map[string]any)
+	if !ok {
+		return out
+	}
+	switch nodes := raw["nodes"].(type) {
+	case []map[string]any:
+		out.Nodes = append(out.Nodes, nodes...)
+	case []any:
+		out.Nodes = make([]map[string]any, 0, len(nodes))
+		for _, node := range nodes {
+			if mapped, ok := node.(map[string]any); ok {
+				out.Nodes = append(out.Nodes, mapped)
+			}
+		}
+	}
+	pageInfo, _ := raw["pageInfo"].(map[string]any)
+	if hasNextPage, ok := pageInfo["hasNextPage"].(bool); ok {
+		out.PageInfo.HasNextPage = hasNextPage
+	}
+	if endCursor, ok := pageInfo["endCursor"].(string); ok {
+		out.PageInfo.EndCursor = endCursor
+	}
+	return out
 }
 
 func (c *Client) doGraphQL(ctx context.Context, query string, variables map[string]any, reporter Reporter, out any) error {


### PR DESCRIPTION
## Summary
- paginate nested GitHub review-thread comments after the initial review-thread GraphQL page
- preserve the existing comments.nodes shape consumed by sync/store/status code
- add regression coverage for fetching a second comment page

## Proof
- go test ./internal/github -run 'TestListPullReviewThreads(DecodesGraphQLEnvelope|PaginatesReviewThreadComments)' -count=1
- env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
- clawpatch revalidate fnd_sig-feat-service-0b6ef82cb4-0399_29ca2af247: fixed
- clawpatch revalidate fnd_sig-feat-service-a799a4509d-32f9_b534e63cbe: fixed
- codex-review clean: no accepted/actionable findings reported
