### PR TITLE
feat(remote): publish cloud SQLite archive objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## 0.4.6 - Unreleased
 
+- Update `crawlkit` to v0.10.0.
 - Add Cloudflare remote archive scaffolding with `[remote]` config, `gitcrawl init --remote`, GitHub-backed `remote login` with OAuth or token-env bootstrap, remote identity/archive/status commands, cloud-mode search against Worker named queries, and `gitcrawl cloud publish` ingestion without creating a local SQLite database for readers.
+- Mirror the local SQLite archive into the Worker-backed R2 object store during
+  `gitcrawl cloud publish`, alongside the D1 row ingest used for live queries.
 - Move the `gitcrawl gh` compatibility cache to Octopool with a hard migration error that points users at `octopool login` and `octopool gh ...`.
 - Add an optional TUI focus layout, configurable with `gitcrawl tui --layout focus`, `tui.default_layout`, or `GITCRAWL_TUI_LAYOUT`, thanks @RomneyDa.
 - Add `gitcrawl clusters-report` for Markdown or JSON cluster triage reports, thanks @RomneyDa.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/mattn/go-isatty v0.0.22
-	github.com/openclaw/crawlkit v0.8.0
+	github.com/openclaw/crawlkit v0.10.0
 	github.com/zalando/go-keyring v0.2.8
 )
 

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.8.0 h1:EZEAMy7dI6zVn+AC6lN8GycMY8bV3TF3KnheG55A0uU=
-github.com/openclaw/crawlkit v0.8.0/go.mod h1:2XkSx3N8yzyjc+Jyf1Zl9VEQVlElh/dzBMW1cRMQQGw=
+github.com/openclaw/crawlkit v0.10.0 h1:FKe5Aus+lgik76KswimTvnlwMdfiuaZV1MGign6z73k=
+github.com/openclaw/crawlkit v0.10.0/go.mod h1:2XkSx3N8yzyjc+Jyf1Zl9VEQVlElh/dzBMW1cRMQQGw=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
 github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -3,9 +3,11 @@ package cli
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -50,6 +52,231 @@ func TestInitWritesConfig(t *testing.T) {
 	}
 	if _, err := os.Stat(wantVectorDir); err != nil {
 		t.Fatalf("stat vector dir: %v", err)
+	}
+}
+
+func TestGitcrawlThreadBodyExpr(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name   string
+		schema string
+		want   string
+	}{
+		{name: "body and excerpt", schema: "create table threads(id text primary key, body text, body_excerpt text)", want: "coalesce(body, body_excerpt, '')"},
+		{name: "body only", schema: "create table threads(id text primary key, body text)", want: "coalesce(body, '')"},
+		{name: "excerpt only", schema: "create table threads(id text primary key, body_excerpt text)", want: "coalesce(body_excerpt, '')"},
+		{name: "neither", schema: "create table threads(id text primary key)", want: "''"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "threads.db"))
+			if err != nil {
+				t.Fatalf("open sqlite: %v", err)
+			}
+			defer db.Close()
+			if _, err := db.ExecContext(ctx, tc.schema); err != nil {
+				t.Fatalf("create schema: %v", err)
+			}
+			got, err := gitcrawlThreadBodyExpr(ctx, db)
+			if err != nil {
+				t.Fatalf("body expr: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("body expr = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCloudSQLiteSnapshotFallbacks(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "closed.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close sqlite: %v", err)
+	}
+	fallback := filepath.Join(t.TempDir(), "fallback.db")
+	got, cleanup, err := sqliteSnapshotPath(ctx, db, fallback)
+	if err != nil {
+		t.Fatalf("snapshot fallback: %v", err)
+	}
+	defer cleanup()
+	if got != fallback {
+		t.Fatalf("snapshot fallback path = %q, want %q", got, fallback)
+	}
+	if _, cleanup, err := sqliteSnapshotPath(ctx, db, ""); err == nil {
+		cleanup()
+		t.Fatal("snapshot without fallback unexpectedly succeeded")
+	}
+}
+
+func TestCloudSQLiteSnapshotVacuum(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "source.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.ExecContext(ctx, "create table repositories(id text primary key)"); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, "insert into repositories(id) values('r1')"); err != nil {
+		t.Fatalf("seed schema: %v", err)
+	}
+	snapshot, cleanup, err := sqliteSnapshotPath(ctx, db, "")
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	defer cleanup()
+	snapshotDB, err := sql.Open("sqlite", snapshot)
+	if err != nil {
+		t.Fatalf("open snapshot: %v", err)
+	}
+	defer snapshotDB.Close()
+	var count int
+	if err := snapshotDB.QueryRowContext(ctx, "select count(*) from repositories").Scan(&count); err != nil {
+		t.Fatalf("query snapshot: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("snapshot count = %d, want 1", count)
+	}
+}
+
+func TestCloudFileSHA256(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "payload.txt")
+	if err := os.WriteFile(path, []byte("abc"), 0o600); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+	got, err := cloudFileSHA256(path)
+	if err != nil {
+		t.Fatalf("hash payload: %v", err)
+	}
+	const want = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+	if got != want {
+		t.Fatalf("hash = %q, want %q", got, want)
+	}
+	if _, err := cloudFileSHA256(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatal("missing payload unexpectedly hashed")
+	}
+}
+
+func TestSendIngestRowsBatchesAndAcceptsEmpty(t *testing.T) {
+	ctx := context.Background()
+	var cursors []string
+	var finals []bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.EscapedPath() != "/v1/apps/gitcrawl/archives/gitcrawl%2Fopenclaw/ingest" {
+			http.NotFound(w, req)
+			return
+		}
+		var body crawlremote.IngestRequest
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		cursors = append(cursors, body.Cursor)
+		finals = append(finals, body.Final)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(crawlremote.IngestResult{Table: body.Table, RowsAccepted: int64(len(body.Rows)), Complete: body.Final})
+	}))
+	defer server.Close()
+	client, err := crawlremote.NewClient(crawlremote.Options{
+		Endpoint:      server.URL,
+		TokenProvider: crawlremote.StaticToken("token"),
+	})
+	if err != nil {
+		t.Fatalf("remote client: %v", err)
+	}
+	manifest := crawlremote.IngestManifest{App: "gitcrawl", Archive: "gitcrawl/openclaw"}
+	empty, err := sendIngestRows(ctx, client, "gitcrawl", "gitcrawl/openclaw", manifest, "repositories", gitcrawlRepositoryColumns, nil, false)
+	if err != nil {
+		t.Fatalf("empty ingest: %v", err)
+	}
+	if empty != 0 {
+		t.Fatalf("empty rows accepted = %d, want 0", empty)
+	}
+	rows := make([][]any, gitcrawlCloudBatchSize+1)
+	for i := range rows {
+		rows[i] = []any{fmt.Sprintf("r%d", i), "openclaw/repo", "openclaw", "repo", "", "", ""}
+	}
+	total, err := sendIngestRows(ctx, client, "gitcrawl", "gitcrawl/openclaw", manifest, "repositories", gitcrawlRepositoryColumns, rows, true)
+	if err != nil {
+		t.Fatalf("batched ingest: %v", err)
+	}
+	if total != int64(len(rows)) {
+		t.Fatalf("rows accepted = %d, want %d", total, len(rows))
+	}
+	if got, want := strings.Join(cursors, ","), ",,250"; got != want {
+		t.Fatalf("cursors = %q, want %q", got, want)
+	}
+	if got, want := fmt.Sprint(finals), "[false false true]"; got != want {
+		t.Fatalf("finals = %s, want %s", got, want)
+	}
+}
+
+func TestRemoteValueCoercionHelpers(t *testing.T) {
+	value := map[string]any{
+		"bool_string":  "true",
+		"bool_number":  json.Number("1"),
+		"int_string":   "42",
+		"int_number":   json.Number("43"),
+		"int64_string": "42000000000",
+		"float_string": "4.25",
+		"float_number": json.Number("5.5"),
+	}
+	if !boolValue(value, "bool_string") || !boolValue(value, "bool_number") || boolValue(value, "missing") {
+		t.Fatalf("bool coercion failed")
+	}
+	if got := intValue(value, "int_string"); got != 42 {
+		t.Fatalf("int string = %d, want 42", got)
+	}
+	if got := intValue(value, "int_number"); got != 43 {
+		t.Fatalf("int number = %d, want 43", got)
+	}
+	if got := int64Value(value, "int64_string"); got != 42000000000 {
+		t.Fatalf("int64 string = %d, want 42000000000", got)
+	}
+	if got := floatValue(value, "float_string"); got != 4.25 {
+		t.Fatalf("float string = %v, want 4.25", got)
+	}
+	if got := floatValue(value, "float_number"); got != 5.5 {
+		t.Fatalf("float number = %v, want 5.5", got)
+	}
+	ref := threadReference{Owner: "openclaw", Repo: "gitcrawl"}
+	if got := ref.FullName(); got != "openclaw/gitcrawl" {
+		t.Fatalf("full name = %q, want openclaw/gitcrawl", got)
+	}
+	if got := (threadReference{Owner: "openclaw"}).FullName(); got != "" {
+		t.Fatalf("partial full name = %q, want empty", got)
+	}
+}
+
+func TestUploadSQLiteArchiveReturnsRemoteError(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "source.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.ExecContext(ctx, "create table repositories(id text primary key)"); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		http.Error(w, "nope", http.StatusBadGateway)
+	}))
+	defer server.Close()
+	client, err := crawlremote.NewClient(crawlremote.Options{
+		Endpoint:      server.URL,
+		TokenProvider: crawlremote.StaticToken("token"),
+	})
+	if err != nil {
+		t.Fatalf("remote client: %v", err)
+	}
+	_, err = uploadSQLiteArchive(ctx, client, "gitcrawl", "gitcrawl/openclaw", db, "", crawlremote.IngestManifest{SchemaName: "gitcrawl-cloud-v1"})
+	if err == nil {
+		t.Fatal("upload unexpectedly succeeded")
 	}
 }
 
