### PR TITLE
fix: reject empty durable clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Reject durable cluster saves with empty member lists instead of leaving stale active memberships.
 - Preserve multiple thread embeddings for the same thread when basis or model differs.
 - Preserve OpenAI retry backoff defaults when callers provide partial retry overrides.
 - Preserve existing comment text in search documents during metadata-only syncs.

--- a/internal/store/clusters.go
+++ b/internal/store/clusters.go
@@ -729,6 +729,9 @@ func (s *Store) saveDurableClusters(ctx context.Context, repoID int64, inputs []
 		result.RunID = runID
 		seenClusterIDs := make([]int64, 0, len(inputs))
 		for _, input := range inputs {
+			if len(input.Members) == 0 {
+				return fmt.Errorf("durable cluster %q has no members", strings.TrimSpace(input.StableKey))
+			}
 			clusterID, err := tx.upsertDurableCluster(ctx, repoID, runID, input, now)
 			if err != nil {
 				return err

--- a/internal/store/clusters_test.go
+++ b/internal/store/clusters_test.go
@@ -871,3 +871,43 @@ func TestSaveDurableClustersRetiresMissingClusters(t *testing.T) {
 		t.Fatal("locally closed cluster should stay hidden after reappearing")
 	}
 }
+
+func TestSaveDurableClustersRejectsEmptyMembers(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	repoID, threadIDs := seedVectorThreads(t, ctx, st)
+	input := DurableClusterInput{
+		StableKey:              "members-empty",
+		StableSlug:             "cluster-empty",
+		RepresentativeThreadID: threadIDs[0],
+		Members:                []DurableClusterMemberInput{{ThreadID: threadIDs[0], Role: "canonical"}},
+	}
+	if _, err := st.SaveDurableClusters(ctx, repoID, []DurableClusterInput{input}); err != nil {
+		t.Fatalf("seed durable cluster: %v", err)
+	}
+	clusterID, err := st.ClusterIDForThreadNumber(ctx, repoID, 301, false)
+	if err != nil {
+		t.Fatalf("cluster id: %v", err)
+	}
+
+	input.Members = nil
+	if _, err := st.SaveDurableClusters(ctx, repoID, []DurableClusterInput{input}); err == nil {
+		t.Fatal("empty member cluster should fail")
+	}
+
+	var activeMembers int
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from cluster_memberships where cluster_id = ? and state = 'active'`, clusterID).Scan(&activeMembers); err != nil {
+		t.Fatalf("count active members: %v", err)
+	}
+	if activeMembers != 1 {
+		t.Fatalf("active members = %d, want 1", activeMembers)
+	}
+	if _, err := st.ClusterIDForThreadNumber(ctx, repoID, 301, false); err != nil {
+		t.Fatalf("cluster should remain available after rejected save: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- reject durable cluster inputs with empty member lists before upserting cluster metadata
- add regression coverage proving a rejected empty save does not disturb existing active memberships
- document the fix in the changelog

## Verification
- go test ./internal/store -run 'TestSaveDurableClustersRejectsEmptyMembers|TestDurableClusterLifecycleAndClosedSummaries|TestSaveDurableClustersRetiresMissingClusters' -count=1
- env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
- Clawpatch revalidate: fixed fnd_sig-feat-service-8c5e4bf928-7126_c0e286c8ea
- codex-review: clean
