### PR TITLE
feat(cloud): upload compressed sqlite bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Add Cloudflare remote archive scaffolding with `[remote]` config, `gitcrawl init --remote`, GitHub-backed `remote login` with OAuth or token-env bootstrap, remote identity/archive/status commands, cloud-mode search against Worker named queries, and `gitcrawl cloud publish` ingestion without creating a local SQLite database for readers.
 - Mirror the local SQLite archive into the Worker-backed R2 object store during
   `gitcrawl cloud publish`, alongside the D1 row ingest used for live queries.
+- Compress the mirrored SQLite archive as a gzip chunk bundle with a manifest
+  so R2 bootstrap/fallback data is smaller and can grow past single-object
+  upload limits.
 - Move the `gitcrawl gh` compatibility cache to Octopool with a hard migration error that points users at `octopool login` and `octopool gh ...`.
 - Add an optional TUI focus layout, configurable with `gitcrawl tui --layout focus`, `tui.default_layout`, or `GITCRAWL_TUI_LAYOUT`, thanks @RomneyDa.
 - Add `gitcrawl clusters-report` for Markdown or JSON cluster triage reports, thanks @RomneyDa.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/mattn/go-isatty v0.0.22
-	github.com/openclaw/crawlkit v0.10.0
+	github.com/openclaw/crawlkit v0.11.0
 	github.com/zalando/go-keyring v0.2.8
 )
 

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.10.0 h1:FKe5Aus+lgik76KswimTvnlwMdfiuaZV1MGign6z73k=
-github.com/openclaw/crawlkit v0.10.0/go.mod h1:2XkSx3N8yzyjc+Jyf1Zl9VEQVlElh/dzBMW1cRMQQGw=
+github.com/openclaw/crawlkit v0.11.0 h1:aKK8XVunwT4WYUYp7IxcgCXdg8L2WeYIX8da5HGuNyg=
+github.com/openclaw/crawlkit v0.11.0/go.mod h1:2XkSx3N8yzyjc+Jyf1Zl9VEQVlElh/dzBMW1cRMQQGw=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
 github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -274,7 +275,7 @@ func TestUploadSQLiteArchiveReturnsRemoteError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("remote client: %v", err)
 	}
-	_, err = uploadSQLiteArchive(ctx, client, "gitcrawl", "gitcrawl/openclaw", db, "", crawlremote.IngestManifest{SchemaName: "gitcrawl-cloud-v1"})
+	_, err = uploadSQLiteArchive(ctx, client, "gitcrawl", "gitcrawl/openclaw", db, "", crawlremote.IngestManifest{SchemaName: "gitcrawl-cloud-v1"}, nil)
 	if err == nil {
 		t.Fatal("upload unexpectedly succeeded")
 	}
