### PR TITLE
fix: derive github enterprise graphql endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Send GitHub Enterprise GraphQL requests to `/api/graphql` when the REST API base URL ends in `/api/v3`.
 - Reject durable cluster saves with empty member lists instead of leaving stale active memberships.
 - Preserve multiple thread embeddings for the same thread when basis or model differs.
 - Preserve OpenAI retry backoff defaults when callers provide partial retry overrides.

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -17,6 +17,7 @@ type Reporter func(message string)
 type Client struct {
 	httpClient *http.Client
 	baseURL    string
+	graphQLURL string
 	token      string
 	userAgent  string
 	pageDelay  time.Duration
@@ -86,6 +87,7 @@ func New(options Options) *Client {
 	return &Client{
 		httpClient: httpClient,
 		baseURL:    baseURL,
+		graphQLURL: graphQLURLForBaseURL(baseURL),
 		token:      options.Token,
 		userAgent:  userAgent,
 		pageDelay:  options.PageDelay,
@@ -291,7 +293,10 @@ func (c *Client) do(ctx context.Context, method, path string, body io.Reader, re
 }
 
 func (c *Client) doOnce(ctx context.Context, method, path string, body io.Reader, reporter Reporter) (*http.Response, error) {
-	fullURL := c.baseURL + path
+	fullURL := path
+	if !isAbsoluteURL(path) {
+		fullURL = c.baseURL + path
+	}
 	req, err := http.NewRequestWithContext(ctx, method, fullURL, body)
 	if err != nil {
 		return nil, err
@@ -323,6 +328,27 @@ func (c *Client) doOnce(ctx context.Context, method, path string, body io.Reader
 		Body:    strings.TrimSpace(string(data)),
 		Headers: resp.Header,
 	}
+}
+
+func isAbsoluteURL(value string) bool {
+	return strings.HasPrefix(value, "https://") || strings.HasPrefix(value, "http://")
+}
+
+func graphQLURLForBaseURL(baseURL string) string {
+	trimmed := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return trimmed + "/graphql"
+	}
+	path := strings.TrimRight(parsed.Path, "/")
+	if strings.HasSuffix(path, "/api/v3") {
+		parsed.Path = strings.TrimSuffix(path, "/api/v3") + "/api/graphql"
+	} else {
+		parsed.Path = path + "/graphql"
+	}
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String()
 }
 
 func (c *Client) observeRateLimit(header http.Header) {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -294,6 +294,32 @@ func TestListPullReviewThreadsDecodesGraphQLEnvelope(t *testing.T) {
 	}
 }
 
+func TestListPullReviewThreadsUsesEnterpriseGraphQLEndpoint(t *testing.T) {
+	var graphQLPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		graphQLPath = r.URL.Path
+		if r.URL.Path != "/api/graphql" {
+			http.Error(w, "wrong graphql endpoint", http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"repository": map[string]any{"pullRequest": map[string]any{
+			"reviewThreads": map[string]any{
+				"nodes":    []map[string]any{},
+				"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+			},
+		}}}})
+	}))
+	defer server.Close()
+
+	client := New(Options{BaseURL: server.URL + "/api/v3", PageDelay: -1})
+	if _, err := client.ListPullReviewThreads(context.Background(), "openclaw", "gitcrawl", 8, nil); err != nil {
+		t.Fatalf("list review threads: %v", err)
+	}
+	if graphQLPath != "/api/graphql" {
+		t.Fatalf("graphql path = %q, want /api/graphql", graphQLPath)
+	}
+}
+
 func TestListPullReviewThreadsPaginatesReviewThreadComments(t *testing.T) {
 	var calls int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/github/review_threads.go
+++ b/internal/github/review_threads.go
@@ -221,7 +221,7 @@ func (c *Client) doGraphQL(ctx context.Context, query string, variables map[stri
 		return fmt.Errorf("encode graphql request: %w", err)
 	}
 	var envelope graphqlResponseEnvelope
-	if err := c.doJSON(ctx, http.MethodPost, "/graphql", bytes.NewReader(payload), reporter, &envelope); err != nil {
+	if err := c.doJSON(ctx, http.MethodPost, c.graphQLURL, bytes.NewReader(payload), reporter, &envelope); err != nil {
 		return err
 	}
 	if len(envelope.Errors) > 0 {


### PR DESCRIPTION
## Summary
- derive a separate GraphQL endpoint from the configured GitHub REST API base URL
- map GitHub Enterprise REST bases ending in /api/v3 to /api/graphql
- add regression coverage for review-thread hydration against a GHE-shaped base URL

## Verification
- go test ./internal/github -run 'TestListPullReviewThreads(DecodesGraphQLEnvelope|UsesEnterpriseGraphQLEndpoint|PaginatesReviewThreadComments)|TestNextPageAndReporterBranches' -count=1
- env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
- Clawpatch revalidate: fixed fnd_sig-feat-service-a799a4509d-5dc8_207db5e2e7
- codex-review: clean
