### PR TITLE
fix: retry transient sqlite cache locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.4.2 - Unreleased
 
 - Update `crawlkit` to v0.7.0.
+- Retry transient SQLite busy/locked cache writes during sync and keep gh-shim auto-hydration quiet so live fallback reads do not surface scary local cache lock noise.
 
 ## 0.4.1 - 2026-05-18
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -2162,6 +2162,7 @@ type syncOptions struct {
 	Numbers          []int
 	IncludeComments  bool
 	IncludePRDetails bool
+	Quiet            bool
 }
 
 func parseSyncWith(value string) (map[string]bool, error) {
@@ -2201,6 +2202,14 @@ func (a *App) syncRepository(ctx context.Context, owner, repo string, options sy
 
 	client := gh.New(gh.Options{Token: token.Value, BaseURL: githubBaseURL(), RateLimit: a.observeGitHubRateLimit(ctx, token.Value)})
 	service := syncer.New(client, rt.Store)
+	var reporter gh.Reporter
+	var logger *slog.Logger
+	if !options.Quiet {
+		reporter = func(message string) {
+			fmt.Fprintln(a.Stderr, message)
+		}
+		logger = progressLogger(a.Stderr)
+	}
 	stats, err := service.Sync(ctx, syncer.Options{
 		Owner:            owner,
 		Repo:             repo,
@@ -2210,10 +2219,8 @@ func (a *App) syncRepository(ctx context.Context, owner, repo string, options sy
 		Numbers:          options.Numbers,
 		IncludeComments:  options.IncludeComments,
 		IncludePRDetails: options.IncludePRDetails,
-		Reporter: func(message string) {
-			fmt.Fprintln(a.Stderr, message)
-		},
-		Logger: progressLogger(a.Stderr),
+		Reporter:         reporter,
+		Logger:           logger,
 	})
 	if err != nil {
 		return syncer.Stats{}, err

--- a/internal/cli/gh_shim.go
+++ b/internal/cli/gh_shim.go
@@ -188,6 +188,7 @@ func (a *App) runGHThreadView(ctx context.Context, resource string, args []strin
 			if _, syncErr := a.syncRepository(ctx, owner, repoName, syncOptions{
 				Numbers:          []int{number},
 				IncludePRDetails: resource == "pr",
+				Quiet:            true,
 			}); syncErr != nil {
 				return localGHUnsupported(syncErr)
 			}

--- a/internal/cli/gh_shim_autohydrate.go
+++ b/internal/cli/gh_shim_autohydrate.go
@@ -34,6 +34,7 @@ func (a *App) loadGHPullRequestCache(ctx context.Context, repoValue string, numb
 	if _, syncErr := a.syncRepository(ctx, owner, repoName, syncOptions{
 		Numbers:          []int{number},
 		IncludePRDetails: true,
+		Quiet:            true,
 	}); syncErr != nil {
 		return store.PullRequestCache{}, localGHUnsupported(syncErr)
 	}

--- a/internal/cli/gh_shim_pr_status.go
+++ b/internal/cli/gh_shim_pr_status.go
@@ -215,6 +215,7 @@ func (a *App) hydrateGHPRStatus(ctx context.Context, repoValue string, number in
 		Numbers:          []int{number},
 		IncludeComments:  true,
 		IncludePRDetails: true,
+		Quiet:            true,
 	}); err != nil {
 		return localGHUnsupported(err)
 	}

--- a/internal/cli/gh_shim_test.go
+++ b/internal/cli/gh_shim_test.go
@@ -200,9 +200,14 @@ func TestGHShimPRStatusAutoHydratesIncompleteCacheAndCountsBodylessApproval(t *t
 
 	run := New()
 	var stdout bytes.Buffer
+	var stderr bytes.Buffer
 	run.Stdout = &stdout
+	run.Stderr = &stderr
 	if err := run.Run(ctx, []string{"--config", configPath, "gh", "pr", "status", "12", "-R", "openclaw/openclaw", "--compact"}); err != nil {
 		t.Fatalf("status should be ready after auto-hydrate: %v\n%s", err, stdout.String())
+	}
+	if strings.Contains(stderr.String(), "sync progress") || strings.Contains(stderr.String(), "database is locked") {
+		t.Fatalf("auto-hydrate wrote noisy stderr: %q", stderr.String())
 	}
 	var row map[string]any
 	if err := json.Unmarshal(stdout.Bytes(), &row); err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3,7 +3,9 @@ package store
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	crawlstore "github.com/openclaw/crawlkit/store"
@@ -14,6 +16,18 @@ const (
 	schemaVersion = 2
 	timeLayout    = time.RFC3339Nano
 )
+
+var sqliteBusyRetryDelays = []time.Duration{
+	50 * time.Millisecond,
+	100 * time.Millisecond,
+	200 * time.Millisecond,
+	400 * time.Millisecond,
+	800 * time.Millisecond,
+}
+
+type sqliteCoder interface {
+	Code() int
+}
 
 type Store struct {
 	db      *sql.DB
@@ -101,6 +115,12 @@ func (s *Store) qsql() *storedb.Queries {
 }
 
 func (s *Store) WithTx(ctx context.Context, fn func(*Store) error) error {
+	return withSQLiteBusyRetry(ctx, sqliteBusyRetryDelays, func() error {
+		return s.withTxOnce(ctx, fn)
+	})
+}
+
+func (s *Store) withTxOnce(ctx context.Context, fn func(*Store) error) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin transaction: %w", err)
@@ -114,6 +134,48 @@ func (s *Store) WithTx(ctx context.Context, fn func(*Store) error) error {
 		return fmt.Errorf("commit transaction: %w", err)
 	}
 	return nil
+}
+
+func withSQLiteBusyRetry(ctx context.Context, delays []time.Duration, fn func() error) error {
+	attempts := len(delays) + 1
+	var lastErr error
+	for attempt := 0; attempt < attempts; attempt++ {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !IsTransientSQLiteBusy(err) || attempt == len(delays) {
+			break
+		}
+		timer := time.NewTimer(delays[attempt])
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+	if IsTransientSQLiteBusy(lastErr) {
+		return fmt.Errorf("sqlite busy after %d attempts: %w", attempts, lastErr)
+	}
+	return lastErr
+}
+
+func IsTransientSQLiteBusy(err error) bool {
+	if err == nil {
+		return false
+	}
+	for current := err; current != nil; current = errors.Unwrap(current) {
+		if coder, ok := current.(sqliteCoder); ok {
+			code := coder.Code() & 0xff
+			return code == 5 || code == 6
+		}
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "sqlite_busy") ||
+		strings.Contains(message, "database is locked") ||
+		strings.Contains(message, "database table is locked")
 }
 
 func (s *Store) Status(ctx context.Context) (Status, error) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -4,12 +4,73 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
+
+type fakeSQLiteCodeError int
+
+func (e fakeSQLiteCodeError) Error() string {
+	return fmt.Sprintf("sqlite code %d", e)
+}
+
+func (e fakeSQLiteCodeError) Code() int {
+	return int(e)
+}
+
+func TestSQLiteBusyRetryRecovers(t *testing.T) {
+	ctx := context.Background()
+	attempts := 0
+	err := withSQLiteBusyRetry(ctx, []time.Duration{0, 0}, func() error {
+		attempts++
+		if attempts < 3 {
+			return fmt.Errorf("upsert thread: %w", fakeSQLiteCodeError(5))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("retry should recover: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3", attempts)
+	}
+}
+
+func TestSQLiteBusyRetryExhausts(t *testing.T) {
+	ctx := context.Background()
+	attempts := 0
+	err := withSQLiteBusyRetry(ctx, []time.Duration{0, 0}, func() error {
+		attempts++
+		return fmt.Errorf("commit transaction: %w", fakeSQLiteCodeError(6))
+	})
+	if err == nil || !strings.Contains(err.Error(), "sqlite busy after 3 attempts") {
+		t.Fatalf("expected exhausted busy error, got %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3", attempts)
+	}
+}
+
+func TestSQLiteBusyRetryDoesNotRetryOtherErrors(t *testing.T) {
+	ctx := context.Background()
+	attempts := 0
+	want := errors.New("database disk image is malformed")
+	err := withSQLiteBusyRetry(ctx, []time.Duration{0, 0}, func() error {
+		attempts++
+		return want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("error = %v, want %v", err, want)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+}
 
 func TestOpenMigratesSchema(t *testing.T) {
 	ctx := context.Background()

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -72,6 +72,21 @@ type Stats struct {
 	FinishedAt          string `json:"finished_at"`
 }
 
+type syncPersistStats struct {
+	ThreadsSynced       int
+	IssuesSynced        int
+	PullRequestsSynced  int
+	CommentsSynced      int
+	ReviewThreadsSynced int
+	PRDetailsSynced     int
+	PRFilesSynced       int
+	PRCommitsSynced     int
+	PRChecksSynced      int
+	WorkflowRunsSynced  int
+	ThreadsClosed       int
+	FinishedAt          string
+}
+
 type threadSyncPayload struct {
 	row                    map[string]any
 	commentRows            []commentRow
@@ -181,7 +196,9 @@ func (s *Syncer) Sync(ctx context.Context, options Options) (Stats, error) {
 			"state", state,
 		},
 	})
+	var persisted syncPersistStats
 	persist := func(st *store.Store) error {
+		attempt := syncPersistStats{}
 		repoID, err := st.UpsertRepository(ctx, store.Repository{
 			Owner:        options.Owner,
 			Name:         options.Repo,
@@ -206,7 +223,7 @@ func (s *Syncer) Sync(ctx context.Context, options Options) (Stats, error) {
 				if err != nil {
 					return err
 				}
-				stats.CommentsSynced += len(comments)
+				attempt.CommentsSynced += len(comments)
 			} else {
 				var err error
 				comments, err = st.ListComments(ctx, thread.ID)
@@ -219,27 +236,27 @@ func (s *Syncer) Sync(ctx context.Context, options Options) (Stats, error) {
 				if err != nil {
 					return err
 				}
-				stats.ReviewThreadsSynced += count
+				attempt.ReviewThreadsSynced += count
 				if payload.hasPullDetails {
 					detailStats, err := s.persistPullRequestDetails(ctx, st, thread, payload.pullDetails)
 					if err != nil {
 						return err
 					}
-					stats.PRDetailsSynced++
-					stats.PRFilesSynced += detailStats.files
-					stats.PRCommitsSynced += detailStats.commits
-					stats.PRChecksSynced += detailStats.checks
-					stats.WorkflowRunsSynced += detailStats.runs
+					attempt.PRDetailsSynced++
+					attempt.PRFilesSynced += detailStats.files
+					attempt.PRCommitsSynced += detailStats.commits
+					attempt.PRChecksSynced += detailStats.checks
+					attempt.WorkflowRunsSynced += detailStats.runs
 				}
 			}
 			if _, err := st.UpsertDocument(ctx, documents.BuildWithComments(thread, comments)); err != nil {
 				return err
 			}
-			stats.ThreadsSynced++
+			attempt.ThreadsSynced++
 			if thread.Kind == "pull_request" {
-				stats.PullRequestsSynced++
+				attempt.PullRequestsSynced++
 			} else {
-				stats.IssuesSynced++
+				attempt.IssuesSynced++
 			}
 			tracker.Add(1,
 				"number", thread.Number,
@@ -252,28 +269,47 @@ func (s *Syncer) Sync(ctx context.Context, options Options) (Stats, error) {
 			if err != nil {
 				return err
 			}
-			stats.ThreadsClosed = closed
+			attempt.ThreadsClosed = closed
 		}
-		stats.FinishedAt = s.now().Format(time.RFC3339Nano)
+		attempt.FinishedAt = s.now().Format(time.RFC3339Nano)
+		runStats := stats
+		applySyncPersistStats(&runStats, attempt)
 		if _, err := st.RecordRun(ctx, store.RunRecord{
 			RepoID:     repoID,
 			Kind:       "sync",
 			Scope:      syncRunScope(state, numbers),
 			Status:     "success",
-			StartedAt:  stats.StartedAt,
-			FinishedAt: stats.FinishedAt,
-			StatsJSON:  mustJSON(stats),
+			StartedAt:  runStats.StartedAt,
+			FinishedAt: runStats.FinishedAt,
+			StatsJSON:  mustJSON(runStats),
 		}); err != nil {
 			return err
 		}
+		persisted = attempt
 		return nil
 	}
 	if err := s.store.WithTx(ctx, persist); err != nil {
 		tracker.Finish(err)
 		return Stats{}, err
 	}
+	applySyncPersistStats(&stats, persisted)
 	tracker.Finish(nil)
 	return stats, nil
+}
+
+func applySyncPersistStats(stats *Stats, persisted syncPersistStats) {
+	stats.ThreadsSynced = persisted.ThreadsSynced
+	stats.IssuesSynced = persisted.IssuesSynced
+	stats.PullRequestsSynced = persisted.PullRequestsSynced
+	stats.CommentsSynced = persisted.CommentsSynced
+	stats.ReviewThreadsSynced = persisted.ReviewThreadsSynced
+	stats.PRDetailsSynced = persisted.PRDetailsSynced
+	stats.PRFilesSynced = persisted.PRFilesSynced
+	stats.PRCommitsSynced = persisted.PRCommitsSynced
+	stats.PRChecksSynced = persisted.PRChecksSynced
+	stats.WorkflowRunsSynced = persisted.WorkflowRunsSynced
+	stats.ThreadsClosed = persisted.ThreadsClosed
+	stats.FinishedAt = persisted.FinishedAt
 }
 
 func uniquePositiveNumbers(numbers []int) []int {


### PR DESCRIPTION
## Summary

- Retry transient SQLite busy/locked transaction failures at the store transaction boundary.
- Keep gh-shim auto-hydration quiet so cache-write lock contention falls through to live gh without scary local cache failure noise.
- Preserve sync stats across transaction retries and add focused retry/quiet-hydrate tests.

## Proof

- `GOWORK=off go test ./internal/store -run 'TestSQLiteBusyRetry|TestOpenMigratesSchema'`
- `GOWORK=off go test ./internal/cli -run 'TestGHShimPRStatusAutoHydratesIncompleteCacheAndCountsBodylessApproval|TestGHShimPRStatusDisabledAutoHydrateDoesNotRefreshIncompleteCache'`
- `GOWORK=off go test ./internal/syncer -run 'TestSync'`
- `GOWORK=off go test ./...`
- `GOWORK=off go build -o /tmp/gitcrawl-sqlite-busy ./cmd/gitcrawl`
- parallel smoke from `/Users/steipete/Projects/clawdbot3`: 12 concurrent `gh pr checks 81443 -R openclaw/openclaw --json name,state,link` reads, all exit 0; stderr grep found no `database is locked`, `SQLITE_BUSY`, `upsert thread`, or failed sync-progress lines.

## Before / After

Before: observed parallel status reads could print `upsert thread: database is locked (5) (SQLITE_BUSY)` even when live GitHub check data was available.

After: parallel patched smoke returned live check JSON and no SQLite lock noise on stderr.

## Autoreview

- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- Result: clean, no accepted/actionable findings.
