### PR TITLE
fix: preserve thread vector variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Preserve multiple thread embeddings for the same thread when basis or model differs.
 - Preserve OpenAI retry backoff defaults when callers provide partial retry overrides.
 - Preserve existing comment text in search documents during metadata-only syncs.
 - Fail PR-detail syncs when GitHub review-thread hydration fails instead of recording a successful partial refresh.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -416,7 +416,7 @@ func (a *App) runRefresh(ctx context.Context, args []string) error {
 			return err
 		}
 		if len(vectors) == 0 {
-			fallbackQuery := store.ThreadVectorQuery{RepoID: repo.ID}
+			fallbackQuery := store.ThreadVectorQuery{RepoID: repo.ID, IncludeClosed: stateIncludesClosed(*state)}
 			fallbackVectors, err := rt.Store.ListThreadVectorsFiltered(ctx, fallbackQuery)
 			if err != nil {
 				_ = rt.Store.Close()
@@ -424,7 +424,7 @@ func (a *App) runRefresh(ctx context.Context, args []string) error {
 			}
 			if len(fallbackVectors) > 0 {
 				query = fallbackQuery
-				vectors = fallbackVectors
+				vectors = dedupeThreadVectorsByThread(fallbackVectors)
 			}
 		}
 		retireMissing := minSize <= 1 && !stateIncludesClosed(*state)
@@ -639,7 +639,50 @@ func semanticSearchVectors(ctx context.Context, st *store.Store, query store.Thr
 		return storedVectors, nil
 	}
 	query.Basis = ""
-	return st.ListThreadVectorsFiltered(ctx, query)
+	fallbackVectors, err := st.ListThreadVectorsFiltered(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	return dedupeThreadVectorsByThread(fallbackVectors), nil
+}
+
+func dedupeThreadVectorsByThread(vectors []store.ThreadVector) []store.ThreadVector {
+	out := make([]store.ThreadVector, 0, len(vectors))
+	indexByThreadID := make(map[int64]int, len(vectors))
+	for _, candidate := range vectors {
+		index, ok := indexByThreadID[candidate.ThreadID]
+		if !ok {
+			indexByThreadID[candidate.ThreadID] = len(out)
+			out = append(out, candidate)
+			continue
+		}
+		if threadVectorPreferred(candidate, out[index]) {
+			out[index] = candidate
+		}
+	}
+	return out
+}
+
+func threadVectorPreferred(candidate, current store.ThreadVector) bool {
+	if candidate.UpdatedAt != current.UpdatedAt {
+		return threadVectorTimestampAfter(candidate.UpdatedAt, current.UpdatedAt)
+	}
+	if candidate.CreatedAt != current.CreatedAt {
+		return threadVectorTimestampAfter(candidate.CreatedAt, current.CreatedAt)
+	}
+	if candidate.Basis != current.Basis {
+		return candidate.Basis < current.Basis
+	}
+	return candidate.Model < current.Model
+}
+
+func threadVectorTimestampAfter(candidate, current string) bool {
+	candidateTime, candidateErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(candidate))
+	currentTime, currentErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(current))
+	if candidateErr == nil && currentErr == nil {
+		return candidateTime.After(currentTime)
+	}
+	return candidate > current
 }
 
 func threadVectorsWithDimensions(vectors []store.ThreadVector, dimensions int) []store.ThreadVector {
@@ -871,7 +914,7 @@ func (a *App) runCluster(ctx context.Context, args []string) error {
 		}
 		if len(fallbackVectors) > 0 {
 			query = fallbackQuery
-			vectors = fallbackVectors
+			vectors = dedupeThreadVectorsByThread(fallbackVectors)
 		}
 	}
 	if limit > 0 && len(vectors) > limit {

--- a/internal/cli/coverage_extra_test.go
+++ b/internal/cli/coverage_extra_test.go
@@ -194,6 +194,20 @@ func TestCLIAppVectorFallbackCoveragePaths(t *testing.T) {
 	}
 }
 
