### PR TITLE
Add clusters report command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ gitcrawl sync owner/repo --numbers https://github.com/owner/repo/issues/123 --wi
 gitcrawl refresh owner/repo
 gitcrawl cluster owner/repo --threshold 0.80
 gitcrawl clusters owner/repo
+gitcrawl clusters-report owner/repo --limit 10 --min-size 5
 gitcrawl durable-clusters owner/repo
 gitcrawl cluster-detail owner/repo --id 123
 gitcrawl cluster-explain owner/repo --id 123
@@ -56,6 +57,7 @@ gitcrawl tui owner/repo
 
 `gitcrawl clusters` and `gitcrawl tui` match ghcrawl's display view: latest raw run clusters first, closed durable rows merged as historical context, sorted by size by default. Pass `--hide-closed` to focus only currently open clusters. `gitcrawl durable-clusters` stays on governed durable rows and needs `--include-closed` for inactive rows.
 `gitcrawl metadata --json`, `gitcrawl status --json`, and `gitcrawl doctor --json` are crawlkit control surfaces for launchers, local automation, and CI checks. They are read-only and do not mutate archive data.
+`gitcrawl clusters-report` writes a Markdown report for the top clusters using the same display view, with an at-a-glance table, per-cluster metadata, member tables, and key snippets. Use `--json` for the hydrated report payload.
 `gitcrawl cluster` and `gitcrawl refresh` build ghcrawl-shaped durable clusters by default (`--threshold 0.80`, `--min-size 1`, `--max-cluster-size 40`, `--k 16`, `--cross-kind-threshold 0.93`): every active vector-backed thread is represented, singleton rows use `singleton_orphan`, multi-member rows use `duplicate_candidate`, and stable IDs are derived from the representative thread. They also add deterministic GitHub reference evidence for direct issue/PR links such as `#123`, `issues/123`, and `pull/123`. Weak embedding edges need concrete title-token overlap unless their similarity is already high, which keeps generic low-confidence bridges from forming unrelated clusters.
 `gitcrawl tui` infers the most recently updated local repository when `owner/repo` is omitted. `serve` is intentionally not part of `gitcrawl`.
 `gitcrawl sync` fetches open issues and pull requests by default. Pass `--state all` or `--state closed` for explicit backfill workflows; incremental open syncs with `--since` also sweep recently closed items so local open state does not rot.

--- a/SPEC.md
+++ b/SPEC.md
@@ -71,6 +71,7 @@ Public commands:
 - `threads`
 - `runs`
 - `clusters`
