### PR TITLE
fix: preserve OpenAI retry defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Preserve OpenAI retry backoff defaults when callers provide partial retry overrides.
 - Preserve existing comment text in search documents during metadata-only syncs.
 - Fail PR-detail syncs when GitHub review-thread hydration fails instead of recording a successful partial refresh.
 - Fetch all paginated GitHub review-thread comments instead of keeping only the first review-thread comment page.

--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -100,9 +100,7 @@ func New(options Options) *Client {
 	if options.Retry != nil {
 		retry = *options.Retry
 	}
-	if retry.MaxAttempts <= 0 {
-		retry.MaxAttempts = 1
-	}
+	retry = normalizeRetryConfig(retry)
 	now := options.Now
 	if now == nil {
 		now = time.Now
@@ -121,6 +119,23 @@ func New(options Options) *Client {
 		sleep:      sleep,
 		rand:       rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
+}
+
+func normalizeRetryConfig(retry RetryConfig) RetryConfig {
+	defaults := DefaultRetryConfig()
+	if retry.MaxAttempts <= 0 {
+		retry.MaxAttempts = 1
+	}
+	if retry.BaseDelay <= 0 {
+		retry.BaseDelay = defaults.BaseDelay
+	}
+	if retry.OverloadedBase <= 0 {
+		retry.OverloadedBase = defaults.OverloadedBase
+	}
+	if retry.MaxDelay <= 0 {
+		retry.MaxDelay = defaults.MaxDelay
+	}
+	return retry
 }
 
 func (c *Client) Embed(ctx context.Context, model string, texts []string) ([][]float64, error) {

--- a/internal/openai/client_test.go
+++ b/internal/openai/client_test.go
@@ -234,6 +234,36 @@ func TestEmbedRetriesOn429AndHonorsRetryAfter(t *testing.T) {
 	}
 }
 
+func TestEmbedPartialRetryConfigUsesDefaultMaxDelay(t *testing.T) {
+	var calls int32
+	server := newSingleVectorServer(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "2")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		writeSingleVector(w)
+	})
+	defer server.Close()
+
+	var slept []time.Duration
+	retry := RetryConfig{MaxAttempts: 2, BaseDelay: time.Millisecond, MaxElapsed: time.Hour}
+	client := New(Options{APIKey: "test", BaseURL: server.URL, Retry: &retry, Sleep: func(_ context.Context, d time.Duration) error {
+		slept = append(slept, d)
+		return nil
+	}})
+	if _, err := client.Embed(context.Background(), "model", []string{"hi"}); err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2", calls)
+	}
+	if len(slept) != 1 || slept[0] != 2*time.Second {
+		t.Fatalf("expected default max delay to preserve 2s Retry-After, got %v", slept)
+	}
+}
+
 func TestEmbedDoesNotSleepAfterFinalRetryableError(t *testing.T) {
 	var calls int32
 	server := newSingleVectorServer(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- normalize partial OpenAI retry overrides so missing delay fields keep default backoff behavior
- add regression coverage for Retry-After with a custom retry config that omits MaxDelay
- update changelog for the retry behavior fix

## Proof
- go test ./internal/openai -run 'TestEmbedPartialRetryConfigUsesDefaultMaxDelay|TestOpenAIErrorAndRetryHelpers|TestEmbedRetriesOn429AndHonorsRetryAfter' -count=1
- env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
- clawpatch revalidate fnd_sig-feat-service-75e79e2e7f-26ff_ac7860226a: fixed
- codex-review clean: no accepted/actionable findings reported