@@ -454,34 +455,75 @@ func TestCloudPublishSendsLocalRows(t *testing.T) {
 	tokenEnv := "GITCRAWL_TEST_PUBLISH_TOKEN"
 	t.Setenv(tokenEnv, "publish-token")
 	seenTables := map[string]crawlremote.IngestRequest{}
-	var sawSQLiteUpload bool
+	var sawSQLitePart bool
+	var sawSQLiteManifest bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("authorization"); got != "Bearer publish-token" {
 			http.Error(w, "missing bearer", http.StatusUnauthorized)
 			return
 		}
 		if r.Method == http.MethodPut && r.URL.EscapedPath() == "/v1/apps/gitcrawl/archives/gitcrawl%2Fopenclaw__openclaw/sqlite" {
-			sawSQLiteUpload = true
+			uploadKind := r.Header.Get("x-crawl-sqlite-upload")
 			payload, err := io.ReadAll(r.Body)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			}
-			if !bytes.HasPrefix(payload, []byte("SQLite format 3")) {
-				http.Error(w, "not sqlite", http.StatusBadRequest)
-				return
-			}
-			if r.Header.Get("x-crawl-content-sha256") == "" {
-				http.Error(w, "missing hash", http.StatusBadRequest)
-				return
-			}
 			w.Header().Set("content-type", "application/json")
-			_ = json.NewEncoder(w).Encode(crawlremote.SQLiteUploadResult{
-				App:      "gitcrawl",
-				Archive:  "gitcrawl/openclaw__openclaw",
-				Complete: true,
-				Object:   &crawlremote.SQLiteObject{Key: "v1/gitcrawl/gitcrawl%2Fopenclaw__openclaw/sqlite/current.db", Size: int64(len(payload))},
-			})
+			switch uploadKind {
+			case "bundle-part":
+				sawSQLitePart = true
+				if r.Header.Get("content-type") != "application/gzip" || r.Header.Get("x-crawl-content-sha256") == "" {
+					http.Error(w, "bad bundle part headers", http.StatusBadRequest)
+					return
+				}
+				if !bytes.HasPrefix(payload, []byte{0x1f, 0x8b}) {
+					http.Error(w, "not gzip", http.StatusBadRequest)
+					return
+				}
+				reader, err := gzip.NewReader(bytes.NewReader(payload))
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				decompressed, err := io.ReadAll(reader)
+				if closeErr := reader.Close(); err == nil {
+					err = closeErr
+				}
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				if !bytes.HasPrefix(decompressed, []byte("SQLite format 3")) {
+					http.Error(w, "bundle did not contain sqlite", http.StatusBadRequest)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(crawlremote.SQLiteUploadResult{
+					App:      "gitcrawl",
+					Archive:  "gitcrawl/openclaw__openclaw",
+					Complete: false,
+					Object:   &crawlremote.SQLiteObject{Key: "v1/gitcrawl/gitcrawl%2Fopenclaw__openclaw/sqlite/chunks/current.db.gz.part-0000", Size: int64(len(payload))},
+				})
+			case "bundle-manifest":
+				sawSQLiteManifest = true
+				var manifest crawlremote.SQLiteBundleManifest
+				if err := json.Unmarshal(payload, &manifest); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				if manifest.Format != crawlremote.SQLiteGzipChunkedBundleFormat || manifest.Compression.Algorithm != crawlremote.SQLiteGzipCompression || manifest.CompressedObject.Size == 0 {
+					http.Error(w, "bad manifest", http.StatusBadRequest)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(crawlremote.SQLiteBundleUploadResult{
+					App:      "gitcrawl",
+					Archive:  "gitcrawl/openclaw__openclaw",
+					Complete: true,
+					Bundle:   &crawlremote.SQLiteBundle{Key: "v1/gitcrawl/gitcrawl%2Fopenclaw__openclaw/sqlite/current.manifest.json", Manifest: &manifest},
+				})
+			default:
+				http.Error(w, "missing upload kind", http.StatusBadRequest)
+			}
 			return
 		}
 		if r.Method != http.MethodPost || r.URL.EscapedPath() != "/v1/apps/gitcrawl/archives/gitcrawl%2Fopenclaw__openclaw/ingest" {
@@ -529,8 +571,8 @@ func TestCloudPublishSendsLocalRows(t *testing.T) {
 	if !seenTables["threads"].Final {
 		t.Fatalf("threads batch should finish ingest")
 	}
-	if !sawSQLiteUpload {
-		t.Fatalf("cloud publish did not upload sqlite object")
+	if !sawSQLitePart || !sawSQLiteManifest {
+		t.Fatalf("cloud publish did not upload compressed sqlite bundle: part=%v manifest=%v", sawSQLitePart, sawSQLiteManifest)
 	}
 	var payload map[string]any
 	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
@@ -539,8 +581,8 @@ func TestCloudPublishSendsLocalRows(t *testing.T) {
 	if payload["repositories"] != float64(1) || payload["threads"] != float64(3) {
 		t.Fatalf("unexpected output: %#v", payload)
 	}
-	if payload["sqlite_object"] == nil {
-		t.Fatalf("missing sqlite object output: %#v", payload)
+	if payload["sqlite_bundle"] == nil {
+		t.Fatalf("missing sqlite bundle output: %#v", payload)
 	}
 }
 

--- a/internal/cli/cloud_commands.go
+++ b/internal/cli/cloud_commands.go
@@ -107,7 +107,10 @@ func (a *App) runCloudPublish(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	sqliteObject, err := uploadSQLiteArchive(ctx, client, "gitcrawl", archiveID, rt.Store.DB(), rt.SourceDBPath, manifest)
+	sqliteBundle, err := uploadSQLiteArchive(ctx, client, "gitcrawl", archiveID, rt.Store.DB(), rt.SourceDBPath, manifest, map[string]int64{
+		"repositories": repoAccepted,
+		"threads":      threadAccepted,
+	})
 	if err != nil {
 		return err
 	}
@@ -116,7 +119,7 @@ func (a *App) runCloudPublish(ctx context.Context, args []string) error {
 		"archive":       archiveID,
 		"repositories":  repoAccepted,
 		"threads":       threadAccepted,
-		"sqlite_object": sqliteObject,
+		"sqlite_bundle": sqliteBundle,
 	}, true)
 }
 
@@ -190,41 +193,31 @@ func cursorFor(start int) string {
 	return fmt.Sprintf("%d", start)
 }
 
-func uploadSQLiteArchive(ctx context.Context, client *crawlremote.Client, app, archive string, db *sql.DB, dbPath string, manifest crawlremote.IngestManifest) (*crawlremote.SQLiteObject, error) {
+func uploadSQLiteArchive(ctx context.Context, client *crawlremote.Client, app, archive string, db *sql.DB, dbPath string, manifest crawlremote.IngestManifest, counts map[string]int64) (*crawlremote.SQLiteBundle, error) {
 	snapshotPath, cleanup, err := sqliteSnapshotPath(ctx, db, dbPath)
 	if err != nil {
 		return nil, err
 	}
 	defer cleanup()
-	file, err := os.Open(snapshotPath)
-	if err != nil {
-		return nil, fmt.Errorf("open sqlite snapshot: %w", err)
-	}
-	defer file.Close()
-	info, err := file.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("stat sqlite snapshot: %w", err)
-	}
-	sum, err := cloudFileSHA256(snapshotPath)
-	if err != nil {
-		return nil, err
-	}
-	if _, err := file.Seek(0, io.SeekStart); err != nil {
-		return nil, fmt.Errorf("rewind sqlite snapshot: %w", err)
-	}
-	result, err := client.UploadSQLite(ctx, app, archive, crawlremote.SQLiteUploadRequest{
-		Body:          file,
-		Size:          info.Size(),
-		ContentSHA256: sum,
-		SchemaName:    manifest.SchemaName,
-		SchemaVersion: manifest.SchemaVersion,
-		SchemaHash:    manifest.SchemaHash,
-		SourceSyncAt:  manifest.SourceSyncAt,
+	bundle, err := crawlremote.BuildGzipSQLiteBundle(ctx, crawlremote.SQLiteBundleBuildOptions{
+		App:        app,
+		Archive:    archive,
+		SourcePath: snapshotPath,
+		Counts:     counts,
+		Privacy: map[string]any{
+			"includes_private_messages": false,
+			"includes_raw_json":         false,
+		},
 	})
 	if err != nil {
 		return nil, err
 	}
-	return result.Object, nil
+	defer bundle.Cleanup()
+	result, err := client.UploadSQLiteBundleFiles(ctx, app, archive, bundle.Manifest, bundle.Parts)
+	if err != nil {
+		return nil, err
+	}
+	return result.Bundle, nil
 }
 
 func sqliteSnapshotPath(ctx context.Context, db *sql.DB, dbPath string) (string, func(), error) {


### PR DESCRIPTION
## Summary
- bump crawlkit to v0.11.0
- publish SQLite mirrors as gzip chunk bundles with count/privacy manifests
- keep D1 row ingest and existing cloud publish behavior intact

## Validation
- GOWORK=off go test -count=1 ./...
- GOWORK=off go vet ./...
- git diff --check