+- `clusters-report`
 - `durable-clusters`
 - `cluster-detail`
 - `cluster-explain`

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -174,6 +174,8 @@ func (a *App) Run(ctx context.Context, args []string) error {
 		return a.runEmbed(ctx, rest[1:])
 	case "clusters":
 		return a.runClusters(ctx, rest[1:])
+	case "clusters-report":
+		return a.runClustersReport(ctx, rest[1:])
 	case "durable-clusters":
 		return a.runDurableClusters(ctx, rest[1:])
 	case "cluster-detail":
@@ -1273,6 +1275,25 @@ func (a *App) runDurableClusters(ctx context.Context, args []string) error {
 	return a.runClusterList(ctx, "durable-clusters", args, true)
 }
 
+type clustersReport struct {
+	Repository  string                `json:"repository"`
+	GeneratedAt string                `json:"generated_at"`
+	Sort        string                `json:"sort"`
+	MinSize     int                   `json:"min_size"`
+	Limit       int                   `json:"limit"`
+	MemberLimit int                   `json:"member_limit"`
+	HideClosed  bool                  `json:"hide_closed,omitempty"`
+	Clusters    []store.ClusterDetail `json:"clusters"`
+	Totals      clustersReportTotals  `json:"totals"`
+}
+
+type clustersReportTotals struct {
+	ClusterCount int `json:"cluster_count"`
+	MemberCount  int `json:"member_count"`
+	OpenCount    int `json:"open_count"`
+	ClosedCount  int `json:"closed_count"`
+}
+
 func clusterListIncludesClosed(durable bool, includeClosed bool, hideClosed bool) bool {
 	if hideClosed {
 		return false
@@ -1345,6 +1366,276 @@ func (a *App) runClusterList(ctx context.Context, command string, args []string,
 		"repository": repo.FullName,
 		"clusters":   clusters,
 	}, true)
+}
+
+func (a *App) runClustersReport(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("clusters-report", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	minSizeRaw := fs.String("min-size", "5", "minimum active member count")
+	limitRaw := fs.String("limit", "10", "maximum cluster rows")
+	memberLimitRaw := fs.String("member-limit", "8", "maximum member rows per cluster")
+	bodyCharsRaw := fs.String("body-chars", "240", "maximum body snippet characters")
+	sortMode := fs.String("sort", "size", "sort mode: size|recent|oldest")
+	includeClosed := fs.Bool("include-closed", false, "deprecated; clusters include closed rows by default")
+	hideClosed := fs.Bool("hide-closed", false, "hide locally closed clusters")
+	jsonOut := fs.Bool("json", false, "write JSON output")
+	if err := fs.Parse(normalizeCommandArgs(args, map[string]bool{"min-size": true, "limit": true, "member-limit": true, "body-chars": true, "sort": true})); err != nil {
+		return usageErr(err)
+	}
+	a.applyCommandJSON(*jsonOut)
+	if fs.NArg() != 1 {
+		return usageErr(fmt.Errorf("clusters-report requires owner/repo"))
+	}
+	owner, repoName, err := parseOwnerRepo(fs.Arg(0))
+	if err != nil {
+		return usageErr(err)
+	}
+	minSize, err := parseOptionalPositiveInt(*minSizeRaw)
+	if err != nil {
+		return usageErr(err)
+	}
+	limit, err := parseOptionalPositiveInt(*limitRaw)
+	if err != nil {
+		return usageErr(err)
+	}
+	memberLimit, err := parseOptionalPositiveInt(*memberLimitRaw)
+	if err != nil {
+		return usageErr(err)
+	}
+	bodyChars, err := parseOptionalPositiveInt(*bodyCharsRaw)
+	if err != nil {
+		return usageErr(err)
+	}
+	sort := strings.TrimSpace(*sortMode)
+	if sort != "recent" && sort != "oldest" && sort != "size" {
+		return usageErr(fmt.Errorf("unsupported sort %q", sort))
+	}
+
+	rt, err := a.openLocalRuntimeReadOnly(ctx)
+	if err != nil {
+		return err
+	}
+	defer rt.Store.Close()
+	repo, err := rt.repository(ctx, owner, repoName)
+	if err != nil {
+		return err
+	}
+	summaries, err := rt.Store.ListDisplayClusterSummaries(ctx, store.ClusterSummaryOptions{
+		RepoID:        repo.ID,
+		IncludeClosed: clusterListIncludesClosed(false, *includeClosed, *hideClosed),
+		MinSize:       minSize,
+		Limit:         limit,
+		Sort:          sort,
+	})
+	if err != nil {
+		return err
+	}
+	report := clustersReport{
+		Repository:  repo.FullName,
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		Sort:        sort,
+		MinSize:     minSize,
+		Limit:       limit,
+		MemberLimit: memberLimit,
+		HideClosed:  *hideClosed,
+		Clusters:    make([]store.ClusterDetail, 0, len(summaries)),
+	}
+	for _, summary := range summaries {
+		detail, err := rt.Store.ClusterDetail(ctx, store.ClusterDetailOptions{
+			RepoID:        repo.ID,
+			ClusterID:     summary.ID,
+			Source:        summary.Source,
+			IncludeClosed: clusterListIncludesClosed(false, *includeClosed, *hideClosed),
+			MemberLimit:   memberLimit,
+			BodyChars:     bodyChars,
+		})
+		if err != nil {
+			return err
+		}
+		report.Clusters = append(report.Clusters, detail)
+		report.Totals.MemberCount += detail.Cluster.MemberCount
+		if detail.Cluster.Status == "closed" || detail.Cluster.ClosedAt != "" {
+			report.Totals.ClosedCount++
+		} else {
+			report.Totals.OpenCount++
+		}
+	}
+	report.Totals.ClusterCount = len(report.Clusters)
+	return a.writeClustersReport(report)
+}
+
+func (a *App) writeClustersReport(report clustersReport) error {
+	if a.format == FormatJSON {
+		return a.writeOutput("clusters-report", report, true)
+	}
+	_, err := fmt.Fprint(a.Stdout, renderClustersReportMarkdown(report))
+	return err
+}
+
+func renderClustersReportMarkdown(report clustersReport) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Cluster Report: %s\n\n", report.Repository)
+	fmt.Fprintf(&b, "Generated: %s UTC\n", report.GeneratedAt)
+	fmt.Fprintf(&b, "View: top %d clusters, min size %d, sorted by %s", report.Limit, report.MinSize, report.Sort)
+	if report.HideClosed {
+		b.WriteString(", closed hidden")
+	}
+	b.WriteString("\n\n")
+	fmt.Fprintf(&b, "**Totals:** %d clusters, %d total members, %d open, %d closed.\n\n", report.Totals.ClusterCount, report.Totals.MemberCount, report.Totals.OpenCount, report.Totals.ClosedCount)
+	if len(report.Clusters) == 0 {
+		b.WriteString("No clusters matched the selected filters.\n")
+		return b.String()
+	}
+	b.WriteString("## At a Glance\n\n")
+	b.WriteString("| Rank | Cluster | Members | Status | Representative | Updated |\n")
+	b.WriteString("| ---: | --- | ---: | --- | --- | --- |\n")
+	for index, detail := range report.Clusters {
+		cluster := detail.Cluster
+		fmt.Fprintf(&b, "| %d | `%s` | %d | %s | %s | %s |\n",
+			index+1,
+			markdownTableText(firstNonEmpty(cluster.StableSlug, fmt.Sprintf("cluster-%d", cluster.ID))),
+			cluster.MemberCount,
+			markdownTableText(firstNonEmpty(cluster.Status, "unknown")),
+			markdownTableText(clusterRepresentativeMarkdown(cluster)),
+			markdownTableText(shortTime(cluster.UpdatedAt)),
+		)
+	}
+	for index, detail := range report.Clusters {
+		cluster := detail.Cluster
+		title := firstNonEmpty(cluster.RepresentativeTitle, cluster.Title, "Untitled cluster")
+		fmt.Fprintf(&b, "\n## %d. %s\n\n", index+1, markdownHeadingText(title))
+		fmt.Fprintf(&b, "- Cluster: `%s` (`%d`)\n", firstNonEmpty(cluster.StableSlug, fmt.Sprintf("cluster-%d", cluster.ID)), cluster.ID)
+		fmt.Fprintf(&b, "- Status: %s\n", firstNonEmpty(cluster.Status, "unknown"))
+		fmt.Fprintf(&b, "- Members: %d total, %d shown\n", cluster.MemberCount, len(detail.Members))
+		fmt.Fprintf(&b, "- Representative: %s\n", clusterRepresentativeMarkdown(cluster))
+		if cluster.UpdatedAt != "" {
+			fmt.Fprintf(&b, "- Last updated: %s\n", shortTime(cluster.UpdatedAt))
+		}
+		if cluster.ClosedAt != "" {
+			fmt.Fprintf(&b, "- Closed locally: %s\n", shortTime(cluster.ClosedAt))
+		}
+		b.WriteString("\n")
+		renderClusterMemberTable(&b, detail.Members)
+		renderClusterSnippetList(&b, detail.Members)
+	}
+	return b.String()
+}
+
+func renderClusterMemberTable(b *strings.Builder, members []store.ClusterMemberDetail) {
+	if len(members) == 0 {
+		b.WriteString("No visible members.\n")
+		return
+	}
+	b.WriteString("| Type | Number | State | Score | Title | Labels |\n")
+	b.WriteString("| --- | ---: | --- | ---: | --- | --- |\n")
+	for _, member := range members {
+		thread := member.Thread
+		score := ""
+		if member.ScoreToRepresentative != nil {
+			score = fmt.Sprintf("%.3f", *member.ScoreToRepresentative)
+		}
+		fmt.Fprintf(b, "| %s | %s | %s | %s | %s | %s |\n",
+			markdownTableText(kindTitle(thread.Kind)),
+			markdownTableText(threadMarkdownLink(thread)),
+			markdownTableText(firstNonEmpty(thread.State, member.State, "unknown")),
+			markdownTableText(score),
+			markdownTableText(thread.Title),
+			markdownTableText(strings.Join(cliLabelNames(thread.LabelsJSON), ", ")),
+		)
+	}
+}
+
+func renderClusterSnippetList(b *strings.Builder, members []store.ClusterMemberDetail) {
+	wroteHeading := false
+	count := 0
+	for _, member := range members {
+		snippet := strings.TrimSpace(member.BodySnippet)
+		if snippet == "" {
+			continue
+		}
+		if !wroteHeading {
+			b.WriteString("\nKey snippets:\n\n")
+			wroteHeading = true
+		}
+		fmt.Fprintf(b, "- %s: %s\n", threadMarkdownLink(member.Thread), markdownInlineText(snippet))
+		count++
+		if count >= 3 {
+			break
+		}
+	}
+}
+
+func clusterRepresentativeMarkdown(cluster store.ClusterSummary) string {
+	if cluster.RepresentativeNumber <= 0 {
+		return "unknown"
+	}
+	return fmt.Sprintf("%s #%d", kindTitle(cluster.RepresentativeKind), cluster.RepresentativeNumber)
+}
+
+func threadMarkdownLink(thread store.Thread) string {
+	label := fmt.Sprintf("#%d", thread.Number)
+	if strings.TrimSpace(thread.HTMLURL) == "" {
+		return label
+	}
+	return fmt.Sprintf("[%s](%s)", label, strings.TrimSpace(thread.HTMLURL))
+}
+
+func markdownHeadingText(value string) string {
+	value = strings.ReplaceAll(strings.TrimSpace(value), "\n", " ")
+	value = strings.ReplaceAll(value, "#", "\\#")
+	return value
+}
+
+func markdownInlineText(value string) string {
+	return strings.Join(strings.Fields(value), " ")
+}
+
+func markdownTableText(value string) string {
+	value = markdownInlineText(value)
+	value = strings.ReplaceAll(value, "|", "\\|")
+	return value
+}
+
+func shortTime(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "unknown"
+	}
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return t.Format("2006-01-02")
+	}
+	if len(value) >= len("2006-01-02") {
+		return value[:len("2006-01-02")]
+	}
+	return value
+}
+
+func cliLabelNames(raw string) []string {
+	var labels []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(raw), &labels); err == nil {
+		out := make([]string, 0, len(labels))
+		for _, label := range labels {
+			if name := strings.TrimSpace(label.Name); name != "" {
+				out = append(out, name)
+			}
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	var names []string
+	if err := json.Unmarshal([]byte(raw), &names); err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		if name = strings.TrimSpace(name); name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
 }
 
 func (a *App) runTUI(ctx context.Context, args []string) error {
@@ -3619,6 +3910,7 @@ Core commands:
   set-cluster-canonical
                        set the canonical row for a durable cluster
   clusters             list latest run cluster summaries, with durable fallback
+  clusters-report      write a Markdown report for the top clusters
   durable-clusters     list durable cluster groups
   cluster-detail       dump one latest run cluster, with durable fallback
   cluster-explain      alias for cluster-detail
@@ -3697,6 +3989,11 @@ Usage:
 
 Usage:
   gitcrawl clusters owner/repo [--sort size|recent|oldest] [--min-size N] [--limit N] [--hide-closed] [--json]
+`,
+	"clusters-report": `gitcrawl clusters-report writes a Markdown report for top display clusters.
+
+Usage:
+  gitcrawl clusters-report owner/repo [--sort size|recent|oldest] [--min-size N] [--limit N] [--member-limit N] [--body-chars N] [--hide-closed] [--json]
 `,
 	"durable-clusters": `gitcrawl durable-clusters lists governed durable cluster groups.
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -165,7 +165,7 @@ func TestMetadataStatusAndControlStatusJSON(t *testing.T) {
 	if !strings.Contains(helpOut.String(), "cluster browser") {
 		t.Fatalf("tui help output = %q", helpOut.String())
 	}
-	for _, topic := range []string{"metadata", "status", "init", "configure", "doctor", "sync", "refresh", "embed", "threads", "search", "cluster", "clusters", "durable-clusters", "cluster-detail", "cluster-explain", "neighbors", "runs", "close-thread", "reopen-thread", "close-cluster", "reopen-cluster", "exclude-cluster-member", "include-cluster-member", "set-cluster-canonical", "gh"} {
+	for _, topic := range []string{"metadata", "status", "init", "configure", "doctor", "sync", "refresh", "embed", "threads", "search", "cluster", "clusters", "clusters-report", "durable-clusters", "cluster-detail", "cluster-explain", "neighbors", "runs", "close-thread", "reopen-thread", "close-cluster", "reopen-cluster", "exclude-cluster-member", "include-cluster-member", "set-cluster-canonical", "gh"} {
 		helpOut.Reset()
 		if err := help.printCommandUsage(topic); err != nil {
 			t.Fatalf("%s help: %v", topic, err)
@@ -1337,6 +1337,9 @@ func TestAppOutputModesAndUsageBranches(t *testing.T) {
 		{"embed", "openclaw/openclaw", "--number", "bad"},
 		{"clusters", "--unknown"},
 		{"clusters", "openclaw/openclaw", "--sort", "bogus"},
+		{"clusters-report", "--unknown"},
+		{"clusters-report", "openclaw/openclaw", "--sort", "bogus"},
+		{"clusters-report", "openclaw/openclaw", "--limit", "bad"},
 		{"tui", "--unknown"},
 		{"tui", "openclaw/openclaw", "extra"},
 		{"tui", "openclaw/openclaw", "--min-size", "bad"},
@@ -1394,6 +1397,7 @@ func TestAppOutputModesAndUsageBranches(t *testing.T) {
 		{"neighbors", "openclaw/openclaw", "--number", "1"},
 		{"cluster", "openclaw/openclaw"},
 		{"clusters", "openclaw/openclaw"},
+		{"clusters-report", "openclaw/openclaw"},
 		{"cluster-detail", "openclaw/openclaw", "--id", "1"},
 		{"runs", "openclaw/openclaw"},
 		{"threads", "openclaw/openclaw"},
@@ -1950,6 +1954,26 @@ func TestCommandFlowCoversSearchEmbedNeighborsClusterDetailRunsAndRefresh(t *tes
 		t.Fatalf("clusters output = %q", stdout.String())
 	}
 
+	report := New()
+	stdout.Reset()
+	report.Stdout = &stdout
+	if err := report.Run(ctx, []string{"--config", configPath, "clusters-report", "openclaw/openclaw", "--sort", "oldest", "--min-size", "1", "--limit", "3", "--member-limit", "5"}); err != nil {
+		t.Fatalf("clusters-report: %v", err)
+	}
+	if out := stdout.String(); !strings.Contains(out, "# Cluster Report: openclaw/openclaw") || !strings.Contains(out, "sorted by oldest") || !strings.Contains(out, "total members") || !strings.Contains(out, "## At a Glance") || !strings.Contains(out, "Gateway websocket stalls") {
+		t.Fatalf("clusters-report output = %q", out)
+	}
+
+	reportJSON := New()
+	stdout.Reset()
+	reportJSON.Stdout = &stdout
+	if err := reportJSON.Run(ctx, []string{"--config", configPath, "clusters-report", "openclaw/openclaw", "--sort", "size", "--min-size", "1", "--limit", "3", "--member-limit", "5", "--json"}); err != nil {
+		t.Fatalf("clusters-report json: %v", err)
+	}
+	if out := stdout.String(); !strings.Contains(out, `"repository": "openclaw/openclaw"`) || !strings.Contains(out, `"clusters"`) {
+		t.Fatalf("clusters-report json output = %q", out)
+	}
+
 	durable := New()
 	stdout.Reset()
 	durable.Stdout = &stdout
@@ -2007,6 +2031,118 @@ func TestCommandFlowCoversSearchEmbedNeighborsClusterDetailRunsAndRefresh(t *tes
 	}
 	if len(threads) != 2 {
 		t.Fatalf("threads by ids = %+v", threads)
+	}
+}
+
+func TestClustersReportUsesDisplaySummarySourceForCollidingIDs(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	dbPath := filepath.Join(dir, "gitcrawl.db")
+	if err := New().Run(ctx, []string{"--config", configPath, "init", "--db", dbPath}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	st, err := store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	repoID, err := st.UpsertRepository(ctx, store.Repository{
+		Owner:     "openclaw",
+		Name:      "openclaw",
+		FullName:  "openclaw/openclaw",
+		RawJSON:   "{}",
+		UpdatedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("seed repository: %v", err)
+	}
+	rawID, err := st.UpsertThread(ctx, store.Thread{
+		RepoID: repoID, GitHubID: "101", Number: 101, Kind: "issue", State: "open",
+		Title: "Raw live cluster", Body: "raw cluster body",
+		HTMLURL:       "https://github.com/openclaw/openclaw/issues/101",
+		LabelsJSON:    "[]",
+		AssigneesJSON: "[]",
+		RawJSON:       "{}",
+		ContentHash:   "raw",
+		UpdatedAt:     now,
+	})
+	if err != nil {
+		t.Fatalf("seed raw thread: %v", err)
+	}
+	durableID, err := st.UpsertThread(ctx, store.Thread{
+		RepoID: repoID, GitHubID: "201", Number: 201, Kind: "issue", State: "closed",
+		Title: "Durable historical cluster", Body: "durable cluster body",
+		HTMLURL:       "https://github.com/openclaw/openclaw/issues/201",
+		LabelsJSON:    "[]",
+		AssigneesJSON: "[]",
+		RawJSON:       "{}",
+		ContentHash:   "durable",
+		UpdatedAt:     now,
+	})
+	if err != nil {
+		t.Fatalf("seed durable thread: %v", err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `
+		insert into cluster_runs(id, repo_id, scope, status, started_at, finished_at, stats_json)
+		values(9, ?, 'repo', 'completed', '2026-05-01T00:00:00Z', '2026-05-01T00:01:00Z', '{}')
+	`, repoID); err != nil {
+		t.Fatalf("seed raw cluster run: %v", err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `
+		insert into clusters(id, repo_id, cluster_run_id, representative_thread_id, member_count, created_at)
+		values(77, ?, 9, ?, 1, '2026-05-01T00:01:00Z')
+	`, repoID, rawID); err != nil {
+		t.Fatalf("seed raw cluster: %v", err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `
+		insert into cluster_members(cluster_id, thread_id, score_to_representative, created_at)
+		values(77, ?, 1.0, '2026-05-01T00:01:00Z')
+	`, rawID); err != nil {
+		t.Fatalf("seed raw cluster member: %v", err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `
+		insert into cluster_groups(id, repo_id, stable_key, stable_slug, status, representative_thread_id, title, created_at, updated_at, closed_at)
+		values(77, ?, 'closed-durable', 'closed-durable', 'closed', ?, 'Durable historical cluster', '2026-04-01T00:00:00Z', '2026-04-02T00:00:00Z', '2026-04-02T00:00:00Z')
+	`, repoID, durableID); err != nil {
+		t.Fatalf("seed durable cluster: %v", err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `
+		insert into cluster_closures(cluster_id, reason, actor_kind, created_at, updated_at)
+		values(77, 'handled', 'local', '2026-04-02T00:00:00Z', '2026-04-02T00:00:00Z')
+	`); err != nil {
+		t.Fatalf("seed durable closure: %v", err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `
+		insert into cluster_memberships(cluster_id, thread_id, role, state, added_by, added_reason_json, created_at, updated_at)
+		values(77, ?, 'representative', 'active', 'system', '{}', '2026-04-01T00:00:00Z', '2026-04-01T00:00:00Z')
+	`, durableID); err != nil {
+		t.Fatalf("seed durable member: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	run := New()
+	var stdout bytes.Buffer
+	run.Stdout = &stdout
+	if err := run.Run(ctx, []string{"--config", configPath, "clusters-report", "openclaw/openclaw", "--sort", "size", "--min-size", "1", "--limit", "2", "--member-limit", "5", "--json"}); err != nil {
+		t.Fatalf("clusters-report: %v", err)
+	}
+	var payload struct {
+		Clusters []store.ClusterDetail `json:"clusters"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, stdout.String())
+	}
+	if len(payload.Clusters) != 2 {
+		t.Fatalf("report clusters = %#v", payload.Clusters)
+	}
+	if payload.Clusters[0].Cluster.Source != store.ClusterSourceRun || payload.Clusters[0].Members[0].Thread.Number != 101 {
+		t.Fatalf("raw report detail used wrong source: %#v", payload.Clusters[0])
+	}
+	if payload.Clusters[1].Cluster.Source != store.ClusterSourceDurable || payload.Clusters[1].Members[0].Thread.Number != 201 {
+		t.Fatalf("durable report detail used wrong source: %#v", payload.Clusters[1])
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `gitcrawl clusters-report` to render top clusters as a Markdown report
- include JSON output for the hydrated report payload
- document the command and add CLI coverage

Proof/Example:
`./gitcrawl clusters-report openclaw/openclaw --limit 3 --min-size 5`

->

```
# Cluster Report: openclaw/openclaw

Generated: 2026-05-25T21:28:35Z UTC
View: top 3 clusters, min size 5, sorted by size

**Totals:** 3 clusters, 119 listed members, 3 open, 0 closed.

## At a Glance

| Rank | Cluster | Members | Status | Representative | Updated |
| ---: | --- | ---: | --- | --- | --- |
| 1 | `search-output-border-f43e` | 40 | active | PR #76920 | 2026-05-25 |
| 2 | `driver-prime-sketch-zjw7` | 40 | active | PR #78342 | 2026-05-25 |
| 3 | `result-maple-margin-1r1o` | 39 | active | PR #81700 | 2026-05-25 |

## 1. fix(telegram): preserve forum topic routing

- Cluster: `search-output-border-f43e` (`1`)
- Status: active
- Members: 40 total, 8 shown
- Representative: PR #76920
- Last updated: 2026-05-25

| Type | Number | State | Score | Title | Labels |
| --- | ---: | --- | ---: | --- | --- |
| PR | [#76920](https://github.com/openclaw/openclaw/pull/76920) | open | 1.000 | fix(telegram): preserve forum topic routing | channel: matrix, channel: telegram, gateway, scripts, size: L, proof: supplied, mantis: telegram-visible-proof |
| PR | [#43808](https://github.com/openclaw/openclaw/pull/43808) | open | 0.940 | cron: honor delivery.threadId for Telegram announce delivery | app: web-ui, gateway, size: M |
| PR | [#49704](https://github.com/openclaw/openclaw/pull/49704) | open | 0.940 | fix(cron): announce delivery for Telegram forum topics | docs, channel: telegram, size: S |
| Issue | [#52286](https://github.com/openclaw/openclaw/issues/52286) | open | 0.940 | [Bug] message tool sends files to DM instead of staying in Telegram topic | bug, bug:behavior |
| PR | [#52824](https://github.com/openclaw/openclaw/pull/52824) | open | 0.940 | fix(announce): preserve threadId in subagent announce for Telegram DM topics | channel: telegram, agents, size: S |
| Issue | [#73900](https://github.com/openclaw/openclaw/issues/73900) | open | 0.940 | [Bug]: main/systemEvent cron heartbeat inherits global heartbeat.to and leaks topic reminder to DM |  |
| PR | [#73583](https://github.com/openclaw/openclaw/pull/73583) | open | 0.834 | Fix Telegram status and group reply delivery | channel: telegram, size: L |
| PR | [#85403](https://github.com/openclaw/openclaw/pull/85403) | open | 0.834 | fix(telegram): suppress message-tool reply previews | channel: telegram, size: L, proof: supplied, proof: sufficient, mantis: telegram-visible-proof, P1, rating: 🐚 platinum hermit, merge-risk: 🚨 compatibility, status: 👀 ready for maintainer look, proof: 📸 screenshot |

Key snippets:

- [#76920](https://github.com/openclaw/openclaw/pull/76920): ## Summary - Keep Telegram thread-not-found fallback for General topic (`message_thread_id=1`), while failing closed for explicit non-General forum topic sends and direct/private topic sends. - Preserve Telegram topic routing for automatic
- [#43808](https://github.com/openclaw/openclaw/pull/43808): ## Summary - Problem: isolated cron announce delivery accepted `delivery.threadId` in job config, but the cron delivery plan/target plumbing never carried that field into outbound delivery. - Why it matters: Telegram forum-topic cron jobs
- [#49704](https://github.com/openclaw/openclaw/pull/49704): ## Problem Cron jobs with `delivery.mode = "announce"` silently fail to deliver to Telegram forum topics. The `deliveryStatus` shows `"not-delivered"` with no surfaced error, even with valid targets like `telegram:-GROUP/TOPIC` or `telegram

## 2. fix: scope agent admin gateway calls

- Cluster: `driver-prime-sketch-zjw7` (`2`)
- Status: active
- Members: 40 total, 8 shown
- Representative: PR #78342
- Last updated: 2026-05-25

| Type | Number | State | Score | Title | Labels |
| --- | ---: | --- | ---: | --- | --- |
| PR | [#78342](https://github.com/openclaw/openclaw/pull/78342) | open | 1.000 | fix: scope agent admin gateway calls | docs, gateway, commands, size: S, triage: refactor-only, triage: blank-template, triage: needs-real-behavior-proof |
| PR | [#80125](https://github.com/openclaw/openclaw/pull/80125) | open | 0.959 | Fix/core bug audit | size: S, triage: refactor-only, triage: blank-template, triage: needs-real-behavior-proof |
| PR | [#85467](https://github.com/openclaw/openclaw/pull/85467) | open | 0.946 | fix(embedded-runner): wrap agent.processEvents in session write lock | agents, size: XS, triage: refactor-only, triage: blank-template, triage: needs-real-behavior-proof, P1, rating: 🧂 unranked krab, merge-risk: 🚨 session-state, merge-risk: 🚨 availability, status: 📣 needs proof |
| PR | [#80997](https://github.com/openclaw/openclaw/pull/80997) | open | 0.943 | Chore/gog autoheal workflow docs | scripts, size: S, triage: refactor-only, triage: blank-template, triage: needs-real-behavior-proof |
| PR | [#83940](https://github.com/openclaw/openclaw/pull/83940) | open | 0.943 | Feat/cron consecutive skips tracking | docs, cli, agents, size: M, triage: refactor-only, triage: blank-template, triage: needs-real-behavior-proof, dependencies-changed, rating: 🌊 off-meta tidepool |
| PR | [#84962](https://github.com/openclaw/openclaw/pull/84962) | open | 0.940 | Railway/fix control UI origin | docs, docker, size: XS, triage: refactor-only, triage: blank-template, triage: needs-real-behavior-proof, P2, rating: 🧂 unranked krab, merge-risk: 🚨 automation, merge-risk: 🚨 compatibility, merge-risk: 🚨 security-boundary, status: 📣 needs proof |
| PR | [#83689](https://github.com/openclaw/openclaw/pull/83689) | open | 0.939 | fix(pi-embedded-runner): handle concatenated tool-call argument JSON | agents, size: S, triage: refactor-only, triage: blank-template, triage: needs-real-behavior-proof, P2, rating: 🧂 unranked krab, merge-risk: 🚨 compatibility, status: 📣 needs proof |
| PR | [#72449](https://github.com/openclaw/openclaw/pull/72449) | open | 0.936 | Fix/cron parse undefined | cli, size: S, triage: refactor-only, triage: blank-template, triage: needs-real-behavior-proof, P2, rating: 🧂 unranked krab, merge-risk: 🚨 compatibility, merge-risk: 🚨 availability, status: 📣 needs proof |

Key snippets:

- [#78342](https://github.com/openclaw/openclaw/pull/78342): ## Summary Describe the problem and fix in 2–5 bullets: If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labele
- [#80125](https://github.com/openclaw/openclaw/pull/80125): ## Summary Describe the problem and fix in 2–5 bullets: If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labele
- [#85467](https://github.com/openclaw/openclaw/pull/85467): installSessionEventWriteLock previously targeted session._processAgentEvent, which was removed in pi-coding-agent v0.75.4. Events now flow through Agent.processEvents (pi-agent-core) -> _handleAgentEvent listener -> appendMessage -> appendF

## 3. fix(auth): drop stale Codex OAuth routing

- Cluster: `result-maple-margin-1r1o` (`3`)
- Status: active
- Members: 39 total, 8 shown
- Representative: PR #81700
- Last updated: 2026-05-25

| Type | Number | State | Score | Title | Labels |
| --- | ---: | --- | ---: | --- | --- |
| PR | [#81700](https://github.com/openclaw/openclaw/pull/81700) | open | 1.000 | fix(auth): drop stale Codex OAuth routing | commands, agents, maintainer, size: L, extensions: codex, P2, impact:session-state, impact:auth-provider, rating: 🧂 unranked krab, merge-risk: 🚨 compatibility, merge-risk: 🚨 auth-provider, merge-risk: 🚨 session-state |
| Issue | [#83223](https://github.com/openclaw/openclaw/issues/83223) | open | 0.940 | v2026.5.16-beta.5 audit: migrated openai/gpt-5.5 route still looks up openai-codex auth before fallback | P2, clawsweeper:no-new-fix-pr, clawsweeper:needs-maintainer-review, clawsweeper:needs-product-decision, clawsweeper:needs-live-repro, impact:session-state, impact:auth-provider |
| PR | [#83451](https://github.com/openclaw/openclaw/pull/83451) | open | 0.940 | fix(auth): preserve Codex sidecar Keychain recovery | commands, agents, maintainer, size: M, P2, impact:security, impact:auth-provider, rating: 🧂 unranked krab, merge-risk: 🚨 compatibility, merge-risk: 🚨 auth-provider, merge-risk: 🚨 security-boundary |
| PR | [#75030](https://github.com/openclaw/openclaw/pull/75030) | open | 0.832 | fix(auth): explain masked oauth profiles | agents, size: S, proof: supplied, proof: sufficient, P2, rating: 🐚 platinum hermit, merge-risk: 🚨 compatibility, merge-risk: 🚨 auth-provider, status: 👀 ready for maintainer look |
| PR | [#83383](https://github.com/openclaw/openclaw/pull/83383) | open | 0.829 | fix(auth): clean refresh contention diagnostics | agents, maintainer, size: M, P2, rating: 🐚 platinum hermit, status: 👀 ready for maintainer look |
| PR | [#85413](https://github.com/openclaw/openclaw/pull/85413) | open | 0.823 | Fix OpenAI compaction runtime routing | gateway, agents, size: L, extensions: codex, triage: mock-only-proof, P2, rating: 🧂 unranked krab, merge-risk: 🚨 auth-provider, status: 📣 needs proof |
| PR | [#86476](https://github.com/openclaw/openclaw/pull/86476) | open | 0.804 | Keep Codex turn timeouts inside Codex | agents, maintainer, size: S, extensions: codex, P1, rating: 🦪 silver shellfish, merge-risk: 🚨 compatibility, merge-risk: 🚨 auth-provider, merge-risk: 🚨 availability, status: 📣 needs proof |
| Issue | [#8673](https://github.com/openclaw/openclaw/issues/8673) | open |  | Add retry logic to OAuth token refresh | enhancement, P2, clawsweeper:no-new-fix-pr, clawsweeper:needs-maintainer-review, clawsweeper:needs-product-decision, clawsweeper:source-repro, impact:auth-provider, issue-rating: 🦞 diamond lobster |

Key snippets:

- [#81700](https://github.com/openclaw/openclaw/pull/81700): ## Summary - expand Codex OAuth refresh-failure classification to match current refresh-token reuse, expiry, invalidation, revocation, and account-mismatch messages - keep stale persisted/session-selected Codex auth profiles and stale `aut
- [#83223](https://github.com/openclaw/openclaw/issues/83223): ## Scope One macOS LaunchAgent-backed OpenClaw instance was updated from `2026.5.12` to the latest beta available from upstream tags at audit time: `v2026.5.16-beta.5`. This report is sanitized. The host is referred to as Host S. Private
- [#83451](https://github.com/openclaw/openclaw/pull/83451): ## Summary - preserve the read-only macOS Keychain fallback for legacy Codex `oauthRef` sidecar decryption - keep `openclaw doctor --fix` able to migrate Keychain-only legacy sidecars back to inline OAuth credentials - keep the re-auth pat
```

## Tests
- `go test ./...`