@@ -227,9 +454,34 @@ func TestCloudPublishSendsLocalRows(t *testing.T) {
 	tokenEnv := "GITCRAWL_TEST_PUBLISH_TOKEN"
 	t.Setenv(tokenEnv, "publish-token")
 	seenTables := map[string]crawlremote.IngestRequest{}
+	var sawSQLiteUpload bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("authorization"); got != "Bearer publish-token" {
 			http.Error(w, "missing bearer", http.StatusUnauthorized)
+			return
+		}
+		if r.Method == http.MethodPut && r.URL.EscapedPath() == "/v1/apps/gitcrawl/archives/gitcrawl%2Fopenclaw__openclaw/sqlite" {
+			sawSQLiteUpload = true
+			payload, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if !bytes.HasPrefix(payload, []byte("SQLite format 3")) {
+				http.Error(w, "not sqlite", http.StatusBadRequest)
+				return
+			}
+			if r.Header.Get("x-crawl-content-sha256") == "" {
+				http.Error(w, "missing hash", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("content-type", "application/json")
+			_ = json.NewEncoder(w).Encode(crawlremote.SQLiteUploadResult{
+				App:      "gitcrawl",
+				Archive:  "gitcrawl/openclaw__openclaw",
+				Complete: true,
+				Object:   &crawlremote.SQLiteObject{Key: "v1/gitcrawl/gitcrawl%2Fopenclaw__openclaw/sqlite/current.db", Size: int64(len(payload))},
+			})
 			return
 		}
 		if r.Method != http.MethodPost || r.URL.EscapedPath() != "/v1/apps/gitcrawl/archives/gitcrawl%2Fopenclaw__openclaw/ingest" {
@@ -277,12 +529,18 @@ func TestCloudPublishSendsLocalRows(t *testing.T) {
 	if !seenTables["threads"].Final {
 		t.Fatalf("threads batch should finish ingest")
 	}
+	if !sawSQLiteUpload {
+		t.Fatalf("cloud publish did not upload sqlite object")
+	}
 	var payload map[string]any
 	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
 		t.Fatalf("decode output: %v\n%s", err, out.String())
 	}
 	if payload["repositories"] != float64(1) || payload["threads"] != float64(3) {
 		t.Fatalf("unexpected output: %#v", payload)
+	}
+	if payload["sqlite_object"] == nil {
+		t.Fatalf("missing sqlite object output: %#v", payload)
 	}
 }
 

--- a/internal/cli/cloud_commands.go
+++ b/internal/cli/cloud_commands.go
@@ -2,11 +2,16 @@ package cli
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"flag"
 	"fmt"
 	"io"
+	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
+	"time"
 
 	crawlremote "github.com/openclaw/crawlkit/remote"
 	"github.com/openclaw/gitcrawl/internal/config"
@@ -67,7 +72,8 @@ func (a *App) runCloudPublish(ctx context.Context, args []string) error {
 		TokenEnv: firstNonEmpty(*tokenEnv, cfg.Remote.TokenEnv, crawlremote.DefaultTokenEnv),
 	}
 	client, err := crawlremote.NewClientFromConfig(remoteCfg, crawlremote.Options{
-		UserAgent: "gitcrawl/" + version,
+		UserAgent:  "gitcrawl/" + version,
+		HTTPClient: &http.Client{Timeout: 10 * time.Minute},
 	})
 	if err != nil {
 		return err
@@ -85,7 +91,11 @@ func (a *App) runCloudPublish(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	threadRows, err := publishRows(ctx, rt.Store.DB(), gitcrawlThreadExportSQL, func(values []any) []any { return values })
+	threadSQL, err := gitcrawlThreadExportSQL(ctx, rt.Store.DB())
+	if err != nil {
+		return err
+	}
+	threadRows, err := publishRows(ctx, rt.Store.DB(), threadSQL, func(values []any) []any { return values })
 	if err != nil {
 		return err
 	}
@@ -97,11 +107,16 @@ func (a *App) runCloudPublish(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	sqliteObject, err := uploadSQLiteArchive(ctx, client, "gitcrawl", archiveID, rt.Store.DB(), rt.SourceDBPath, manifest)
+	if err != nil {
+		return err
+	}
 	return a.writeOutput("cloud publish", map[string]any{
-		"remote":       strings.TrimRight(endpoint, "/"),
-		"archive":      archiveID,
-		"repositories": repoAccepted,
-		"threads":      threadAccepted,
+		"remote":        strings.TrimRight(endpoint, "/"),
+		"archive":       archiveID,
+		"repositories":  repoAccepted,
+		"threads":       threadAccepted,
+		"sqlite_object": sqliteObject,
 	}, true)
 }
 
@@ -175,6 +190,74 @@ func cursorFor(start int) string {
 	return fmt.Sprintf("%d", start)
 }
 
+func uploadSQLiteArchive(ctx context.Context, client *crawlremote.Client, app, archive string, db *sql.DB, dbPath string, manifest crawlremote.IngestManifest) (*crawlremote.SQLiteObject, error) {
+	snapshotPath, cleanup, err := sqliteSnapshotPath(ctx, db, dbPath)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+	file, err := os.Open(snapshotPath)
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite snapshot: %w", err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat sqlite snapshot: %w", err)
+	}
+	sum, err := cloudFileSHA256(snapshotPath)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("rewind sqlite snapshot: %w", err)
+	}
+	result, err := client.UploadSQLite(ctx, app, archive, crawlremote.SQLiteUploadRequest{
+		Body:          file,
+		Size:          info.Size(),
+		ContentSHA256: sum,
+		SchemaName:    manifest.SchemaName,
+		SchemaVersion: manifest.SchemaVersion,
+		SchemaHash:    manifest.SchemaHash,
+		SourceSyncAt:  manifest.SourceSyncAt,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.Object, nil
+}
+
+func sqliteSnapshotPath(ctx context.Context, db *sql.DB, dbPath string) (string, func(), error) {
+	tmpDir, err := os.MkdirTemp("", "gitcrawl-cloud-sqlite-*")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("create sqlite snapshot dir: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(tmpDir) }
+	snapshotPath := filepath.Join(tmpDir, "archive.db")
+	if _, err := db.ExecContext(ctx, "vacuum main into ?", snapshotPath); err == nil {
+		return snapshotPath, cleanup, nil
+	}
+	source := strings.TrimSpace(dbPath)
+	if source == "" {
+		cleanup()
+		return "", func() {}, fmt.Errorf("sqlite snapshot failed and no source db path is available")
+	}
+	return source, cleanup, nil
+}
+
+func cloudFileSHA256(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open sqlite snapshot for hash: %w", err)
+	}
+	defer file.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", fmt.Errorf("hash sqlite snapshot: %w", err)
+	}
+	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+}
+
 var gitcrawlRepositoryColumns = []string{"id", "full_name", "owner", "name", "html_url", "default_branch", "updated_at"}
 
 const gitcrawlRepositoryExportSQL = `
@@ -184,11 +267,60 @@ order by id`
 
 var gitcrawlThreadColumns = []string{"id", "repo_id", "github_id", "number", "kind", "state", "title", "body", "author_login", "author_type", "html_url", "labels_json", "assignees_json", "is_draft", "created_at_gh", "updated_at_gh", "closed_at_gh", "merged_at_gh", "updated_at"}
 
-const gitcrawlThreadExportSQL = `
-select id, repo_id, github_id, number, kind, state, title, coalesce(body, ''),
+func gitcrawlThreadExportSQL(ctx context.Context, db *sql.DB) (string, error) {
+	bodyExpr, err := gitcrawlThreadBodyExpr(ctx, db)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`
+select id, repo_id, github_id, number, kind, state, title, %s,
        coalesce(author_login, ''), coalesce(author_type, ''), html_url,
        labels_json, assignees_json, is_draft, coalesce(created_at_gh, ''),
        coalesce(updated_at_gh, ''), coalesce(closed_at_gh, ''),
        coalesce(merged_at_gh, ''), updated_at
 from threads
-order by repo_id, number`
+order by repo_id, number`, bodyExpr), nil
+}
+
+func gitcrawlThreadBodyExpr(ctx context.Context, db *sql.DB) (string, error) {
+	hasBody, err := sqliteColumnExists(ctx, db, "threads", "body")
+	if err != nil {
+		return "", err
+	}
+	hasExcerpt, err := sqliteColumnExists(ctx, db, "threads", "body_excerpt")
+	if err != nil {
+		return "", err
+	}
+	switch {
+	case hasBody && hasExcerpt:
+		return "coalesce(body, body_excerpt, '')", nil
+	case hasBody:
+		return "coalesce(body, '')", nil
+	case hasExcerpt:
+		return "coalesce(body_excerpt, '')", nil
+	default:
+		return "''", nil
+	}
+}
+
+func sqliteColumnExists(ctx context.Context, db *sql.DB, table, column string) (bool, error) {
+	rows, err := db.QueryContext(ctx, `pragma table_info(`+table+`)`)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull int
+		var defaultValue any
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}


### PR DESCRIPTION
## Summary
- update crawlkit to v0.10.0
- upload a consistent SQLite archive object during `gitcrawl cloud publish` after D1 ingest
- tolerate portable stores with `threads.body_excerpt` but no `threads.body`

## Verification
- GOWORK=off go test ./internal/cli -run 'TestCloudPublishSendsLocalRows|TestRemote|TestCloud'\n- GOWORK=off go test ./...\n- live cloud publish to `gitcrawl/openclaw__openclaw` uploaded a 89,976,832 byte SQLite object to R2