### PR TITLE
fix: set TUI detail viewport content in Update, not View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.4.1 - 2026-05-18
 
+- Make the TUI detail pane scrollable again with the keyboard, mouse wheel,
+  and trackpad; its viewport content was only set on the render copy, so the
+  live pane never had anything to scroll.
 - Add cached release checks with `gitcrawl check-update` and passive terminal
   notices when a newer OpenClaw release is available.
 

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -344,6 +344,8 @@ func (m clusterBrowserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.autoRefreshCmd()
 		}
 		m.autoRefreshFromStore()
+		m.keepVisible()
+		m.syncComponents()
 		return m, m.autoRefreshCmd()
 	case tuiWheelScrollMsg:
 		if msg.seq != m.wheelScrollSeq {
@@ -379,6 +381,8 @@ func (m clusterBrowserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			m.refreshFromStore()
+			m.keepVisible()
+			m.syncComponents()
 			m.status = "Remote data refreshed"
 			return m, nil
 		}
@@ -734,19 +738,31 @@ func (m clusterBrowserModel) renderMembers(rect tuiRect) string {
 	return paneStyle(focusMembers, m.focus, rect.w, rect.h).Render(lipgloss.JoinVertical(lipgloss.Left, paneTitle(focusMembers, m.focus, m.memberPositionLabel()), tableView))
 }
 
-func (m clusterBrowserModel) renderDetail(rect tuiRect) string {
+// detailPaneText builds the full text shown in the detail pane for the given
+// content width. It is the single source of truth for both the per-frame
+// render (renderDetail) and the persistent viewport content set in
+// syncComponents, so scrolling and display never diverge.
+func (m clusterBrowserModel) detailPaneText(width int) string {
 	mode := "full"
 	if m.compactDetail {
 		mode = "compact"
 	}
-	lines := append([]string{paneTitle(focusDetail, m.focus, mode)}, m.detailLines(rect.w-4)...)
+	lines := append([]string{paneTitle(focusDetail, m.focus, mode)}, m.detailLines(width)...)
 	if m.showHelp {
-		lines = append([]string{paneTitle(focusDetail, m.focus, mode)}, m.helpLines(rect.w-4)...)
+		lines = append([]string{paneTitle(focusDetail, m.focus, mode)}, m.helpLines(width)...)
 	}
 	if m.menuOpen && !m.menuFloating {
-		lines = append([]string{paneTitle(focusDetail, m.focus, mode)}, m.menuLines(rect.w-4)...)
+		lines = append([]string{paneTitle(focusDetail, m.focus, mode)}, m.menuLines(width)...)
 	}
-	m.detailView.SetContent(strings.Join(lines, "\n"))
+	return strings.Join(lines, "\n")
+}
+
+func (m clusterBrowserModel) renderDetail(rect tuiRect) string {
+	// renderDetail runs from View() on a value copy, so the SetContent here
+	// only ever affects this frame's copy. The persistent viewport content is
+	// set in syncComponents (Update path); without that, the live model's
+	// viewport stays empty and keyboard/wheel scrolling has nothing to move.
+	m.detailView.SetContent(m.detailPaneText(rect.w - 4))
 	return paneStyle(focusDetail, m.focus, rect.w, rect.h).Render(m.detailView.View())
 }
 
@@ -2706,6 +2722,11 @@ func (m *clusterBrowserModel) syncComponents() {
 	m.detailView.Height = detailH
 	m.detailView.MouseWheelEnabled = true
 	m.detailView.MouseWheelDelta = 3
+	// Set content on the persistent viewport (this runs from Update, which
+	// keeps the model) so the line count is real and keyboard/wheel scrolling
+	// has something to move. renderDetail repeats this on the View() copy for
+	// per-frame display freshness.
+	m.detailView.SetContent(m.detailPaneText(detailW))
 	m.searchInput.Width = maxInt(20, m.width-16)
 }
 

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -147,6 +147,7 @@ type clusterBrowserModel struct {
 	wheelDelta       int
 	wheelSeq         int
 	detailView       viewport.Model
+	detailContentKey string
 	searchInput      textinput.Model
 	detailCache      map[string]store.ClusterDetail
 	neighborCache    map[int64][]tuiNeighbor
@@ -396,18 +397,25 @@ func (m clusterBrowserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		m.cancelQueuedWheelScroll()
 		if m.menuOpen {
-			return m.updateMenu(msg)
+			var cmd tea.Cmd
+			next, cmd := m.updateMenu(msg)
+			m = next.(clusterBrowserModel)
+			m.keepVisible()
+			m.syncComponents()
+			return m, cmd
 		}
 		if m.searching {
 			var cmd tea.Cmd
 			m, cmd = m.handleSearchKey(msg)
 			m.keepVisible()
+			m.syncComponents()
 			return m, cmd
 		}
 		if m.jumping {
 			var cmd tea.Cmd
 			m, cmd = m.handleJumpKey(msg)
 			m.keepVisible()
+			m.syncComponents()
 			return m, cmd
 		}
 		switch msg.String() {
@@ -476,9 +484,13 @@ func (m clusterBrowserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.toggleClosedVisibility()
 		case "/":
 			cmd := m.startFilterInput()
+			m.keepVisible()
+			m.syncComponents()
 			return m, cmd
 		case "#":
 			cmd := m.startJumpInput()
+			m.keepVisible()
+			m.syncComponents()
 			return m, cmd
 		case "esc":
 			if m.showHelp {
@@ -2726,8 +2738,37 @@ func (m *clusterBrowserModel) syncComponents() {
 	// keeps the model) so the line count is real and keyboard/wheel scrolling
 	// has something to move. renderDetail repeats this on the View() copy for
 	// per-frame display freshness.
+	contentKey := m.detailPaneContentKey()
+	if contentKey != m.detailContentKey {
+		m.detailView.GotoTop()
+		m.detailContentKey = contentKey
+	}
 	m.detailView.SetContent(m.detailPaneText(detailW))
+	if m.detailView.PastBottom() {
+		m.detailView.GotoBottom()
+	}
 	m.searchInput.Width = maxInt(20, m.width-16)
+}
+
+func (m clusterBrowserModel) detailPaneContentKey() string {
+	if m.showHelp {
+		return "help"
+	}
+	if m.menuOpen && !m.menuFloating {
+		return "menu:" + m.menuTitle
+	}
+	mode := "full"
+	if m.compactDetail {
+		mode = "compact"
+	}
+	if member, ok := m.selectedMember(); ok {
+		return fmt.Sprintf("detail:%s:%d", mode, member.Thread.ID)
+	}
+	if len(m.payload.Clusters) > 0 && m.selected >= 0 && m.selected < len(m.payload.Clusters) {
+		cluster := m.payload.Clusters[m.selected]
+		return fmt.Sprintf("detail:%s:cluster:%d:%s", mode, cluster.ID, cluster.Source)
+	}
+	return "detail:" + mode
 }
 
 func renderStyledTable(columns []table.Column, rows []table.Row, offset, height, width int, headerColor string, styleForRow func(index int) lipgloss.Style) string {

--- a/internal/cli/tui_test.go
+++ b/internal/cli/tui_test.go
@@ -4017,3 +4017,56 @@ func seedTUIClusterPair(ctx context.Context, st *store.Store, repoID, clusterID 
 	}
 	return firstID, secondID, nil
 }
+
+// TestTUIDetailViewportScrollsWithKeyboard guards the regression where the
+// detail pane could not be scrolled by any input. detailView.SetContent was
+// only called from renderDetail (a View() value-receiver copy), so the
+// persistent viewport never had content and LineUp/LineDown/wheel were no-ops.
+func TestTUIDetailViewportScrollsWithKeyboard(t *testing.T) {
+	model := newClusterBrowserModel(context.Background(), nil, 0, clusterBrowserPayload{
+		Repository: "openclaw/openclaw",
+		Sort:       "recent",
+		Clusters: []store.ClusterSummary{
+			{ID: 1, Status: "active", MemberCount: 1, UpdatedAt: "2026-04-27T00:00:00Z"},
+		},
+	})
+	model.detail = store.ClusterDetail{
+		Cluster: model.payload.Clusters[0],
+		Members: []store.ClusterMemberDetail{
+			{Thread: store.Thread{
+				ID: 10, Number: 10, Kind: "issue", State: "open",
+				Title: strings.Repeat("a long detail title that wraps many times ", 40),
+			}},
+		},
+	}
+	model.hasDetail = true
+	model.sortMembers()
+
+	// Small terminal so detail content overflows its viewport, then focus the
+	// detail pane (clusters -> members -> detail).
+	var updated tea.Model = model
+	for _, msg := range []tea.Msg{
+		tea.WindowSizeMsg{Width: 120, Height: 16},
+		tea.KeyMsg{Type: tea.KeyTab},
+		tea.KeyMsg{Type: tea.KeyTab},
+	} {
+		next, _ := updated.Update(msg)
+		updated = next
+	}
+	model = updated.(clusterBrowserModel)
+
+	if model.focus != focusDetail {
+		t.Fatalf("focus = %q, want detail", model.focus)
+	}
+	if model.detailView.TotalLineCount() <= model.detailView.Height {
+		t.Fatalf("detail content does not overflow viewport (persistent SetContent missing): lines=%d height=%d",
+			model.detailView.TotalLineCount(), model.detailView.Height)
+	}
+
+	before := model.detailView.YOffset
+	next, _ := model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	model = next.(clusterBrowserModel)
+	if model.detailView.YOffset <= before {
+		t.Fatalf("detail pane did not scroll on KeyDown: YOffset %d -> %d", before, model.detailView.YOffset)
+	}
+}

--- a/internal/cli/tui_test.go
+++ b/internal/cli/tui_test.go
@@ -4033,10 +4033,13 @@ func TestTUIDetailViewportScrollsWithKeyboard(t *testing.T) {
 	model.detail = store.ClusterDetail{
 		Cluster: model.payload.Clusters[0],
 		Members: []store.ClusterMemberDetail{
-			{Thread: store.Thread{
-				ID: 10, Number: 10, Kind: "issue", State: "open",
-				Title: strings.Repeat("a long detail title that wraps many times ", 40),
-			}},
+			{
+				Thread: store.Thread{
+					ID: 10, Number: 10, Kind: "issue", State: "open",
+					Title: strings.Repeat("a long detail title that wraps many times ", 40),
+				},
+				BodySnippet: strings.Repeat("body line\n", 60),
+			},
 		},
 	}
 	model.hasDetail = true
@@ -4068,5 +4071,201 @@ func TestTUIDetailViewportScrollsWithKeyboard(t *testing.T) {
 	model = next.(clusterBrowserModel)
 	if model.detailView.YOffset <= before {
 		t.Fatalf("detail pane did not scroll on KeyDown: YOffset %d -> %d", before, model.detailView.YOffset)
+	}
+}
+
+func TestTUISyncComponentsClampsDetailViewportAfterResize(t *testing.T) {
+	model := newClusterBrowserModel(context.Background(), nil, 0, clusterBrowserPayload{
+		Repository: "openclaw/openclaw",
+		Sort:       "recent",
+		Clusters: []store.ClusterSummary{
+			{ID: 1, Status: "active", MemberCount: 1, UpdatedAt: "2026-04-27T00:00:00Z"},
+		},
+	})
+	model.detail = store.ClusterDetail{
+		Cluster: model.payload.Clusters[0],
+		Members: []store.ClusterMemberDetail{
+			{
+				Thread: store.Thread{
+					ID: 10, Number: 10, Kind: "issue", State: "open",
+					Title: strings.Repeat("a long detail title that wraps many times ", 40),
+				},
+				BodySnippet: strings.Repeat("body line\n", 60),
+			},
+		},
+	}
+	model.hasDetail = true
+	model.sortMembers()
+	model.width = 120
+	model.height = 16
+	model.syncComponents()
+	model.detailView.GotoBottom()
+	if model.detailView.YOffset == 0 {
+		t.Fatalf("test setup did not produce overflowing detail content: lines=%d height=%d",
+			model.detailView.TotalLineCount(), model.detailView.Height)
+	}
+
+	model.height = 80
+	model.syncComponents()
+
+	if model.detailView.PastBottom() {
+		t.Fatalf("detail viewport offset remains past bottom after resize: offset=%d lines=%d height=%d",
+			model.detailView.YOffset, model.detailView.TotalLineCount(), model.detailView.Height)
+	}
+}
+
+func TestTUISyncComponentsResetsDetailViewportWhenContentModeChanges(t *testing.T) {
+	model := newClusterBrowserModel(context.Background(), nil, 0, clusterBrowserPayload{
+		Repository: "openclaw/openclaw",
+		Sort:       "recent",
+		Clusters: []store.ClusterSummary{
+			{ID: 1, Status: "active", MemberCount: 1, UpdatedAt: "2026-04-27T00:00:00Z"},
+		},
+	})
+	model.detail = store.ClusterDetail{
+		Cluster: model.payload.Clusters[0],
+		Members: []store.ClusterMemberDetail{
+			{
+				Thread: store.Thread{
+					ID: 10, Number: 10, Kind: "issue", State: "open",
+					Title: strings.Repeat("a long detail title that wraps many times ", 40),
+				},
+				BodySnippet: strings.Repeat("body line\n", 60),
+			},
+		},
+	}
+	model.hasDetail = true
+	model.sortMembers()
+	model.width = 120
+	model.height = 16
+	model.syncComponents()
+	model.detailView.GotoBottom()
+	if model.detailView.YOffset == 0 {
+		t.Fatalf("test setup did not produce overflowing detail content: lines=%d height=%d",
+			model.detailView.TotalLineCount(), model.detailView.Height)
+	}
+
+	model.showHelp = true
+	model.syncComponents()
+	if model.detailView.YOffset != 0 {
+		t.Fatalf("help content reused detail scroll offset: got %d, want 0", model.detailView.YOffset)
+	}
+
+	model.detailView.GotoBottom()
+	model.showHelp = false
+	model.syncComponents()
+	if model.detailView.YOffset != 0 {
+		t.Fatalf("detail content reused help scroll offset: got %d, want 0", model.detailView.YOffset)
+	}
+}
+
+func TestTUIUpdateSyncsDetailViewportAfterMenuKey(t *testing.T) {
+	model := newClusterBrowserModel(context.Background(), nil, 0, clusterBrowserPayload{
+		Repository: "openclaw/openclaw",
+		Sort:       "recent",
+		Clusters: []store.ClusterSummary{
+			{ID: 1, Status: "active", MemberCount: 1, UpdatedAt: "2026-04-27T00:00:00Z"},
+		},
+	})
+	model.detail = store.ClusterDetail{
+		Cluster: model.payload.Clusters[0],
+		Members: []store.ClusterMemberDetail{
+			{
+				Thread: store.Thread{
+					ID: 10, Number: 10, Kind: "issue", State: "open",
+					Title: strings.Repeat("a long detail title that wraps many times ", 40),
+				},
+				BodySnippet: strings.Repeat("body line\n", 60),
+			},
+		},
+	}
+	model.hasDetail = true
+	model.sortMembers()
+	model.width = 120
+	model.height = 16
+	model.syncComponents()
+	model.detailView.GotoBottom()
+	if model.detailView.YOffset == 0 {
+		t.Fatalf("test setup did not produce overflowing detail content: lines=%d height=%d",
+			model.detailView.TotalLineCount(), model.detailView.Height)
+	}
+
+	model.menuOpen = true
+	next, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	model = next.(clusterBrowserModel)
+
+	if !model.showHelp {
+		t.Fatal("menu help key did not enable help")
+	}
+	if model.detailContentKey != "help" {
+		t.Fatalf("detail content key = %q, want help", model.detailContentKey)
+	}
+	if model.detailView.YOffset != 0 {
+		t.Fatalf("menu key reused stale detail scroll offset: got %d, want 0", model.detailView.YOffset)
+	}
+}
+
+func TestTUIUpdateSyncsDetailViewportAfterSearchJumpShortcuts(t *testing.T) {
+	newModel := func() clusterBrowserModel {
+		model := newClusterBrowserModel(context.Background(), nil, 0, clusterBrowserPayload{
+			Repository: "openclaw/openclaw",
+			Sort:       "recent",
+			Clusters: []store.ClusterSummary{
+				{ID: 1, Status: "active", MemberCount: 1, UpdatedAt: "2026-04-27T00:00:00Z"},
+			},
+		})
+		model.detail = store.ClusterDetail{
+			Cluster: model.payload.Clusters[0],
+			Members: []store.ClusterMemberDetail{
+				{
+					Thread: store.Thread{
+						ID: 10, Number: 10, Kind: "issue", State: "open",
+						Title: strings.Repeat("a long detail title that wraps many times ", 40),
+					},
+					BodySnippet: strings.Repeat("body line\n", 60),
+				},
+			},
+		}
+		model.hasDetail = true
+		model.sortMembers()
+		model.width = 120
+		model.height = 8
+		model.showHelp = true
+		model.syncComponents()
+		model.detailView.GotoBottom()
+		if model.detailView.YOffset == 0 {
+			t.Fatalf("test setup did not produce overflowing help content: lines=%d height=%d",
+				model.detailView.TotalLineCount(), model.detailView.Height)
+		}
+		return model
+	}
+
+	for _, tc := range []struct {
+		name        string
+		key         rune
+		wantSearch  bool
+		wantJumping bool
+	}{
+		{name: "search", key: '/', wantSearch: true},
+		{name: "jump", key: '#', wantJumping: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			model := newModel()
+			next, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{tc.key}})
+			model = next.(clusterBrowserModel)
+
+			if model.searching != tc.wantSearch || model.jumping != tc.wantJumping {
+				t.Fatalf("mode after %q: searching=%v jumping=%v", string(tc.key), model.searching, model.jumping)
+			}
+			if model.showHelp {
+				t.Fatalf("%q shortcut left help visible", string(tc.key))
+			}
+			if model.detailContentKey == "help" {
+				t.Fatalf("%q shortcut left stale help content key", string(tc.key))
+			}
+			if model.detailView.YOffset != 0 {
+				t.Fatalf("%q shortcut reused stale help scroll offset: got %d, want 0", string(tc.key), model.detailView.YOffset)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Problem

The TUI detail pane (third column) cannot be scrolled by **any** input —
keyboard up/down, pgup/pgdn, mouse wheel, or trackpad. The text is
visible but scrolling never moves it. Confirmed across keyboard and
trackpad; verified the keyboard `move()` path reaches
`detailView.LineDown` yet the viewport offset never changes.

## Root cause

`detailView.SetContent(...)` is called in exactly one place:
`renderDetail()`. `renderDetail()` is reached only from `View()`, which
has a **value receiver** — it runs on a per-frame copy of the model. So
`SetContent` only ever mutates that throwaway copy; the persistent
model's `detailView` never receives content. A bubbles `viewport.Model`
with empty content has a zero scroll range, so `LineUp`/`LineDown`/
`GotoBottom`/wheel (which run in `Update` against the persistent model)
are all no-ops. The text you see is painted from the copy each frame,
but the scroll state has nowhere to live.

## Fix

- Extract the pane text into a shared `detailPaneText(width)` helper —
  one source of truth for both paths.
- Set content on the **persistent** viewport from `syncComponents()`
  (which runs in the `Update` path and is kept), so the line count is
  real and scrolling has something to move.
- `renderDetail()` still sets it on the per-frame copy, so the rendered
  output is byte-identical to before (no display regression) — the
  change is purely additive for scroll state.
- Also call `syncComponents()` after the auto-refresh and
  remote-refresh branches, which previously skipped it, so the viewport
  tracks size and content after background reloads too.

## Test

`TestTUIDetailViewportScrollsWithKeyboard` focuses the detail pane in a
small terminal and asserts `KeyDown` increases `detailView.YOffset`. It
**fails on the prior behavior** (`lines=0` — persistent viewport empty)
and passes with the fix. Full `internal/cli` package and `go vet ./...`
pass; `gofmt` clean.

Found alongside #50 (member-selection reset); kept as a separate PR
since this is a render-architecture change vs. that state fix.
