### PR TITLE
fix: preserve comments in metadata sync documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Preserve existing comment text in search documents during metadata-only syncs.
 - Fail PR-detail syncs when GitHub review-thread hydration fails instead of recording a successful partial refresh.
 - Fetch all paginated GitHub review-thread comments instead of keeping only the first review-thread comment page.
 - Keep `gh xcache gc` from expiring stable PR diff cache entries with the short fallback TTL while the PR head SHA is unchanged.

--- a/internal/store/portable.go
+++ b/internal/store/portable.go
@@ -302,7 +302,7 @@ func sqliteIdentifier(value string) string {
 
 func (s *Store) tableExists(ctx context.Context, table string) bool {
 	var name string
-	err := s.db.QueryRowContext(ctx, `select name from sqlite_master where type in ('table', 'virtual table') and name = ?`, table).Scan(&name)
+	err := s.q().QueryRowContext(ctx, `select name from sqlite_master where type in ('table', 'virtual table') and name = ?`, table).Scan(&name)
 	return err == nil && name == table
 }
 

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -162,6 +162,12 @@ func (s *Syncer) Sync(ctx context.Context, options Options) (Stats, error) {
 					return err
 				}
 				stats.CommentsSynced += len(comments)
+			} else {
+				var err error
+				comments, err = st.ListComments(ctx, thread.ID)
+				if err != nil {
+					return err
+				}
 			}
 			if options.IncludePRDetails && thread.Kind == "pull_request" {
 				count, err := s.syncPullReviewThreads(ctx, st, options, thread)

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -441,6 +441,29 @@ func TestSyncPersistsIssuesAndPullRequests(t *testing.T) {
 	}
 }
 
+func TestMetadataOnlySyncPreservesCommentBackedDocumentText(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	s := New(fakeGitHub{}, st)
+	s.now = func() time.Time { return time.Date(2026, 4, 26, 0, 0, 0, 0, time.UTC) }
+	if _, err := s.Sync(ctx, Options{Owner: "openclaw", Repo: "gitcrawl", IncludeComments: true}); err != nil {
+		t.Fatalf("sync with comments: %v", err)
+	}
+	assertDocumentFTSCount(t, st, "same", 1)
+	stats, err := s.Sync(ctx, Options{Owner: "openclaw", Repo: "gitcrawl"})
+	if err != nil {
+		t.Fatalf("metadata sync: %v", err)
+	}
+	if !stats.MetadataOnly || stats.CommentsSynced != 0 {
+		t.Fatalf("metadata stats = %#v", stats)
+	}
+	assertDocumentFTSCount(t, st, "same", 1)
+}
+
 func TestSyncHydratesPullReviewComments(t *testing.T) {
 	ctx := context.Background()
 	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
@@ -922,4 +945,15 @@ func testProgressLogger(out *bytes.Buffer) *slog.Logger {
 			return attr
 		},
 	}))
+}
+
+func assertDocumentFTSCount(t *testing.T, st *store.Store, query string, want int) {
+	t.Helper()
+	var got int
+	if err := st.DB().QueryRowContext(context.Background(), `select count(*) from documents_fts where documents_fts match ?`, query).Scan(&got); err != nil {
+		t.Fatalf("query document index: %v", err)
+	}
+	if got != want {
+		t.Fatalf("document FTS count for %q: got %d want %d", query, got, want)
+	}
 }


### PR DESCRIPTION
## Summary
- preserve stored comments when metadata-only sync rebuilds search documents
- make tableExists transaction-aware so comment reads work inside metadata-only sync transactions
- add regression coverage for full sync followed by metadata-only sync retaining a comment-only FTS term

## Proof
- go test ./internal/syncer -run 'Test(MetadataOnlySyncPreservesCommentBackedDocumentText|SyncPersistsIssuesAndPullRequests)' -count=1
- go test ./internal/store -run 'TestUpsertPullRequestReviewThreadsRollsBackReplacementOnInsertError' -count=1
- env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
- clawpatch revalidate fnd_sig-feat-service-0b6ef82cb4-851c_896034ea93: fixed
- codex-review clean: no accepted/actionable findings reported
