### PR TITLE
fix: fail pr sync on review thread errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Fail PR-detail syncs when GitHub review-thread hydration fails instead of recording a successful partial refresh.
 - Fetch all paginated GitHub review-thread comments instead of keeping only the first review-thread comment page.
 - Keep `gh xcache gc` from expiring stable PR diff cache entries with the short fallback TTL while the PR head SHA is unchanged.
 - Fall back or fail for unsupported local `gh pr checks` and `gh run` JSON fields instead of silently omitting them.

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -413,8 +413,7 @@ func (s *Syncer) syncComments(ctx context.Context, options Options, thread store
 func (s *Syncer) syncPullReviewThreads(ctx context.Context, st *store.Store, options Options, thread store.Thread) (int, error) {
 	rows, err := s.client.ListPullReviewThreads(ctx, options.Owner, options.Repo, thread.Number, options.Reporter)
 	if err != nil {
-		options.Reporter.Printf("[sync] review threads skipped number=%d err=%v", thread.Number, err)
-		return 0, nil
+		return 0, fmt.Errorf("list pull request review threads for #%d: %w", thread.Number, err)
 	}
 	fetchedAt := s.now().Format(time.RFC3339Nano)
 	threads := make([]store.PullRequestReviewThread, 0, len(rows))

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"path/filepath"
 	"strings"
@@ -269,6 +270,10 @@ type emptyHeadPullGitHub struct {
 	runsCalled   bool
 }
 
+type failingReviewThreadsGitHub struct {
+	pullDetailsGitHub
+}
+
 type txProbePullDetailsGitHub struct {
 	fakeGitHub
 	st                    *store.Store
@@ -316,6 +321,10 @@ func (g *emptyHeadPullGitHub) ListWorkflowRuns(ctx context.Context, owner, repo 
 
 func (pullDetailsGitHub) ListPullReviewThreads(ctx context.Context, owner, repo string, number int, reporter gh.Reporter) ([]map[string]any, error) {
 	return pullCommentGitHub{}.ListPullReviewThreads(ctx, owner, repo, number, reporter)
+}
+
+func (failingReviewThreadsGitHub) ListPullReviewThreads(ctx context.Context, owner, repo string, number int, reporter gh.Reporter) ([]map[string]any, error) {
+	return nil, errors.New("graphql unavailable")
 }
 
 func (pullDetailsGitHub) ListPullFiles(ctx context.Context, owner, repo string, number int, reporter gh.Reporter) ([]map[string]any, error) {
@@ -528,6 +537,39 @@ func TestSyncHydratesPullRequestDetails(t *testing.T) {
 	}
 	if fetchedAt == "" {
 		t.Fatal("missing review thread sync marker")
+	}
+}
+
+func TestSyncPullRequestDetailsFailsOnReviewThreadFetchError(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	s := New(failingReviewThreadsGitHub{}, st)
+	s.now = func() time.Time { return time.Date(2026, 4, 26, 0, 0, 0, 0, time.UTC) }
+	_, err = s.Sync(ctx, Options{Owner: "openclaw", Repo: "gitcrawl", Numbers: []int{8}, IncludePRDetails: true})
+	if err == nil || !strings.Contains(err.Error(), "list pull request review threads for #8") {
+		t.Fatalf("sync error = %v", err)
+	}
+	repo, err := st.RepositoryByFullName(ctx, "openclaw/gitcrawl")
+	if err != nil {
+		t.Fatalf("repo: %v", err)
+	}
+	threads, err := st.ListThreads(ctx, repo.ID, true)
+	if err != nil {
+		t.Fatalf("threads: %v", err)
+	}
+	if len(threads) != 1 {
+		t.Fatalf("threads = %+v", threads)
+	}
+	fetchedAt, err := st.PullRequestReviewThreadsFetchedAt(ctx, threads[0].ID)
+	if err != nil {
+		t.Fatalf("review thread marker: %v", err)
+	}
+	if fetchedAt != "" {
+		t.Fatalf("review thread marker should stay empty after failed fetch, got %q", fetchedAt)
 	}
 }
 


### PR DESCRIPTION
## Summary
- propagate review-thread hydration failures during PR-detail sync
- prevent failed review-thread fetches from recording fresh successful PR-detail sync state
- add regression coverage for failed review-thread hydration leaving the fetched marker empty

## Proof
- go test ./internal/syncer -run 'TestSync(HydratesPullRequestDetails|PullRequestDetailsFailsOnReviewThreadFetchError)' -count=1
- env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
- clawpatch revalidate fnd_sig-feat-service-0b6ef82cb4-570f_6648a5564f: fixed
- codex-review clean: no accepted/actionable findings reported