+func TestDedupeThreadVectorsByThreadPrefersNewest(t *testing.T) {
+	vectors := dedupeThreadVectorsByThread([]store.ThreadVector{
+		{ThreadID: 1, Basis: "z_basis", Model: "model", UpdatedAt: "2026-05-15T00:00:00.12Z", Vector: []float64{1, 0}},
+		{ThreadID: 1, Basis: "a_basis", Model: "model", UpdatedAt: "2026-05-15T00:00:00.123Z", Vector: []float64{0, 1}},
+		{ThreadID: 2, Basis: "z_basis", Model: "model", UpdatedAt: "2026-05-15T00:00:00Z", Vector: []float64{0.5, 0.5}},
+	})
+	if len(vectors) != 2 {
+		t.Fatalf("vectors = %#v, want one row per thread", vectors)
+	}
+	if vectors[0].ThreadID != 1 || vectors[0].Basis != "a_basis" {
+		t.Fatalf("did not keep newest duplicate vector: %#v", vectors)
+	}
+}
+
 func TestCLIAppUsageBranches(t *testing.T) {
 	ctx := context.Background()
 	configPath := filepath.Join(t.TempDir(), "config.toml")

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -292,7 +292,7 @@ create table if not exists document_embeddings (
 );
 
 create table if not exists thread_vectors (
-  thread_id integer primary key references threads(id) on delete cascade,
+  thread_id integer not null references threads(id) on delete cascade,
   basis text not null,
   model text not null,
   dimensions integer not null,
@@ -300,7 +300,8 @@ create table if not exists thread_vectors (
   vector_json text not null,
   vector_backend text not null,
   created_at text not null,
-  updated_at text not null
+  updated_at text not null,
+  primary key(thread_id, basis, model)
 );
 
 create table if not exists thread_fingerprints (

--- a/internal/store/sqlc/schema.sql
+++ b/internal/store/sqlc/schema.sql
@@ -195,7 +195,7 @@ create table documents (
 );
 
 create table thread_vectors (
-  thread_id integer primary key references threads(id) on delete cascade,
+  thread_id integer not null references threads(id) on delete cascade,
   basis text not null,
   model text not null,
   dimensions integer not null,
@@ -203,7 +203,8 @@ create table thread_vectors (
   vector_json text not null,
   vector_backend text not null,
   created_at text not null,
-  updated_at text not null
+  updated_at text not null,
+  primary key(thread_id, basis, model)
 );
 
 create table thread_key_summaries (

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	schemaVersion = 1
+	schemaVersion = 2
 	timeLayout    = time.RFC3339Nano
 )
 
@@ -183,6 +183,9 @@ func (s *Store) migrate(ctx context.Context) error {
 	if err := s.ensureLegacyPortableColumns(ctx); err != nil {
 		return err
 	}
+	if err := s.ensureThreadVectorsCompositeKey(ctx); err != nil {
+		return err
+	}
 	if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`pragma user_version = %d`, schemaVersion)); err != nil {
 		return fmt.Errorf("set schema version: %w", err)
 	}
@@ -206,6 +209,68 @@ func (s *Store) ensureLegacyPortableColumns(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+func (s *Store) ensureThreadVectorsCompositeKey(ctx context.Context) error {
+	if !s.hasTable(ctx, "thread_vectors") || s.threadVectorsHaveCompositeKey(ctx) {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin thread vector key migration: %w", err)
+	}
+	defer tx.Rollback()
+	for _, stmt := range []string{
+		`drop index if exists idx_thread_vectors_basis_model`,
+		`alter table thread_vectors rename to thread_vectors_old`,
+		`create table thread_vectors (
+			thread_id integer not null references threads(id) on delete cascade,
+			basis text not null,
+			model text not null,
+			dimensions integer not null,
+			content_hash text not null,
+			vector_json text not null,
+			vector_backend text not null,
+			created_at text not null,
+			updated_at text not null,
+			primary key(thread_id, basis, model)
+		)`,
+		`insert into thread_vectors(thread_id, basis, model, dimensions, content_hash, vector_json, vector_backend, created_at, updated_at)
+			select thread_id, basis, model, dimensions, content_hash, vector_json, vector_backend, created_at, updated_at
+			from thread_vectors_old`,
+		`drop table thread_vectors_old`,
+		`create index if not exists idx_thread_vectors_basis_model on thread_vectors(basis, model)`,
+	} {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("migrate thread vector key: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit thread vector key migration: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) threadVectorsHaveCompositeKey(ctx context.Context) bool {
+	rows, err := s.db.QueryContext(ctx, `pragma table_info(thread_vectors)`)
+	if err != nil {
+		return false
+	}
+	defer rows.Close()
+	pk := map[string]int{}
+	for rows.Next() {
+		var cid int
+		var name, columnType string
+		var notNull, primaryKey int
+		var defaultValue any
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			return false
+		}
+		if primaryKey > 0 {
+			pk[name] = primaryKey
+		}
+	}
+	return pk["thread_id"] == 1 && pk["basis"] == 2 && pk["model"] == 3
 }
 
 func (s *Store) hasTable(ctx context.Context, table string) bool {

--- a/internal/store/vectors.go
+++ b/internal/store/vectors.go
@@ -43,9 +43,7 @@ func (s *Store) UpsertThreadVector(ctx context.Context, vector ThreadVector) err
 	_, err = s.db.ExecContext(ctx, `
 		insert into thread_vectors(thread_id, basis, model, dimensions, content_hash, vector_json, vector_backend, created_at, updated_at)
 		values(?, ?, ?, ?, ?, ?, ?, ?, ?)
-		on conflict(thread_id) do update set
-			basis=excluded.basis,
-			model=excluded.model,
+		on conflict(thread_id, basis, model) do update set
 			dimensions=excluded.dimensions,
 			content_hash=excluded.content_hash,
 			vector_json=excluded.vector_json,

--- a/internal/store/vectors_test.go
+++ b/internal/store/vectors_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"encoding/binary"
 	"math"
 	"path/filepath"
@@ -34,12 +35,18 @@ func TestUpsertAndListThreadVectors(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("vector: %v", err)
 	}
+	if err := st.UpsertThreadVector(ctx, ThreadVector{
+		ThreadID: threadID, Basis: "llm_key_summary", Model: "test", Dimensions: 3,
+		ContentHash: "summary-hash", Vector: []float64{0, 1, 0}, CreatedAt: "2026-04-26T00:00:00Z", UpdatedAt: "2026-04-26T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("summary vector: %v", err)
+	}
 
 	vectors, err := st.ListThreadVectors(ctx, repoID)
 	if err != nil {
 		t.Fatalf("list vectors: %v", err)
 	}
-	if len(vectors) != 1 || vectors[0].Vector[0] != 1 {
+	if len(vectors) != 2 {
 		t.Fatalf("unexpected vectors: %#v", vectors)
 	}
 
@@ -49,6 +56,97 @@ func TestUpsertAndListThreadVectors(t *testing.T) {
 	}
 	if thread.ID != threadID || vector.ThreadID != threadID {
 		t.Fatalf("unexpected thread/vector: %#v %#v", thread, vector)
+	}
+	if len(vector.Vector) != 3 || vector.Vector[0] != 1 {
+		t.Fatalf("title vector was overwritten: %#v", vector)
+	}
+	_, vector, err = st.ThreadVectorByNumber(ctx, ThreadVectorQuery{RepoID: repoID, Model: "test", Basis: "llm_key_summary"}, 1)
+	if err != nil {
+		t.Fatalf("summary thread vector by number: %v", err)
+	}
+	if len(vector.Vector) != 3 || vector.Vector[1] != 1 {
+		t.Fatalf("summary vector missing: %#v", vector)
+	}
+}
+
+func TestOpenMigratesThreadVectorsToCompositeKey(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "gitcrawl.db")
+	st, err := Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	repoID, err := st.UpsertRepository(ctx, Repository{Owner: "openclaw", Name: "gitcrawl", FullName: "openclaw/gitcrawl", RawJSON: "{}", UpdatedAt: "2026-04-26T00:00:00Z"})
+	if err != nil {
+		t.Fatalf("repo: %v", err)
+	}
+	threadID, err := st.UpsertThread(ctx, Thread{
+		RepoID: repoID, GitHubID: "1", Number: 1, Kind: "issue", State: "open",
+		Title: "download stalls", HTMLURL: "https://github.com/openclaw/gitcrawl/issues/1",
+		LabelsJSON: "[]", AssigneesJSON: "[]", RawJSON: "{}", ContentHash: "hash", UpdatedAt: "2026-04-26T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("thread: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open raw db: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `
+		drop index if exists idx_thread_vectors_basis_model;
+		drop table thread_vectors;
+		create table thread_vectors (
+			thread_id integer primary key references threads(id) on delete cascade,
+			basis text not null,
+			model text not null,
+			dimensions integer not null,
+			content_hash text not null,
+			vector_json text not null,
+			vector_backend text not null,
+			created_at text not null,
+			updated_at text not null
+		);
+		insert into thread_vectors(thread_id, basis, model, dimensions, content_hash, vector_json, vector_backend, created_at, updated_at)
+		values(?, 'title_original', 'test', 3, 'hash', '[1,0,0]', 'exact', '2026-04-26T00:00:00Z', '2026-04-26T00:00:00Z');
+	`, threadID)
+	if err != nil {
+		t.Fatalf("seed legacy vector table: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close raw db: %v", err)
+	}
+
+	st, err = Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open migrated store: %v", err)
+	}
+	defer st.Close()
+	if !st.threadVectorsHaveCompositeKey(ctx) {
+		t.Fatal("thread_vectors primary key was not migrated")
+	}
+	var version int
+	if err := st.DB().QueryRowContext(ctx, `pragma user_version`).Scan(&version); err != nil {
+		t.Fatalf("read user_version: %v", err)
+	}
+	if version != schemaVersion {
+		t.Fatalf("user_version = %d, want %d", version, schemaVersion)
+	}
+	if err := st.UpsertThreadVector(ctx, ThreadVector{
+		ThreadID: threadID, Basis: "llm_key_summary", Model: "test", Dimensions: 3,
+		ContentHash: "summary-hash", Vector: []float64{0, 1, 0}, CreatedAt: "2026-04-26T00:00:00Z", UpdatedAt: "2026-04-26T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("summary vector: %v", err)
+	}
+	vectors, err := st.ListThreadVectors(ctx, repoID)
+	if err != nil {
+		t.Fatalf("list vectors: %v", err)
+	}
+	if len(vectors) != 2 {
+		t.Fatalf("migrated vector table still overwrites rows: %#v", vectors)
 	}
 }
 


### PR DESCRIPTION
## Summary
- preserve separate thread embeddings for different basis/model values
- migrate legacy thread_vectors tables to a composite primary key
- dedupe unfiltered vector fallback paths before clustering/search

## Verification
- go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.31.1 generate
- go test ./internal/cli -run 'TestDedupeThreadVectorsByThreadPrefersNewest|TestCLIAppVectorFallbackCoveragePaths|TestClusterCommandPersistsDurableClusters' -count=1
- go test ./internal/store -run 'TestUpsertAndListThreadVectors|TestOpenMigratesThreadVectorsToCompositeKey|TestOpenMigratesSchema|TestListEmbeddingTasks' -count=1
- env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
- Clawpatch revalidate: fixed fnd_sig-feat-service-8c5e4bf928-07dc_e137410021
- codex-review: clean
