### PR TITLE
fix: replay github retry request bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.5 - Unreleased
 
+- Replay GitHub request bodies on rate-limit retries so GraphQL POST retries keep their JSON payload.
 - Send GitHub Enterprise GraphQL requests to `/api/graphql` when the REST API base URL ends in `/api/v3`.
 - Reject durable cluster saves with empty member lists instead of leaving stale active memberships.
 - Preserve multiple thread embeddings for the same thread when basis or model differs.

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -273,7 +274,21 @@ func (c *Client) doJSON(ctx context.Context, method, path string, body io.Reader
 }
 
 func (c *Client) do(ctx context.Context, method, path string, body io.Reader, reporter Reporter) (*http.Response, error) {
-	resp, err := c.doOnce(ctx, method, path, body, reporter)
+	var bodyBytes []byte
+	if body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(body)
+		if err != nil {
+			return nil, fmt.Errorf("read github request body: %w", err)
+		}
+	}
+	bodyReader := func() io.Reader {
+		if body == nil {
+			return nil
+		}
+		return bytes.NewReader(bodyBytes)
+	}
+	resp, err := c.doOnce(ctx, method, path, bodyReader(), reporter)
 	if err == nil {
 		return resp, nil
 	}
@@ -289,7 +304,7 @@ func (c *Client) do(ctx context.Context, method, path string, body io.Reader, re
 		return nil, ctx.Err()
 	case <-timer.C:
 	}
-	return c.doOnce(ctx, method, path, body, reporter)
+	return c.doOnce(ctx, method, path, bodyReader(), reporter)
 }
 
 func (c *Client) doOnce(ctx context.Context, method, path string, body io.Reader, reporter Reporter) (*http.Response, error) {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -320,6 +320,39 @@ func TestListPullReviewThreadsUsesEnterpriseGraphQLEndpoint(t *testing.T) {
 	}
 }
 
+func TestListPullReviewThreadsRetriesWithBody(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body graphqlEnvelope
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode graphql request %d: %v", atomic.LoadInt32(&calls)+1, err)
+		}
+		if body.Query == "" || body.Variables["owner"] != "openclaw" || body.Variables["repo"] != "gitcrawl" {
+			t.Fatalf("graphql request body = %+v", body)
+		}
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.Header().Set("Retry-After", "1")
+			http.Error(w, "slow down", http.StatusTooManyRequests)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"repository": map[string]any{"pullRequest": map[string]any{
+			"reviewThreads": map[string]any{
+				"nodes":    []map[string]any{},
+				"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+			},
+		}}}})
+	}))
+	defer server.Close()
+
+	client := New(Options{BaseURL: server.URL, PageDelay: -1})
+	if _, err := client.ListPullReviewThreads(context.Background(), "openclaw", "gitcrawl", 8, nil); err != nil {
+		t.Fatalf("list review threads: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("calls = %d, want 2", got)
+	}
+}
+
 func TestListPullReviewThreadsPaginatesReviewThreadComments(t *testing.T) {
 	var calls int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- buffer GitHub request bodies once before a rate-limit retry
- create a fresh body reader for the initial request and the retry request
- add GraphQL POST retry coverage that asserts both attempts carry the JSON payload

## Verification
- go test ./internal/github -run 'TestListPullReviewThreadsRetriesWithBody|TestRateLimitRetriesOn403WithRemainingZero|TestRateLimitRetriesOn429WithRetryAfter|TestListPullReviewThreadsDecodesGraphQLEnvelope' -count=1
- env GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
- Clawpatch revalidate: fixed fnd_sig-feat-service-a799a4509d-959d_f2ea9294a8
- codex-review: clean
