### PR TITLE
feat: add local monorepo code search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add extra regression coverage for TUI detail-pane keyboard and wheel scrolling, thanks @RomneyDa.
 - Bound portable-store Git subprocess cancellation so stale fetch helpers cannot hang read-only commands, and expose the last portable refresh failure in `gitcrawl doctor --json`.
 - Backfill a missing or stale source embedding for `gitcrawl neighbors` with a one-row capped embedding request, and show the exact cheap `gitcrawl embed --number ... --limit 1` recovery command when no OpenAI key is configured.
+- Add PR-aware thread indexing for changed paths and commit subjects, plus `gitcrawl code index` and `search --scope code|all` for bounded local full-text search over tracked monorepo source files.
 
 ## 0.4.5 - 2026-05-23
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ gitcrawl search owner/repo --query "download stalls"
 gitcrawl search issues "download stalls" -R owner/repo --state open --json number,title,state,url,updatedAt,labels --limit 30
 gitcrawl search prs "manifest cache" -R owner/repo --state open --json number,title,state,url,updatedAt,isDraft,author --limit 20
 gitcrawl search issues "hot loop" -R owner/repo --state open --sync-if-stale 5m --json number,title,url
+gitcrawl code index owner/repo --path /path/to/checkout
+gitcrawl search owner/repo --query "manifest cache" --scope all --json
 gitcrawl sync owner/repo --numbers 123 --with pr-details
 octopool login
 octopool gh api repos/openclaw/openclaw/pulls/123 --jq .number
@@ -69,6 +71,7 @@ Use `gitcrawl remote login --github-token-env GITHUB_TOKEN` for non-browser boot
 Pass `--numbers` to refresh exact issue or pull request rows without relying on list ordering or updated-time windows.
 Thread-reference inputs accept bare numbers, `#123`, `issues/123`, `pull/123`, `owner/repo#123`, and full GitHub issue/PR URLs. This applies to sync filters, `--number` flags, governance member commands, neighbor/embed lookups, and TUI jump input.
 Pass `--with pr-details` or `--include-pr-details` to hydrate pull request files, commits, checks, workflow runs, and review-thread state for local review.
+`gitcrawl code index owner/repo --path ...` snapshots tracked UTF-8 text files from a local Git checkout into separate source-document tables in a normal local database. Direct search accepts `--scope threads|code|all`; source documents do not enter issue embeddings, duplicate clusters, portable stores, or cloud snapshots.
 `gitcrawl search issues|prs` accepts the common `gh search` shape (`<query> -R owner/repo --state open --json fields --limit N`) and answers from the local SQLite cache. It is intended for discovery without spending GitHub REST search quota; use `gh` for final live verification and GitHub write actions. Pass `--sync-if-stale 5m` to perform one metadata sync before the cached search when the local repository mirror is older than that duration.
 `gitcrawl gh` moved to Octopool. Run `octopool login`, then use `octopool gh ...` or symlink Octopool as `gh` for the shared org cache and pooled GitHub relay.
 The TUI starts at `--min-size 5` and `--sort size`, like ghcrawl's saved default, so the first screen is the useful cluster workload instead of singleton noise. Pass `--min-size 1` when you intentionally want singleton clusters, or `--layout focus` when you want more readable detail text. Mouse support is built in: click rows, wheel panes, and right-click for copy, sort, filter, jump, link, neighbor, local close/reopen, and member triage actions. Press `a` to open the same action menu from the keyboard, `#` to jump directly to an issue or PR number, `p` to switch between repositories already present in the local store, or `n` to load neighbors for the selected issue or PR. Enter from the members pane also loads neighbors before opening detail. The TUI quietly refreshes from the local store every 15 seconds.

--- a/SPEC.md
+++ b/SPEC.md
@@ -12,6 +12,7 @@ The target is a compact, local SQLite workflow for syncing, searching, clusterin
 - metadata-first GitHub sync for open issues and pull requests
 - optional comment, review, review-comment, PR code, and PR review-thread hydration
 - canonical thread document building
+- bounded local Git source-document indexing
 - FTS search
 - OpenAI summaries and embeddings
 - deterministic fingerprints
@@ -37,6 +38,7 @@ The target is a compact, local SQLite workflow for syncing, searching, clusterin
 - `internal/github`: GitHub API client
 - `internal/syncer`: repository sync workflows
 - `internal/documents`: canonical document generation
+- `internal/codeindex`: tracked source-file scanning
 - `internal/openai`: OpenAI summaries and embeddings
 - `internal/vector`: vector search abstraction
 - `internal/cluster`: similarity and durable cluster governance
@@ -77,6 +79,7 @@ Public commands:
 - `cluster-explain`
 - `neighbors`
 - `search`
+- `code`
 - `gh`
 - `close-thread`
 - `close-cluster`

--- a/docs/code-index.md
+++ b/docs/code-index.md
@@ -1,0 +1,67 @@
+---
+title: Code indexing
+nav_order: 9
+permalink: /code-index/
+---
+
+# Code indexing
+{: .no_toc }
+
+Load tracked source files from a local Git checkout into gitcrawl's separate
+code-document index.
+{: .fs-6 .fw-300 }
+
+1. TOC
+{:toc}
+
+## Index a checkout
+
+Mirror the GitHub repository first, then point gitcrawl at a checkout:
+
+```bash
+gitcrawl sync owner/repo
+gitcrawl code index owner/repo --path /path/to/checkout
+```
+
+The repository identity comes from `owner/repo`; `--path` supplies the local
+Git worktree. The command records the current `HEAD`, whether tracked files are
+dirty, file counts, indexed bytes, and skip counts.
+
+Defaults:
+
+| Flag | Default | Purpose |
+| --- | --- | --- |
+| `--path` | `.` | Git checkout to scan |
+| `--max-file-bytes` | `524288` | Skip larger files |
+| `--max-total-bytes` | `268435456` | Refuse unexpectedly large text corpora |
+| `--max-files` | `100000` | Refuse unexpectedly large text corpora |
+
+Only stage-0 regular blobs returned by `git ls-files --stage` are considered.
+Symlinks, submodules, paths that resolve outside the checkout, other
+non-regular files, tracked paths absent from the worktree, NUL-containing
+files, invalid UTF-8 files, and oversized files are skipped. Untracked files
+are ignored.
+
+Each successful index replaces the previous code snapshot for that repository,
+so deleted and renamed paths do not linger in search.
+
+Code indexing requires a normal local database. Portable-store runtime mirrors
+are refreshed from their published source and therefore reject `code index`;
+the source corpus is never added to the portable payload.
+
+## Search source
+
+```bash
+gitcrawl search owner/repo --query "RefreshManifest" --scope code
+gitcrawl search owner/repo --query "manifest cache" --scope all
+```
+
+Code search uses local SQLite FTS. `--scope all` interleaves thread results and
+code results within the requested limit.
+
+## Boundaries
+
+Code documents are deliberately separate from GitHub thread documents. They do
+not enter OpenAI embedding requests, semantic neighbors, or durable duplicate
+clusters. Portable-store and cloud publish flows also remain focused on GitHub
+archive data.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -45,13 +45,14 @@ These work on every command.
 | `gitcrawl refresh owner/repo [--no-sync --no-embed --no-cluster ...]` | Wrapper that runs sync → embed → cluster | [Refresh and embed](/refresh-and-embed/) |
 | `gitcrawl embed owner/repo [--number <ref> --limit --force --include-closed --json]` | Generate OpenAI embeddings for thread documents | [Refresh and embed](/refresh-and-embed/#embed) |
 | `gitcrawl runs owner/repo [--kind sync\|embedding\|cluster --limit --json]` | List recorded run history | [Refresh and embed](/refresh-and-embed/#runs) |
+| `gitcrawl code index owner/repo [--path --max-file-bytes --max-total-bytes --max-files --json]` | Index tracked text files from a local Git checkout | [Code indexing](/code-index/) |
 
 ## Inspect
 
 | Command | Purpose | Docs |
 | --- | --- | --- |
 | `gitcrawl threads owner/repo [--include-closed --numbers --limit --json]` | List threads from local cache | — |
-| `gitcrawl search owner/repo --query <text> [--mode keyword\|semantic\|hybrid --limit --json]` | Local search (direct mode) | [Search](/search/) |
+| `gitcrawl search owner/repo --query <text> [--scope threads\|code\|all --mode keyword\|semantic\|hybrid --limit --json]` | Local thread/source search (direct mode) | [Search](/search/) |
 | `gitcrawl search issues\|prs <query> -R owner/repo [--state --json --limit --sync-if-stale]` | Local search (`gh search` shape) | [Search](/search/#gh-search-compatibility-mode) |
 | `gitcrawl neighbors owner/repo --number <ref> [--limit --threshold --json]` | Vector-similar threads to a specific issue/PR | [Clustering](/clustering/#find-similar-threads-neighbors) |
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -36,6 +36,24 @@ A **document** is the canonical text gitcrawl indexes for a thread — title plu
 
 Most users never interact with documents directly; they show up in JSON output as a `document` field on neighbors and search hits.
 
+PR documents include hydrated changed paths and commit subjects when
+`--with pr-details` data is available. Patches remain in the PR-detail cache;
+they are not copied into embedding input.
+
+## Code snapshot
+
+A **code snapshot** is the latest tracked source corpus indexed from a local Git
+checkout with `gitcrawl code index`. It is separate from GitHub threads:
+
+- tracked regular files only
+- valid UTF-8 text only
+- bounded by per-file, aggregate-byte, and file-count limits
+- labeled with the checkout commit and dirty-worktree state
+
+Re-indexing replaces the repository's previous code snapshot. Code documents
+feed local FTS search, but not thread embeddings, neighbors, or duplicate
+clusters.
+
 ## Embedding
 
 An **embedding** is a vector representation of a thread's document, produced by an OpenAI model (default `text-embedding-3-small`, 1024 dimensions). Vectors live in `~/.config/gitcrawl/vectors` and are referenced from the `thread_vectors` table.

--- a/docs/search.md
+++ b/docs/search.md
@@ -22,15 +22,23 @@ Local full-text and semantic search over the SQLite mirror, plus a `gh search`-c
 ```bash
 gitcrawl search owner/repo --query "download stalls"
 gitcrawl search owner/repo --query "manifest cache" --mode hybrid --limit 30 --json
+gitcrawl search owner/repo --query "RefreshManifest" --scope code --json
+gitcrawl search owner/repo --query "manifest cache" --scope all --json
 ```
 
 | Flag | Default | Description |
 | --- | --- | --- |
 | `--query <text>` | _(required)_ | Search text |
 | `--mode keyword\|semantic\|hybrid` | `keyword` | `keyword` uses SQLite FTS, `semantic` uses vector cosine, `hybrid` blends them |
+| `--scope threads\|code\|all` | `threads` | Search GitHub thread documents, indexed source files, or both |
 | `--limit <n>` | _(implementation default)_ | Maximum hits |
 
 **Hybrid mode** is the most robust default — it blends full-text recall with semantic neighbors so typos, synonyms, and stack-trace fragments still surface relevant rows.
+
+Code search is keyword-only. With `--scope all`, the selected thread mode runs
+alongside keyword code search and the result streams are interleaved. Run
+`gitcrawl code index` first; an unindexed repository simply contributes no code
+hits.
 
 JSON output:
 
@@ -121,6 +129,9 @@ gitcrawl tui owner/repo
 ## Limits
 
 - The keyword index covers titles, bodies, and (when synced) comments and review comments.
+- Hydrated PR changed paths and commit subjects are included in thread keyword and embedding documents.
+- Code scope covers the latest locally indexed tracked-text snapshot.
 - Semantic search relies on the local vector store. Run `gitcrawl embed` first.
+- Code documents are not embedded and do not participate in neighbors or clustering.
 - Hybrid mode degrades gracefully: with no vectors, it behaves like keyword.
 - Closed threads are included by the FTS index when synced; locally closed threads are filtered out by the `--hide-closed` flag where applicable.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -175,6 +175,8 @@ func (a *App) Run(ctx context.Context, args []string) error {
 		return a.runRuns(ctx, rest[1:])
 	case "search":
 		return a.runSearch(ctx, rest[1:])
+	case "code":
+		return a.runCode(ctx, rest[1:])
 	case "gh":
 		return a.runGHShim(ctx, rest[1:])
 	case "configure":
@@ -491,8 +493,9 @@ func (a *App) runSearch(ctx context.Context, args []string) error {
 	query := fs.String("query", "", "search query")
 	limitRaw := fs.String("limit", "", "maximum hit rows")
 	mode := fs.String("mode", "keyword", "search mode: keyword|semantic|hybrid")
+	scope := fs.String("scope", "threads", "search scope: threads|code|all")
 	jsonOut := fs.Bool("json", false, "write JSON output")
-	if err := fs.Parse(normalizeCommandArgs(args, map[string]bool{"query": true, "limit": true, "mode": true})); err != nil {
+	if err := fs.Parse(normalizeCommandArgs(args, map[string]bool{"query": true, "limit": true, "mode": true, "scope": true})); err != nil {
 		return usageErr(err)
 	}
 	a.applyCommandJSON(*jsonOut)
@@ -517,7 +520,20 @@ func (a *App) runSearch(ctx context.Context, args []string) error {
 	if searchMode != "keyword" && searchMode != "semantic" && searchMode != "hybrid" {
 		return usageErr(fmt.Errorf("unsupported search mode %q", searchMode))
 	}
+	searchScope := strings.TrimSpace(*scope)
+	if searchScope == "" {
+		searchScope = "threads"
+	}
+	if searchScope != "threads" && searchScope != "code" && searchScope != "all" {
+		return usageErr(fmt.Errorf("unsupported search scope %q", searchScope))
+	}
+	if searchScope == "code" && searchMode != "keyword" {
+		return usageErr(fmt.Errorf("code search currently supports --mode keyword only"))
+	}
 	if cfg, err := config.LoadRuntime(a.configPath); err == nil && cfg.Remote.Enabled() && cfg.Remote.Mode == crawlremote.ModeCloud {
+		if searchScope != "threads" {
+			return usageErr(fmt.Errorf("code search requires a local gitcrawl database"))
+		}
 		return a.runRemoteSearch(ctx, cfg, owner, repoName, strings.TrimSpace(*query), limit, searchMode)
 	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
@@ -534,9 +550,40 @@ func (a *App) runSearch(ctx context.Context, args []string) error {
 		return err
 	}
 	queryText := strings.TrimSpace(*query)
+	if searchScope == "code" {
+		hits, err := rt.Store.SearchCodeDocuments(ctx, repo.ID, queryText, limit)
+		if err != nil {
+			return err
+		}
+		return a.writeOutput("search", map[string]any{
+			"repository": repo.FullName,
+			"query":      queryText,
+			"mode":       "keyword",
+			"scope":      "code",
+			"hits":       hits,
+		}, true)
+	}
 	hits, effectiveMode, err := a.searchDocuments(ctx, rt, repo.ID, queryText, limit, searchMode)
 	if err != nil {
 		return err
+	}
+	if searchScope == "all" {
+		codeHits, err := rt.Store.SearchCodeDocuments(ctx, repo.ID, queryText, limit)
+		if err != nil {
+			return err
+		}
+		payload := map[string]any{
+			"repository": repo.FullName,
+			"query":      queryText,
+			"mode":       effectiveMode,
+			"code_mode":  "keyword",
+			"scope":      "all",
+			"hits":       mergeScopedSearchHits(hits, codeHits, limit),
+		}
+		if effectiveMode != searchMode {
+			payload["requested_mode"] = searchMode
+		}
+		return a.writeOutput("search", payload, true)
 	}
 	payload := map[string]any{
 		"repository": repo.FullName,
@@ -3439,8 +3486,8 @@ func (a *App) runMetadata(args []string) error {
 		DefaultCache:    cfg.CacheDir,
 		DefaultLogs:     cfg.LogDir,
 	}
-	manifest.Capabilities = []string{"metadata", "status", "doctor", "sync", "search", "tui", "portable", "remote", "cloud-publish", "clusters", "embeddings"}
-	manifest.Privacy = control.Privacy{ContainsPrivateMessages: false, ExportsSecrets: false, LocalOnlyScopes: []string{"github", "sqlite", "portable"}}
+	manifest.Capabilities = []string{"metadata", "status", "doctor", "sync", "search", "code-index", "tui", "portable", "remote", "cloud-publish", "clusters", "embeddings"}
+	manifest.Privacy = control.Privacy{ContainsPrivateMessages: false, ExportsSecrets: false, LocalOnlyScopes: []string{"github", "git", "sqlite", "portable"}}
 	manifest.Commands = map[string]control.Command{
 		"status":          {Title: "Status", Argv: []string{"gitcrawl", "status", "--json"}, JSON: true},
 		"remote-status":   {Title: "Remote archive status", Argv: []string{"gitcrawl", "remote", "status", "--json"}, JSON: true},
@@ -3452,6 +3499,7 @@ func (a *App) runMetadata(args []string) error {
 		"doctor":          {Title: "Doctor", Argv: []string{"gitcrawl", "doctor", "--json"}, JSON: true},
 		"sync":            {Title: "Sync repository", Argv: []string{"gitcrawl", "sync", "--json"}, JSON: true, Mutates: true},
 		"search":          {Title: "Search", Argv: []string{"gitcrawl", "search", "--json"}, JSON: true},
+		"code-index":      {Title: "Code index", Argv: []string{"gitcrawl", "code", "index", "--json"}, JSON: true, Mutates: true},
 		"tui":             {Title: "Terminal cluster browser", Argv: []string{"gitcrawl", "tui"}},
 		"tui-json":        {Title: "Terminal cluster data", Argv: []string{"gitcrawl", "tui", "--json"}, JSON: true},
 		"portable":        {Title: "Portable store tools", Argv: []string{"gitcrawl", "portable", "prune", "--json"}, JSON: true, Mutates: true},
@@ -4261,6 +4309,7 @@ Core commands:
   refresh              run sync, enrichment, embedding, and clustering pipeline
   embed                generate OpenAI embeddings for local thread documents
   threads              list local issue and pull request rows
+  code index           index tracked text files from a local Git checkout
   cluster              build durable clusters from local thread vectors
   close-thread         locally hide one issue or pull request row
   reopen-thread        clear a local hide for one issue or pull request row
@@ -4278,7 +4327,7 @@ Core commands:
   cluster-detail       dump one latest run cluster, with durable fallback
   cluster-explain      alias for cluster-detail
   neighbors            list vector-nearest local issue and pull request rows
-  search               search local thread documents; also supports search issues|prs gh syntax
+  search               search local thread and source documents; also supports search issues|prs gh syntax
   gh                   moved to Octopool; prints migration note
   portable prune       prune volatile payloads from a portable store
   tui [owner/repo]     browse clusters in the terminal UI; repo is inferred when omitted
@@ -4359,8 +4408,13 @@ Usage:
 	"search": `gitcrawl search queries local thread documents, or accepts gh-shaped issue and PR search.
 
 Usage:
-  gitcrawl search owner/repo --query text [--mode keyword|semantic|hybrid] [--limit N] [--json]
+  gitcrawl search owner/repo --query text [--scope threads|code|all] [--mode keyword|semantic|hybrid] [--limit N] [--json]
   gitcrawl search issues|prs <query> -R owner/repo [--state open|closed|all] [--json fields] [--limit N] [--sync-if-stale duration]
+`,
+	"code": `gitcrawl code indexes source from a local Git checkout.
+
+Usage:
+  gitcrawl code index owner/repo [--path DIR] [--max-file-bytes N] [--max-total-bytes N] [--max-files N] [--json]
 `,
 	"cluster": `gitcrawl cluster builds durable clusters from local thread vectors.
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -145,6 +145,54 @@ func TestCloudSQLiteSnapshotVacuum(t *testing.T) {
 	}
 }
 
+func TestCloudSQLiteSnapshotDropsLocalCodeCorpus(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "source.db")
+	st, err := store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	repoID, err := st.UpsertRepository(ctx, store.Repository{Owner: "openclaw", Name: "gitcrawl", FullName: "openclaw/gitcrawl", RawJSON: "{}", UpdatedAt: "2026-06-06T00:00:00Z"})
+	if err != nil {
+		t.Fatalf("repo: %v", err)
+	}
+	if _, err := st.ReplaceCodeSnapshot(ctx, store.CodeSnapshot{
+		RepoID: repoID, SourceRoot: "/private/repo", GitSHA: "abc",
+		FileCount: 1, ByteCount: 6, IndexedAt: "2026-06-06T00:00:00Z",
+	}, []store.CodeDocument{{Path: "secret.txt", Language: "txt", ContentHash: "h", Text: "secret", ByteSize: 6, UpdatedAt: "2026-06-06T00:00:00Z"}}); err != nil {
+		t.Fatalf("replace code snapshot: %v", err)
+	}
+	snapshotPath, cleanup, err := cloudSQLiteSnapshotPath(ctx, st.DB(), dbPath)
+	if err != nil {
+		t.Fatalf("cloud snapshot: %v", err)
+	}
+	defer cleanup()
+	snapshotDB, err := sql.Open("sqlite", snapshotPath)
+	if err != nil {
+		t.Fatalf("open cloud snapshot: %v", err)
+	}
+	defer snapshotDB.Close()
+	for _, table := range []string{"code_snapshots", "code_documents", "code_documents_fts"} {
+		var count int
+		if err := snapshotDB.QueryRowContext(ctx, `select count(*) from sqlite_schema where name = ?`, table).Scan(&count); err != nil {
+			t.Fatalf("inspect %s: %v", table, err)
+		}
+		if count != 0 {
+			t.Fatalf("cloud snapshot retained %s", table)
+		}
+	}
+	var sourceCount int
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from code_documents`).Scan(&sourceCount); err != nil {
+		t.Fatalf("source code documents: %v", err)
+	}
+	if sourceCount != 1 {
+		t.Fatalf("cloud snapshot mutated source corpus: count=%d", sourceCount)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+}
+
 func TestCloudFileSHA256(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "payload.txt")
 	if err := os.WriteFile(path, []byte("abc"), 0o600); err != nil {
@@ -839,7 +887,7 @@ func TestMetadataStatusAndControlStatusJSON(t *testing.T) {
 	if !strings.Contains(helpOut.String(), "cluster browser") {
 		t.Fatalf("tui help output = %q", helpOut.String())
 	}
-	for _, topic := range []string{"metadata", "status", "remote", "whoami", "init", "configure", "doctor", "sync", "refresh", "embed", "threads", "search", "cluster", "clusters", "clusters-report", "durable-clusters", "cluster-detail", "cluster-explain", "neighbors", "runs", "close-thread", "reopen-thread", "close-cluster", "reopen-cluster", "exclude-cluster-member", "include-cluster-member", "set-cluster-canonical", "gh"} {
+	for _, topic := range []string{"metadata", "status", "remote", "whoami", "init", "configure", "doctor", "sync", "refresh", "embed", "threads", "search", "code", "cluster", "clusters", "clusters-report", "durable-clusters", "cluster-detail", "cluster-explain", "neighbors", "runs", "close-thread", "reopen-thread", "close-cluster", "reopen-cluster", "exclude-cluster-member", "include-cluster-member", "set-cluster-canonical", "gh"} {
 		helpOut.Reset()
 		if err := help.printCommandUsage(topic); err != nil {
 			t.Fatalf("%s help: %v", topic, err)

--- a/internal/cli/cloud_commands.go
+++ b/internal/cli/cloud_commands.go
@@ -110,7 +110,7 @@ func (a *App) runCloudPublish(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	sqliteBundle, err := uploadSQLiteArchive(ctx, client, "gitcrawl", archiveID, rt.Store.DB(), rt.SourceDBPath, manifest, map[string]int64{
+	sqliteBundle, err := uploadSQLiteArchive(ctx, client, "gitcrawl", archiveID, rt.Store.DB(), rt.Store.Path(), manifest, map[string]int64{
 		"repositories": repoAccepted,
 		"threads":      threadAccepted,
 	})
@@ -197,7 +197,7 @@ func cursorFor(start int) string {
 }
 
 func uploadSQLiteArchive(ctx context.Context, client *crawlremote.Client, app, archive string, db *sql.DB, dbPath string, manifest crawlremote.IngestManifest, counts map[string]int64) (*crawlremote.SQLiteBundle, error) {
-	snapshotPath, cleanup, err := sqliteSnapshotPath(ctx, db, dbPath)
+	snapshotPath, cleanup, err := cloudSQLiteSnapshotPath(ctx, db, dbPath)
 	if err != nil {
 		return nil, err
 	}
@@ -211,6 +211,7 @@ func uploadSQLiteArchive(ctx context.Context, client *crawlremote.Client, app, a
 		Privacy: map[string]any{
 			"includes_private_messages": false,
 			"includes_raw_json":         false,
+			"includes_source_code":      false,
 		},
 	})
 	if err != nil {
@@ -222,6 +223,54 @@ func uploadSQLiteArchive(ctx context.Context, client *crawlremote.Client, app, a
 		return nil, err
 	}
 	return result.Bundle, nil
+}
+
+func cloudSQLiteSnapshotPath(ctx context.Context, db *sql.DB, dbPath string) (string, func(), error) {
+	snapshotPath, cleanup, err := sqliteSnapshotPath(ctx, db, "")
+	if err != nil {
+		source := strings.TrimSpace(dbPath)
+		if source == "" {
+			return "", func() {}, err
+		}
+		if _, statErr := os.Stat(source); statErr != nil {
+			return "", func() {}, fmt.Errorf("stat cloud SQLite source: %w", statErr)
+		}
+		reopened, openErr := sql.Open("sqlite", source)
+		if openErr != nil {
+			return "", func() {}, fmt.Errorf("reopen cloud SQLite source: %w", openErr)
+		}
+		snapshotPath, cleanup, err = sqliteSnapshotPath(ctx, reopened, "")
+		closeErr := reopened.Close()
+		if err != nil {
+			return "", func() {}, err
+		}
+		if closeErr != nil {
+			cleanup()
+			return "", func() {}, fmt.Errorf("close reopened cloud SQLite source: %w", closeErr)
+		}
+	}
+	snapshotDB, err := sql.Open("sqlite", snapshotPath)
+	if err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("open cloud SQLite snapshot: %w", err)
+	}
+	for _, table := range []string{"code_documents_fts", "code_documents", "code_snapshots"} {
+		if _, err := snapshotDB.ExecContext(ctx, `drop table if exists `+table); err != nil {
+			_ = snapshotDB.Close()
+			cleanup()
+			return "", func() {}, fmt.Errorf("drop local-only cloud snapshot table %s: %w", table, err)
+		}
+	}
+	if _, err := snapshotDB.ExecContext(ctx, `vacuum`); err != nil {
+		_ = snapshotDB.Close()
+		cleanup()
+		return "", func() {}, fmt.Errorf("compact cloud SQLite snapshot: %w", err)
+	}
+	if err := snapshotDB.Close(); err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("close cloud SQLite snapshot: %w", err)
+	}
+	return snapshotPath, cleanup, nil
 }
 
 func sqliteSnapshotPath(ctx context.Context, db *sql.DB, dbPath string) (string, func(), error) {

--- a/internal/cli/code.go
+++ b/internal/cli/code.go
@@ -1,0 +1,144 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/openclaw/gitcrawl/internal/codeindex"
+	"github.com/openclaw/gitcrawl/internal/store"
+)
+
+type codeIndexResult struct {
+	Repository         string `json:"repository"`
+	SourceRoot         string `json:"source_root"`
+	GitSHA             string `json:"git_sha"`
+	WorktreeDirty      bool   `json:"worktree_dirty"`
+	SnapshotID         int64  `json:"snapshot_id"`
+	FilesSeen          int    `json:"files_seen"`
+	FilesIndexed       int    `json:"files_indexed"`
+	BytesIndexed       int64  `json:"bytes_indexed"`
+	SkippedBinary      int    `json:"skipped_binary"`
+	SkippedLarge       int    `json:"skipped_large"`
+	SkippedMissing     int    `json:"skipped_missing"`
+	SkippedNonRegular  int    `json:"skipped_non_regular"`
+	SkippedOutsideRoot int    `json:"skipped_outside_root"`
+	IndexedAt          string `json:"indexed_at"`
+}
+
+func (a *App) runCode(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		return usageErr(fmt.Errorf("code requires a subcommand"))
+	}
+	switch args[0] {
+	case "index":
+		return a.runCodeIndex(ctx, args[1:])
+	default:
+		return usageErr(fmt.Errorf("unknown code subcommand %q", args[0]))
+	}
+}
+
+func (a *App) runCodeIndex(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("code index", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	path := fs.String("path", ".", "local Git checkout")
+	maxFileBytesRaw := fs.String("max-file-bytes", strconv.FormatInt(codeindex.DefaultMaxFileBytes, 10), "maximum bytes per indexed file")
+	maxTotalBytesRaw := fs.String("max-total-bytes", strconv.FormatInt(codeindex.DefaultMaxTotalBytes, 10), "maximum bytes across indexed files")
+	maxFilesRaw := fs.String("max-files", strconv.Itoa(codeindex.DefaultMaxFiles), "maximum tracked text files")
+	jsonOut := fs.Bool("json", false, "write JSON output")
+	if err := fs.Parse(normalizeCommandArgs(args, map[string]bool{"path": true, "max-file-bytes": true, "max-total-bytes": true, "max-files": true})); err != nil {
+		return usageErr(err)
+	}
+	a.applyCommandJSON(*jsonOut)
+	if fs.NArg() != 1 {
+		return usageErr(fmt.Errorf("code index requires owner/repo"))
+	}
+	owner, repoName, err := parseOwnerRepo(fs.Arg(0))
+	if err != nil {
+		return usageErr(err)
+	}
+	maxFileBytes, err := strconv.ParseInt(strings.TrimSpace(*maxFileBytesRaw), 10, 64)
+	if err != nil || maxFileBytes <= 0 {
+		return usageErr(fmt.Errorf("code index requires positive --max-file-bytes"))
+	}
+	maxTotalBytes, err := strconv.ParseInt(strings.TrimSpace(*maxTotalBytesRaw), 10, 64)
+	if err != nil || maxTotalBytes <= 0 {
+		return usageErr(fmt.Errorf("code index requires positive --max-total-bytes"))
+	}
+	maxFiles, err := parseOptionalPositiveInt(*maxFilesRaw)
+	if err != nil || maxFiles <= 0 {
+		return usageErr(fmt.Errorf("code index requires positive --max-files"))
+	}
+
+	rt, err := a.openLocalRuntime(ctx)
+	if err != nil {
+		return err
+	}
+	defer rt.Store.Close()
+	if rt.RemoteSource {
+		return fmt.Errorf("code index requires a local database; portable-store runtime mirrors are refreshed from their source")
+	}
+	repo, err := rt.repository(ctx, owner, repoName)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("repository %s/%s is not mirrored; run gitcrawl sync first", owner, repoName)
+		}
+		return err
+	}
+	scanned, err := codeindex.Scan(ctx, codeindex.Options{
+		Path:          *path,
+		MaxFileBytes:  maxFileBytes,
+		MaxTotalBytes: maxTotalBytes,
+		MaxFiles:      maxFiles,
+	})
+	if err != nil {
+		return err
+	}
+	indexedAt := time.Now().UTC().Format(time.RFC3339Nano)
+	documents := make([]store.CodeDocument, 0, len(scanned.Documents))
+	for _, document := range scanned.Documents {
+		documents = append(documents, store.CodeDocument{
+			RepoID:      repo.ID,
+			Path:        document.Path,
+			Language:    document.Language,
+			ContentHash: document.ContentHash,
+			Text:        document.Text,
+			ByteSize:    document.ByteSize,
+			UpdatedAt:   indexedAt,
+		})
+	}
+	snapshotID, err := rt.Store.ReplaceCodeSnapshot(ctx, store.CodeSnapshot{
+		RepoID:        repo.ID,
+		SourceRoot:    scanned.SourceRoot,
+		GitSHA:        scanned.GitSHA,
+		WorktreeDirty: scanned.WorktreeDirty,
+		FileCount:     scanned.FilesIndexed,
+		ByteCount:     scanned.BytesIndexed,
+		IndexedAt:     indexedAt,
+	}, documents)
+	if err != nil {
+		return err
+	}
+	return a.writeOutput("code index", codeIndexResult{
+		Repository:         repo.FullName,
+		SourceRoot:         scanned.SourceRoot,
+		GitSHA:             scanned.GitSHA,
+		WorktreeDirty:      scanned.WorktreeDirty,
+		SnapshotID:         snapshotID,
+		FilesSeen:          scanned.FilesSeen,
+		FilesIndexed:       scanned.FilesIndexed,
+		BytesIndexed:       scanned.BytesIndexed,
+		SkippedBinary:      scanned.SkippedBinary,
+		SkippedLarge:       scanned.SkippedLarge,
+		SkippedMissing:     scanned.SkippedMissing,
+		SkippedNonRegular:  scanned.SkippedNonRegular,
+		SkippedOutsideRoot: scanned.SkippedOutsideRoot,
+		IndexedAt:          indexedAt,
+	}, true)
+}

--- a/internal/cli/code_search.go
+++ b/internal/cli/code_search.go
@@ -1,0 +1,63 @@
+package cli
+
+import "github.com/openclaw/gitcrawl/internal/store"
+
+type scopedSearchHit struct {
+	Scope         string  `json:"scope"`
+	ThreadID      int64   `json:"thread_id,omitempty"`
+	DocumentID    int64   `json:"document_id,omitempty"`
+	Number        int     `json:"number,omitempty"`
+	Kind          string  `json:"kind"`
+	State         string  `json:"state,omitempty"`
+	Title         string  `json:"title"`
+	Path          string  `json:"path,omitempty"`
+	Language      string  `json:"language,omitempty"`
+	HTMLURL       string  `json:"html_url,omitempty"`
+	AuthorLogin   string  `json:"author_login,omitempty"`
+	Snippet       string  `json:"snippet"`
+	Score         float64 `json:"score,omitempty"`
+	GitSHA        string  `json:"git_sha,omitempty"`
+	SourceRoot    string  `json:"source_root,omitempty"`
+	WorktreeDirty bool    `json:"worktree_dirty,omitempty"`
+}
+
+func mergeScopedSearchHits(threadHits []store.SearchHit, codeHits []store.CodeSearchHit, limit int) []scopedSearchHit {
+	if limit <= 0 {
+		limit = 20
+	}
+	out := make([]scopedSearchHit, 0, min(limit, len(threadHits)+len(codeHits)))
+	maxLen := max(len(threadHits), len(codeHits))
+	for index := 0; index < maxLen && len(out) < limit; index++ {
+		if index < len(threadHits) {
+			hit := threadHits[index]
+			out = append(out, scopedSearchHit{
+				Scope:       "threads",
+				ThreadID:    hit.ThreadID,
+				Number:      hit.Number,
+				Kind:        hit.Kind,
+				State:       hit.State,
+				Title:       hit.Title,
+				HTMLURL:     hit.HTMLURL,
+				AuthorLogin: hit.AuthorLogin,
+				Snippet:     hit.Snippet,
+				Score:       hit.Score,
+			})
+		}
+		if index < len(codeHits) && len(out) < limit {
+			hit := codeHits[index]
+			out = append(out, scopedSearchHit{
+				Scope:         "code",
+				DocumentID:    hit.DocumentID,
+				Kind:          "code",
+				Title:         hit.Path,
+				Path:          hit.Path,
+				Language:      hit.Language,
+				Snippet:       hit.Snippet,
+				GitSHA:        hit.GitSHA,
+				SourceRoot:    hit.SourceRoot,
+				WorktreeDirty: hit.WorktreeDirty,
+			})
+		}
+	}
+	return out
+}

--- a/internal/cli/code_test.go
+++ b/internal/cli/code_test.go
@@ -1,0 +1,162 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/gitcrawl/internal/store"
+)
+
+func TestCodeIndexAndScopedSearch(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	dbPath := filepath.Join(dir, "gitcrawl.db")
+	if err := New().Run(ctx, []string{"--config", configPath, "init", "--db", dbPath}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	st, err := store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	repoID, err := st.UpsertRepository(ctx, store.Repository{
+		Owner: "openclaw", Name: "gitcrawl", FullName: "openclaw/gitcrawl",
+		RawJSON: "{}", UpdatedAt: "2026-06-06T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("repo: %v", err)
+	}
+	threadID, err := st.UpsertThread(ctx, store.Thread{
+		RepoID: repoID, GitHubID: "1", Number: 1, Kind: "issue", State: "open",
+		Title: "Manifest refresh issue", Body: "cache misses", HTMLURL: "https://github.com/openclaw/gitcrawl/issues/1",
+		LabelsJSON: "[]", AssigneesJSON: "[]", RawJSON: "{}", ContentHash: "h", UpdatedAt: "2026-06-06T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("thread: %v", err)
+	}
+	if _, err := st.UpsertDocument(ctx, store.Document{
+		ThreadID: threadID, Title: "Manifest refresh issue", RawText: "manifest refresh cache misses",
+		DedupeText: "manifest refresh cache misses", UpdatedAt: "2026-06-06T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("thread document: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	source := filepath.Join(dir, "source")
+	if err := os.MkdirAll(filepath.Join(source, "internal", "cache"), 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "internal", "cache", "store.go"), []byte("package cache\n// manifest refresh\nfunc RefreshManifest() {}\n"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	if err := runGit(ctx, source, "init", "-b", "main"); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	if err := runGit(ctx, source, "add", "."); err != nil {
+		t.Fatalf("git add: %v", err)
+	}
+	if err := runGit(ctx, source, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed"); err != nil {
+		t.Fatalf("git commit: %v", err)
+	}
+
+	app := New()
+	var stdout bytes.Buffer
+	app.Stdout = &stdout
+	if err := app.Run(ctx, []string{"--config", configPath, "--json", "code", "index", "openclaw/gitcrawl", "--path", source}); err != nil {
+		t.Fatalf("code index: %v", err)
+	}
+	var indexed codeIndexResult
+	if err := json.Unmarshal(stdout.Bytes(), &indexed); err != nil {
+		t.Fatalf("decode code index: %v\n%s", err, stdout.String())
+	}
+	expectedRoot, err := filepath.EvalSymlinks(source)
+	if err != nil {
+		t.Fatalf("resolve source root: %v", err)
+	}
+	if indexed.FilesIndexed != 1 || indexed.GitSHA == "" || indexed.SourceRoot != expectedRoot {
+		t.Fatalf("index result = %#v", indexed)
+	}
+
+	stdout.Reset()
+	search := New()
+	search.Stdout = &stdout
+	if err := search.Run(ctx, []string{"--config", configPath, "--json", "search", "openclaw/gitcrawl", "--query", "RefreshManifest", "--scope", "code"}); err != nil {
+		t.Fatalf("code search: %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"path": "internal/cache/store.go"`) || !strings.Contains(stdout.String(), `"scope": "code"`) {
+		t.Fatalf("code search output = %s", stdout.String())
+	}
+
+	stdout.Reset()
+	allSearch := New()
+	allSearch.Stdout = &stdout
+	if err := allSearch.Run(ctx, []string{"--config", configPath, "--json", "search", "openclaw/gitcrawl", "--query", "manifest", "--scope", "all"}); err != nil {
+		t.Fatalf("all search: %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"scope": "threads"`) || !strings.Contains(stdout.String(), `"scope": "code"`) {
+		t.Fatalf("all search output = %s", stdout.String())
+	}
+}
+
+func TestCodeCommandValidation(t *testing.T) {
+	ctx := context.Background()
+	for _, args := range [][]string{
+		{"code"},
+		{"code", "unknown"},
+		{"code", "index"},
+		{"code", "index", "badrepo"},
+		{"code", "index", "openclaw/gitcrawl", "--max-files", "0"},
+		{"code", "index", "openclaw/gitcrawl", "--max-total-bytes", "0"},
+		{"search", "openclaw/gitcrawl", "--query", "x", "--scope", "bad"},
+		{"search", "openclaw/gitcrawl", "--query", "x", "--scope", "code", "--mode", "semantic"},
+	} {
+		if err := New().Run(ctx, args); err == nil {
+			t.Fatalf("args unexpectedly succeeded: %#v", args)
+		}
+	}
+}
+
+func TestCodeIndexRejectsPortableStoreRuntime(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	checkout := filepath.Join(dir, "portable")
+	configPath := filepath.Join(dir, "config.toml")
+	dbPath := filepath.Join(checkout, "data", "gitcrawl.db")
+	if err := New().Run(ctx, []string{"--config", configPath, "init", "--db", dbPath}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	st, err := store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if _, err := st.UpsertRepository(ctx, store.Repository{
+		Owner: "openclaw", Name: "gitcrawl", FullName: "openclaw/gitcrawl",
+		RawJSON: "{}", UpdatedAt: "2026-06-06T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("repo: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	if err := runGit(ctx, checkout, "init", "-b", "main"); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	if err := runGit(ctx, checkout, "add", "."); err != nil {
+		t.Fatalf("git add: %v", err)
+	}
+	if err := runGit(ctx, checkout, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed"); err != nil {
+		t.Fatalf("git commit: %v", err)
+	}
+
+	err = New().Run(ctx, []string{"--config", configPath, "code", "index", "openclaw/gitcrawl", "--path", checkout})
+	if err == nil || !strings.Contains(err.Error(), "requires a local database") {
+		t.Fatalf("code index portable error = %v", err)
+	}
+}

--- a/internal/codeindex/indexer.go
+++ b/internal/codeindex/indexer.go
@@ -1,0 +1,265 @@
+package codeindex
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	DefaultMaxFileBytes  int64 = 512 * 1024
+	DefaultMaxTotalBytes int64 = 256 * 1024 * 1024
+	DefaultMaxFiles            = 100000
+)
+
+type Options struct {
+	Path          string
+	MaxFileBytes  int64
+	MaxTotalBytes int64
+	MaxFiles      int
+}
+
+type Document struct {
+	Path        string
+	Language    string
+	ContentHash string
+	Text        string
+	ByteSize    int64
+}
+
+type Result struct {
+	SourceRoot         string
+	GitSHA             string
+	WorktreeDirty      bool
+	FilesSeen          int
+	FilesIndexed       int
+	BytesIndexed       int64
+	SkippedBinary      int
+	SkippedLarge       int
+	SkippedMissing     int
+	SkippedNonRegular  int
+	SkippedOutsideRoot int
+	Documents          []Document
+}
+
+func Scan(ctx context.Context, options Options) (Result, error) {
+	path := strings.TrimSpace(options.Path)
+	if path == "" {
+		path = "."
+	}
+	if options.MaxFileBytes <= 0 {
+		options.MaxFileBytes = DefaultMaxFileBytes
+	}
+	if options.MaxTotalBytes <= 0 {
+		options.MaxTotalBytes = DefaultMaxTotalBytes
+	}
+	if options.MaxFiles <= 0 {
+		options.MaxFiles = DefaultMaxFiles
+	}
+
+	root, err := gitText(ctx, path, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return Result{}, err
+	}
+	root, err = filepath.Abs(strings.TrimSpace(root))
+	if err != nil {
+		return Result{}, fmt.Errorf("resolve source root: %w", err)
+	}
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		return Result{}, fmt.Errorf("resolve source root symlinks: %w", err)
+	}
+	sha, err := gitText(ctx, root, "rev-parse", "HEAD")
+	if err != nil {
+		return Result{}, err
+	}
+	status, err := gitBytes(ctx, root, "status", "--porcelain", "--untracked-files=no")
+	if err != nil {
+		return Result{}, err
+	}
+	rawEntries, err := gitBytes(ctx, root, "ls-files", "-z", "--cached", "--stage")
+	if err != nil {
+		return Result{}, err
+	}
+	rootFS, err := os.OpenRoot(root)
+	if err != nil {
+		return Result{}, fmt.Errorf("open source root: %w", err)
+	}
+	defer rootFS.Close()
+
+	result := Result{
+		SourceRoot:    root,
+		GitSHA:        strings.TrimSpace(string(sha)),
+		WorktreeDirty: len(bytes.TrimSpace(status)) > 0,
+	}
+	for _, rawEntry := range bytes.Split(rawEntries, []byte{0}) {
+		if len(rawEntry) == 0 {
+			continue
+		}
+		result.FilesSeen++
+		metadata, rawPath, ok := bytes.Cut(rawEntry, []byte{'\t'})
+		fields := bytes.Fields(metadata)
+		if !ok || len(fields) != 3 {
+			return Result{}, fmt.Errorf("parse tracked entry %q", rawEntry)
+		}
+		mode := string(fields[0])
+		stage := string(fields[2])
+		if stage != "0" || (mode != "100644" && mode != "100755") {
+			result.SkippedNonRegular++
+			continue
+		}
+		path := filepath.ToSlash(string(rawPath))
+		if !safeRelativePath(path) {
+			return Result{}, fmt.Errorf("git returned unsafe tracked path %q", path)
+		}
+		rootPath := filepath.FromSlash(path)
+		info, err := rootFS.Lstat(rootPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				result.SkippedMissing++
+				continue
+			}
+			if pathEscapesRoot(err) {
+				result.SkippedOutsideRoot++
+				continue
+			}
+			return Result{}, fmt.Errorf("stat tracked file %s: %w", path, err)
+		}
+		if !info.Mode().IsRegular() {
+			result.SkippedNonRegular++
+			continue
+		}
+		if info.Size() > options.MaxFileBytes {
+			result.SkippedLarge++
+			continue
+		}
+		data, tooLarge, err := readFileAtMost(rootFS, rootPath, options.MaxFileBytes)
+		if err != nil {
+			if os.IsNotExist(err) {
+				result.SkippedMissing++
+				continue
+			}
+			if pathEscapesRoot(err) {
+				result.SkippedOutsideRoot++
+				continue
+			}
+			return Result{}, fmt.Errorf("read tracked file %s: %w", path, err)
+		}
+		if tooLarge {
+			result.SkippedLarge++
+			continue
+		}
+		if bytes.IndexByte(data, 0) >= 0 || !utf8.Valid(data) {
+			result.SkippedBinary++
+			continue
+		}
+		if result.FilesIndexed >= options.MaxFiles {
+			return Result{}, fmt.Errorf("tracked text file count exceeds --max-files %d", options.MaxFiles)
+		}
+		if result.BytesIndexed+int64(len(data)) > options.MaxTotalBytes {
+			return Result{}, fmt.Errorf("tracked text corpus exceeds --max-total-bytes %d", options.MaxTotalBytes)
+		}
+		sum := sha256.Sum256(data)
+		result.Documents = append(result.Documents, Document{
+			Path:        path,
+			Language:    languageForPath(path),
+			ContentHash: hex.EncodeToString(sum[:]),
+			Text:        string(data),
+			ByteSize:    int64(len(data)),
+		})
+		result.FilesIndexed++
+		result.BytesIndexed += int64(len(data))
+	}
+	finalSHA, err := gitText(ctx, root, "rev-parse", "HEAD")
+	if err != nil {
+		return Result{}, err
+	}
+	if strings.TrimSpace(finalSHA) != result.GitSHA {
+		return Result{}, fmt.Errorf("repository HEAD changed during code scan; retry indexing")
+	}
+	finalStatus, err := gitBytes(ctx, root, "status", "--porcelain", "--untracked-files=no")
+	if err != nil {
+		return Result{}, err
+	}
+	result.WorktreeDirty = result.WorktreeDirty || len(bytes.TrimSpace(finalStatus)) > 0
+	return result, nil
+}
+
+func readFileAtMost(root *os.Root, path string, maxBytes int64) ([]byte, bool, error) {
+	file, err := root.Open(path)
+	if err != nil {
+		return nil, false, err
+	}
+	limit := maxBytes
+	if limit < math.MaxInt64 {
+		limit++
+	}
+	data, readErr := io.ReadAll(io.LimitReader(file, limit))
+	closeErr := file.Close()
+	if readErr != nil {
+		return nil, false, readErr
+	}
+	if closeErr != nil {
+		return nil, false, closeErr
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, true, nil
+	}
+	return data, false, nil
+}
+
+func pathEscapesRoot(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "path escapes from parent")
+}
+
+func safeRelativePath(path string) bool {
+	if path == "" || filepath.IsAbs(filepath.FromSlash(path)) {
+		return false
+	}
+	clean := filepath.ToSlash(filepath.Clean(filepath.FromSlash(path)))
+	return clean != ".." && !strings.HasPrefix(clean, "../")
+}
+
+func languageForPath(path string) string {
+	base := strings.ToLower(filepath.Base(path))
+	switch base {
+	case "dockerfile":
+		return "dockerfile"
+	case "makefile":
+		return "makefile"
+	}
+	ext := strings.TrimPrefix(strings.ToLower(filepath.Ext(path)), ".")
+	if ext == "" {
+		return "text"
+	}
+	return ext
+}
+
+func gitText(ctx context.Context, dir string, args ...string) (string, error) {
+	out, err := gitBytes(ctx, dir, args...)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func gitBytes(ctx context.Context, dir string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("git %s failed: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}

--- a/internal/codeindex/indexer_test.go
+++ b/internal/codeindex/indexer_test.go
@@ -1,0 +1,174 @@
+package codeindex
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestScanIndexesTrackedTextAndSkipsUnsafeContent(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	runGit(t, root, "init", "-b", "main")
+	writeFile(t, filepath.Join(root, "cmd", "main.go"), "package main\n")
+	writeFile(t, filepath.Join(root, "README.md"), "readme")
+	writeFile(t, filepath.Join(root, "large.txt"), "0123456789")
+	if err := os.WriteFile(filepath.Join(root, "binary.dat"), []byte{'a', 0, 'b'}, 0o600); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+	if err := os.Symlink("README.md", filepath.Join(root, "linked.md")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	runGit(t, root, "add", ".")
+	runGit(t, root, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed")
+
+	result, err := Scan(ctx, Options{Path: root, MaxFileBytes: 8, MaxFiles: 10})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if result.GitSHA == "" || result.WorktreeDirty {
+		t.Fatalf("snapshot metadata = %#v", result)
+	}
+	if result.FilesSeen != 5 || result.FilesIndexed != 1 || result.SkippedLarge != 2 || result.SkippedBinary != 1 || result.SkippedNonRegular != 1 {
+		t.Fatalf("scan stats = %#v", result)
+	}
+	if got := result.Documents[0]; got.Path != "README.md" || got.Language != "md" || got.ContentHash == "" {
+		t.Fatalf("document = %#v", got)
+	}
+
+	writeFile(t, filepath.Join(root, "README.md"), "# Dirty\n")
+	result, err = Scan(ctx, Options{Path: root, MaxFileBytes: 1024, MaxFiles: 10})
+	if err != nil {
+		t.Fatalf("dirty scan: %v", err)
+	}
+	if !result.WorktreeDirty {
+		t.Fatal("dirty worktree was not reported")
+	}
+}
+
+func TestScanRejectsFileLimit(t *testing.T) {
+	root := t.TempDir()
+	runGit(t, root, "init", "-b", "main")
+	writeFile(t, filepath.Join(root, "a.txt"), "a")
+	writeFile(t, filepath.Join(root, "b.txt"), "b")
+	runGit(t, root, "add", ".")
+	runGit(t, root, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed")
+
+	if _, err := Scan(context.Background(), Options{Path: root, MaxFiles: 1}); err == nil {
+		t.Fatal("file limit unexpectedly accepted")
+	}
+	if _, err := Scan(context.Background(), Options{Path: root, MaxTotalBytes: 1}); err == nil {
+		t.Fatal("total byte limit unexpectedly accepted")
+	}
+}
+
+func TestScanSkipsTrackedFilesMissingFromWorktree(t *testing.T) {
+	root := t.TempDir()
+	runGit(t, root, "init", "-b", "main")
+	writeFile(t, filepath.Join(root, "present.txt"), "present")
+	writeFile(t, filepath.Join(root, "deleted.txt"), "deleted")
+	runGit(t, root, "add", ".")
+	runGit(t, root, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed")
+	if err := os.Remove(filepath.Join(root, "deleted.txt")); err != nil {
+		t.Fatalf("remove tracked file: %v", err)
+	}
+
+	result, err := Scan(context.Background(), Options{Path: root})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if !result.WorktreeDirty || result.FilesSeen != 2 || result.FilesIndexed != 1 || result.SkippedMissing != 1 {
+		t.Fatalf("scan stats = %#v", result)
+	}
+	if got := result.Documents[0].Path; got != "present.txt" {
+		t.Fatalf("indexed path = %q", got)
+	}
+}
+
+func TestScanSkipsTrackedPathsEscapingThroughSymlinkedDirectory(t *testing.T) {
+	root := t.TempDir()
+	runGit(t, root, "init", "-b", "main")
+	trackedDir := filepath.Join(root, "vendor")
+	writeFile(t, filepath.Join(trackedDir, "config.txt"), "tracked")
+	runGit(t, root, "add", ".")
+	runGit(t, root, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed")
+
+	external := t.TempDir()
+	writeFile(t, filepath.Join(external, "config.txt"), "external secret")
+	if err := os.RemoveAll(trackedDir); err != nil {
+		t.Fatalf("remove tracked directory: %v", err)
+	}
+	if err := os.Symlink(external, trackedDir); err != nil {
+		t.Fatalf("replace tracked directory with symlink: %v", err)
+	}
+
+	result, err := Scan(context.Background(), Options{Path: root})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if result.FilesSeen != 1 || result.FilesIndexed != 0 || result.SkippedOutsideRoot != 1 {
+		t.Fatalf("scan stats = %#v", result)
+	}
+}
+
+func TestReadFileAtMostBoundsBytesRead(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "growing.txt")
+	writeFile(t, path, "0123456789")
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatalf("open root: %v", err)
+	}
+	defer root.Close()
+	data, tooLarge, err := readFileAtMost(root, "growing.txt", 4)
+	if err != nil {
+		t.Fatalf("read bounded file: %v", err)
+	}
+	if !tooLarge || data != nil {
+		t.Fatalf("bounded read = %q, tooLarge=%v", data, tooLarge)
+	}
+}
+
+func TestScanSkipsGitlinkReplacedByRegularFile(t *testing.T) {
+	root := t.TempDir()
+	runGit(t, root, "init", "-b", "main")
+	writeFile(t, filepath.Join(root, "README.md"), "readme")
+	runGit(t, root, "add", ".")
+	runGit(t, root, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed")
+	head, err := gitText(context.Background(), root, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+	runGit(t, root, "update-index", "--add", "--cacheinfo", "160000", head, "submodule")
+	runGit(t, root, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "add gitlink")
+	writeFile(t, filepath.Join(root, "submodule"), "not tracked blob content")
+
+	result, err := Scan(context.Background(), Options{Path: root})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if result.FilesSeen != 2 || result.FilesIndexed != 1 || result.SkippedNonRegular != 1 {
+		t.Fatalf("scan stats = %#v", result)
+	}
+	if result.Documents[0].Path != "README.md" {
+		t.Fatalf("documents = %#v", result.Documents)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	if _, err := gitBytes(context.Background(), dir, args...); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/codeindex/indexer_test.go
+++ b/internal/codeindex/indexer_test.go
@@ -63,6 +63,44 @@ func TestScanRejectsFileLimit(t *testing.T) {
 	}
 }
 
+func TestScanRejectsNonRepository(t *testing.T) {
+	if _, err := Scan(context.Background(), Options{Path: t.TempDir()}); err == nil {
+		t.Fatal("non-repository scan unexpectedly succeeded")
+	}
+}
+
+func TestScanRejectsRepositoryWithoutCommit(t *testing.T) {
+	root := t.TempDir()
+	runGit(t, root, "init", "-b", "main")
+	if _, err := Scan(context.Background(), Options{Path: root}); err == nil {
+		t.Fatal("repository without HEAD unexpectedly succeeded")
+	}
+}
+
+func TestScanDefaultsToCurrentDirectory(t *testing.T) {
+	root := t.TempDir()
+	runGit(t, root, "init", "-b", "main")
+	writeFile(t, filepath.Join(root, "README.md"), "readme")
+	runGit(t, root, "add", ".")
+	runGit(t, root, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed")
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer os.Chdir(previous)
+
+	result, err := Scan(context.Background(), Options{})
+	if err != nil {
+		t.Fatalf("scan current directory: %v", err)
+	}
+	if result.FilesIndexed != 1 || result.Documents[0].Path != "README.md" {
+		t.Fatalf("scan result = %#v", result)
+	}
+}
+
 func TestScanSkipsTrackedFilesMissingFromWorktree(t *testing.T) {
 	root := t.TempDir()
 	runGit(t, root, "init", "-b", "main")
@@ -128,6 +166,9 @@ func TestReadFileAtMostBoundsBytesRead(t *testing.T) {
 	if !tooLarge || data != nil {
 		t.Fatalf("bounded read = %q, tooLarge=%v", data, tooLarge)
 	}
+	if _, _, err := readFileAtMost(root, "missing.txt", 4); !os.IsNotExist(err) {
+		t.Fatalf("missing bounded read error = %v", err)
+	}
 }
 
 func TestScanSkipsGitlinkReplacedByRegularFile(t *testing.T) {
@@ -153,6 +194,24 @@ func TestScanSkipsGitlinkReplacedByRegularFile(t *testing.T) {
 	}
 	if result.Documents[0].Path != "README.md" {
 		t.Fatalf("documents = %#v", result.Documents)
+	}
+}
+
+func TestPathAndLanguageClassification(t *testing.T) {
+	for _, path := range []string{"", "..", "../outside", "/absolute"} {
+		if safeRelativePath(path) {
+			t.Fatalf("unsafe path accepted: %q", path)
+		}
+	}
+	for path, want := range map[string]string{
+		"Dockerfile": "dockerfile",
+		"Makefile":   "makefile",
+		"LICENSE":    "text",
+		"main.GO":    "go",
+	} {
+		if got := languageForPath(path); got != want {
+			t.Fatalf("languageForPath(%q) = %q, want %q", path, got, want)
+		}
 	}
 }
 

--- a/internal/documents/builder.go
+++ b/internal/documents/builder.go
@@ -3,6 +3,7 @@ package documents
 import (
 	"encoding/json"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/openclaw/gitcrawl/internal/store"
@@ -10,11 +11,20 @@ import (
 
 var whitespacePattern = regexp.MustCompile(`\s+`)
 
+const (
+	maxChangedFilePaths = 200
+	maxCommitSubjects   = 100
+)
+
 func Build(thread store.Thread) store.Document {
 	return BuildWithComments(thread, nil)
 }
 
 func BuildWithComments(thread store.Thread, comments []store.Comment) store.Document {
+	return BuildWithContext(thread, comments, nil, nil)
+}
+
+func BuildWithContext(thread store.Thread, comments []store.Comment, files []store.PullRequestFile, commits []store.PullRequestCommit) store.Document {
 	labels := labelNames(thread.LabelsJSON)
 	sections := []string{
 		"# " + thread.Title,
@@ -31,6 +41,14 @@ func BuildWithComments(thread store.Thread, comments []store.Comment) store.Docu
 		}
 		sections = append(sections, comment.AuthorLogin+": "+strings.TrimSpace(comment.Body))
 	}
+	changedPaths := changedFilePaths(files)
+	if len(changedPaths) > 0 {
+		sections = append(sections, "Changed files:\n- "+strings.Join(changedPaths, "\n- "))
+	}
+	commitSubjects := pullCommitSubjects(commits)
+	if len(commitSubjects) > 0 {
+		sections = append(sections, "Commits:\n- "+strings.Join(commitSubjects, "\n- "))
+	}
 	rawText := strings.Join(sections, "\n\n")
 	dedupeParts := []string{thread.Title, thread.Body, strings.Join(labels, " ")}
 	for _, comment := range comments {
@@ -39,6 +57,8 @@ func BuildWithComments(thread store.Thread, comments []store.Comment) store.Docu
 		}
 		dedupeParts = append(dedupeParts, comment.Body)
 	}
+	dedupeParts = append(dedupeParts, changedPaths...)
+	dedupeParts = append(dedupeParts, commitSubjects...)
 	return store.Document{
 		ThreadID:   thread.ID,
 		Title:      thread.Title,
@@ -47,6 +67,46 @@ func BuildWithComments(thread store.Thread, comments []store.Comment) store.Docu
 		DedupeText: normalizeDedupe(strings.Join(dedupeParts, " ")),
 		UpdatedAt:  thread.UpdatedAt,
 	}
+}
+
+func changedFilePaths(files []store.PullRequestFile) []string {
+	paths := make([]string, 0, min(len(files), maxChangedFilePaths))
+	seen := make(map[string]bool, len(files))
+	for _, file := range files {
+		for _, path := range []string{file.Path, file.PreviousPath} {
+			path = strings.TrimSpace(path)
+			if path == "" || seen[path] {
+				continue
+			}
+			seen[path] = true
+			paths = append(paths, path)
+		}
+	}
+	sort.Strings(paths)
+	if len(paths) > maxChangedFilePaths {
+		paths = paths[:maxChangedFilePaths]
+	}
+	return paths
+}
+
+func pullCommitSubjects(commits []store.PullRequestCommit) []string {
+	subjects := make([]string, 0, min(len(commits), maxCommitSubjects))
+	for _, commit := range commits {
+		message := strings.TrimSpace(commit.Message)
+		if message == "" {
+			continue
+		}
+		if newline := strings.IndexByte(message, '\n'); newline >= 0 {
+			message = strings.TrimSpace(message[:newline])
+		}
+		if message != "" {
+			subjects = append(subjects, message)
+		}
+		if len(subjects) == maxCommitSubjects {
+			break
+		}
+	}
+	return subjects
 }
 
 func normalizeDedupe(value string) string {

--- a/internal/documents/builder_test.go
+++ b/internal/documents/builder_test.go
@@ -42,3 +42,29 @@ func TestBuildSupportsLegacyStringLabels(t *testing.T) {
 		t.Fatalf("dedupe text: %q", doc.DedupeText)
 	}
 }
+
+func TestBuildIncludesPullRequestPathsAndCommitSubjects(t *testing.T) {
+	doc := BuildWithContext(
+		store.Thread{ID: 8, Title: "Refresh cache", LabelsJSON: "[]"},
+		nil,
+		[]store.PullRequestFile{
+			{Path: "internal/cache/store.go"},
+			{Path: "docs/cache.md", PreviousPath: "docs/old-cache.md"},
+		},
+		[]store.PullRequestCommit{
+			{Message: "fix: refresh manifest cache\n\nLong body"},
+			{Message: "test: cover stale entries"},
+		},
+	)
+	for _, want := range []string{"Changed files:", "internal/cache/store.go", "docs/old-cache.md", "Commits:", "fix: refresh manifest cache"} {
+		if !strings.Contains(doc.RawText, want) {
+			t.Fatalf("raw text missing %q: %s", want, doc.RawText)
+		}
+	}
+	if strings.Contains(doc.RawText, "Long body") {
+		t.Fatalf("commit body leaked into document: %s", doc.RawText)
+	}
+	if !strings.Contains(doc.DedupeText, "internal/cache/store.go") || !strings.Contains(doc.DedupeText, "test: cover stale entries") {
+		t.Fatalf("dedupe text missing pull context: %s", doc.DedupeText)
+	}
+}

--- a/internal/store/code_documents.go
+++ b/internal/store/code_documents.go
@@ -1,0 +1,181 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type CodeSnapshot struct {
+	ID            int64  `json:"id"`
+	RepoID        int64  `json:"repo_id"`
+	SourceRoot    string `json:"source_root"`
+	GitSHA        string `json:"git_sha"`
+	WorktreeDirty bool   `json:"worktree_dirty"`
+	FileCount     int    `json:"file_count"`
+	ByteCount     int64  `json:"byte_count"`
+	IndexedAt     string `json:"indexed_at"`
+}
+
+type CodeDocument struct {
+	ID          int64  `json:"id"`
+	SnapshotID  int64  `json:"snapshot_id"`
+	RepoID      int64  `json:"repo_id"`
+	Path        string `json:"path"`
+	Language    string `json:"language"`
+	ContentHash string `json:"content_hash"`
+	Text        string `json:"text"`
+	ByteSize    int64  `json:"byte_size"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+type CodeSearchHit struct {
+	DocumentID    int64  `json:"document_id"`
+	Path          string `json:"path"`
+	Language      string `json:"language"`
+	Snippet       string `json:"snippet"`
+	GitSHA        string `json:"git_sha"`
+	SourceRoot    string `json:"source_root"`
+	WorktreeDirty bool   `json:"worktree_dirty"`
+}
+
+func (s *Store) ReplaceCodeSnapshot(ctx context.Context, snapshot CodeSnapshot, documents []CodeDocument) (int64, error) {
+	var snapshotID int64
+	err := s.WithTx(ctx, func(tx *Store) error {
+		dirty := 0
+		if snapshot.WorktreeDirty {
+			dirty = 1
+		}
+		err := tx.q().QueryRowContext(ctx, `
+			insert into code_snapshots(repo_id, source_root, git_sha, worktree_dirty, file_count, byte_count, indexed_at)
+			values(?, ?, ?, ?, ?, ?, ?)
+			returning id
+		`, snapshot.RepoID, snapshot.SourceRoot, snapshot.GitSHA, dirty, snapshot.FileCount, snapshot.ByteCount, snapshot.IndexedAt).Scan(&snapshotID)
+		if err != nil {
+			return fmt.Errorf("insert code snapshot: %w", err)
+		}
+		stmt, err := tx.q().PrepareContext(ctx, `
+			insert into code_documents(snapshot_id, repo_id, path, language, content_hash, text_content, byte_size, updated_at)
+			values(?, ?, ?, ?, ?, ?, ?, ?)
+		`)
+		if err != nil {
+			return fmt.Errorf("prepare code document insert: %w", err)
+		}
+		defer stmt.Close()
+		for _, document := range documents {
+			if _, err := stmt.ExecContext(ctx, snapshotID, snapshot.RepoID, document.Path, document.Language, document.ContentHash, document.Text, document.ByteSize, document.UpdatedAt); err != nil {
+				return fmt.Errorf("insert code document %s: %w", document.Path, err)
+			}
+		}
+		if _, err := tx.q().ExecContext(ctx, `delete from code_snapshots where repo_id = ? and id != ?`, snapshot.RepoID, snapshotID); err != nil {
+			return fmt.Errorf("prune old code snapshots: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return snapshotID, nil
+}
+
+func (s *Store) LatestCodeSnapshot(ctx context.Context, repoID int64) (CodeSnapshot, error) {
+	if !s.hasTable(ctx, "code_snapshots") {
+		return CodeSnapshot{}, sql.ErrNoRows
+	}
+	var snapshot CodeSnapshot
+	var dirty int
+	err := s.q().QueryRowContext(ctx, `
+		select id, repo_id, source_root, git_sha, worktree_dirty, file_count, byte_count, indexed_at
+		from code_snapshots
+		where repo_id = ?
+		order by indexed_at desc, id desc
+		limit 1
+	`, repoID).Scan(&snapshot.ID, &snapshot.RepoID, &snapshot.SourceRoot, &snapshot.GitSHA, &dirty, &snapshot.FileCount, &snapshot.ByteCount, &snapshot.IndexedAt)
+	if err != nil {
+		return CodeSnapshot{}, err
+	}
+	snapshot.WorktreeDirty = dirty != 0
+	return snapshot, nil
+}
+
+func (s *Store) SearchCodeDocuments(ctx context.Context, repoID int64, query string, limit int) ([]CodeSearchHit, error) {
+	if !s.hasTable(ctx, "code_documents") || !s.hasTable(ctx, "code_documents_fts") {
+		return []CodeSearchHit{}, nil
+	}
+	if limit <= 0 {
+		limit = 20
+	}
+	snapshot, err := s.LatestCodeSnapshot(ctx, repoID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return []CodeSearchHit{}, nil
+		}
+		return nil, fmt.Errorf("latest code snapshot: %w", err)
+	}
+	matchQuery := ftsQuery(query)
+	if matchQuery == "" {
+		return s.searchCodeDocumentsLike(ctx, snapshot, query, limit)
+	}
+	rows, err := s.q().QueryContext(ctx, `
+		select cd.id, cd.path, cd.language,
+			snippet(code_documents_fts, 2, '[', ']', '...', 24)
+		from code_documents_fts
+		join code_documents cd on cd.id = code_documents_fts.rowid
+		where cd.snapshot_id = ? and code_documents_fts match ?
+		order by bm25(code_documents_fts)
+		limit ?
+	`, snapshot.ID, matchQuery, limit)
+	if err != nil {
+		return s.searchCodeDocumentsLike(ctx, snapshot, query, limit)
+	}
+	defer rows.Close()
+	hits, err := scanCodeSearchHits(rows, snapshot)
+	if err != nil {
+		return nil, err
+	}
+	if len(hits) == 0 {
+		return s.searchCodeDocumentsLike(ctx, snapshot, query, limit)
+	}
+	return hits, nil
+}
+
+func (s *Store) searchCodeDocumentsLike(ctx context.Context, snapshot CodeSnapshot, query string, limit int) ([]CodeSearchHit, error) {
+	needle := strings.TrimSpace(strings.ToLower(query))
+	if needle == "" {
+		return []CodeSearchHit{}, nil
+	}
+	pattern := "%" + escapeLike(needle) + "%"
+	rows, err := s.q().QueryContext(ctx, `
+		select id, path, language, substr(text_content, 1, 320)
+		from code_documents
+		where snapshot_id = ?
+		  and (lower(path) like ? escape '\' or lower(text_content) like ? escape '\')
+		order by path
+		limit ?
+	`, snapshot.ID, pattern, pattern, limit)
+	if err != nil {
+		return nil, fmt.Errorf("search code documents: %w", err)
+	}
+	defer rows.Close()
+	return scanCodeSearchHits(rows, snapshot)
+}
+
+func scanCodeSearchHits(rows *sql.Rows, snapshot CodeSnapshot) ([]CodeSearchHit, error) {
+	out := make([]CodeSearchHit, 0)
+	for rows.Next() {
+		var hit CodeSearchHit
+		if err := rows.Scan(&hit.DocumentID, &hit.Path, &hit.Language, &hit.Snippet); err != nil {
+			return nil, fmt.Errorf("scan code search hit: %w", err)
+		}
+		hit.GitSHA = snapshot.GitSHA
+		hit.SourceRoot = snapshot.SourceRoot
+		hit.WorktreeDirty = snapshot.WorktreeDirty
+		out = append(out, hit)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate code search hits: %w", err)
+	}
+	return out, nil
+}

--- a/internal/store/code_documents_test.go
+++ b/internal/store/code_documents_test.go
@@ -1,0 +1,106 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestReplaceAndSearchCodeSnapshot(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	repoID, err := st.UpsertRepository(ctx, Repository{Owner: "openclaw", Name: "gitcrawl", FullName: "openclaw/gitcrawl", RawJSON: "{}", UpdatedAt: "2026-06-06T00:00:00Z"})
+	if err != nil {
+		t.Fatalf("repo: %v", err)
+	}
+	snapshotID, err := st.ReplaceCodeSnapshot(ctx, CodeSnapshot{
+		RepoID: repoID, SourceRoot: "/tmp/gitcrawl", GitSHA: "abc", WorktreeDirty: true,
+		FileCount: 2, ByteCount: 40, IndexedAt: "2026-06-06T00:00:00Z",
+	}, []CodeDocument{
+		{Path: "internal/cache/store.go", Language: "go", ContentHash: "h1", Text: "package cache\nfunc RefreshManifest() {}", ByteSize: 39, UpdatedAt: "2026-06-06T00:00:00Z"},
+		{Path: "README.md", Language: "md", ContentHash: "h2", Text: "local archive", ByteSize: 13, UpdatedAt: "2026-06-06T00:00:00Z"},
+	})
+	if err != nil {
+		t.Fatalf("replace snapshot: %v", err)
+	}
+	hits, err := st.SearchCodeDocuments(ctx, repoID, "RefreshManifest", 10)
+	if err != nil {
+		t.Fatalf("search code: %v", err)
+	}
+	if len(hits) != 1 || hits[0].Path != "internal/cache/store.go" || hits[0].GitSHA != "abc" || !hits[0].WorktreeDirty {
+		t.Fatalf("hits = %#v", hits)
+	}
+
+	replacementID, err := st.ReplaceCodeSnapshot(ctx, CodeSnapshot{
+		RepoID: repoID, SourceRoot: "/tmp/gitcrawl", GitSHA: "abc",
+		FileCount: 1, ByteCount: 12, IndexedAt: "2026-06-06T01:00:00Z",
+	}, []CodeDocument{{Path: "new.go", Language: "go", ContentHash: "h3", Text: "package fresh", ByteSize: 13, UpdatedAt: "2026-06-06T01:00:00Z"}})
+	if err != nil {
+		t.Fatalf("replace newer snapshot: %v", err)
+	}
+	if replacementID == snapshotID {
+		t.Fatal("same-commit re-index reused old snapshot id")
+	}
+	oldHits, err := st.SearchCodeDocuments(ctx, repoID, "RefreshManifest", 10)
+	if err != nil {
+		t.Fatalf("search old code: %v", err)
+	}
+	if len(oldHits) != 0 {
+		t.Fatalf("old snapshot still searchable: %#v", oldHits)
+	}
+	var snapshots int
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from code_snapshots where repo_id = ?`, repoID).Scan(&snapshots); err != nil {
+		t.Fatalf("count snapshots: %v", err)
+	}
+	if snapshots != 1 {
+		t.Fatalf("snapshot count = %d, want 1", snapshots)
+	}
+
+	if _, err := st.ReplaceCodeSnapshot(ctx, CodeSnapshot{
+		RepoID: repoID, SourceRoot: "/tmp/gitcrawl", GitSHA: "abc",
+		FileCount: 2, ByteCount: 20, IndexedAt: "2026-06-06T02:00:00Z",
+	}, []CodeDocument{
+		{Path: "duplicate.go", Language: "go", ContentHash: "h4", Text: "package duplicate", ByteSize: 17, UpdatedAt: "2026-06-06T02:00:00Z"},
+		{Path: "duplicate.go", Language: "go", ContentHash: "h5", Text: "package broken", ByteSize: 14, UpdatedAt: "2026-06-06T02:00:00Z"},
+	}); err == nil {
+		t.Fatal("invalid replacement unexpectedly succeeded")
+	}
+	hits, err = st.SearchCodeDocuments(ctx, repoID, "package fresh", 10)
+	if err != nil {
+		t.Fatalf("search after failed replacement: %v", err)
+	}
+	if len(hits) != 1 || hits[0].Path != "new.go" {
+		t.Fatalf("failed replacement discarded prior snapshot: %#v", hits)
+	}
+}
+
+func TestPortablePruneDropsCodeCorpus(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	repoID, err := st.UpsertRepository(ctx, Repository{Owner: "openclaw", Name: "gitcrawl", FullName: "openclaw/gitcrawl", RawJSON: "{}", UpdatedAt: "2026-06-06T00:00:00Z"})
+	if err != nil {
+		t.Fatalf("repo: %v", err)
+	}
+	if _, err := st.ReplaceCodeSnapshot(ctx, CodeSnapshot{
+		RepoID: repoID, SourceRoot: "/private/repo", GitSHA: "abc",
+		FileCount: 1, ByteCount: 6, IndexedAt: "2026-06-06T00:00:00Z",
+	}, []CodeDocument{{Path: "secret.txt", Language: "txt", ContentHash: "h", Text: "secret", ByteSize: 6, UpdatedAt: "2026-06-06T00:00:00Z"}}); err != nil {
+		t.Fatalf("replace snapshot: %v", err)
+	}
+	if _, err := st.PrunePortablePayloads(ctx, PortablePruneOptions{BodyChars: 64}); err != nil {
+		t.Fatalf("portable prune: %v", err)
+	}
+	for _, table := range []string{"code_snapshots", "code_documents", "code_documents_fts"} {
+		if st.tableExists(ctx, table) {
+			t.Fatalf("portable prune retained %s", table)
+		}
+	}
+}

--- a/internal/store/code_documents_test.go
+++ b/internal/store/code_documents_test.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"path/filepath"
 	"testing"
 )
@@ -101,6 +103,51 @@ func TestPortablePruneDropsCodeCorpus(t *testing.T) {
 	for _, table := range []string{"code_snapshots", "code_documents", "code_documents_fts"} {
 		if st.tableExists(ctx, table) {
 			t.Fatalf("portable prune retained %s", table)
+		}
+	}
+	hits, err := st.SearchCodeDocuments(ctx, repoID, "secret", 10)
+	if err != nil {
+		t.Fatalf("search pruned code corpus: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("pruned code hits = %#v", hits)
+	}
+	if _, err := st.LatestCodeSnapshot(ctx, repoID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("latest pruned snapshot error = %v", err)
+	}
+}
+
+func TestSearchCodeDocumentsHandlesEmptyStates(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	repoID, err := st.UpsertRepository(ctx, Repository{Owner: "openclaw", Name: "gitcrawl", FullName: "openclaw/gitcrawl", RawJSON: "{}", UpdatedAt: "2026-06-06T00:00:00Z"})
+	if err != nil {
+		t.Fatalf("repo: %v", err)
+	}
+	hits, err := st.SearchCodeDocuments(ctx, repoID, "missing", 0)
+	if err != nil {
+		t.Fatalf("search unindexed code: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("unindexed code hits = %#v", hits)
+	}
+	if _, err := st.ReplaceCodeSnapshot(ctx, CodeSnapshot{
+		RepoID: repoID, SourceRoot: "/tmp/gitcrawl", GitSHA: "abc",
+		FileCount: 1, ByteCount: 12, IndexedAt: "2026-06-06T00:00:00Z",
+	}, []CodeDocument{{Path: "README.md", Language: "md", ContentHash: "h", Text: "local archive", ByteSize: 13, UpdatedAt: "2026-06-06T00:00:00Z"}}); err != nil {
+		t.Fatalf("replace snapshot: %v", err)
+	}
+	for _, query := range []string{"", "not-present"} {
+		hits, err := st.SearchCodeDocuments(ctx, repoID, query, 0)
+		if err != nil {
+			t.Fatalf("search %q: %v", query, err)
+		}
+		if len(hits) != 0 {
+			t.Fatalf("search %q hits = %#v", query, hits)
 		}
 	}
 }

--- a/internal/store/coverage_test.go
+++ b/internal/store/coverage_test.go
@@ -164,7 +164,7 @@ func TestEmbeddingTasksSkipExistingHashAndForce(t *testing.T) {
 	}
 	defer st.Close()
 	repoID, threadIDs := seedVectorThreads(t, ctx, st)
-	text := "First vector thread\n\nalpha body"
+	text := "First vector thread\nalpha body"
 	hash := embeddingContentHash("title_original", "test", text)
 	if err := st.UpsertThreadVector(ctx, ThreadVector{ThreadID: threadIDs[0], Basis: "title_original", Model: "test", Dimensions: 2, ContentHash: hash, Vector: []float64{1, 0}, CreatedAt: "2026-04-30T00:00:00Z", UpdatedAt: "2026-04-30T00:00:00Z"}); err != nil {
 		t.Fatalf("upsert existing vector: %v", err)

--- a/internal/store/documents.go
+++ b/internal/store/documents.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/openclaw/gitcrawl/internal/store/storedb"
@@ -26,6 +28,9 @@ func (s *Store) UpsertDocument(ctx context.Context, doc Document) (int64, error)
 		DedupeText: doc.DedupeText,
 		UpdatedAt:  doc.UpdatedAt,
 	})
+	if errors.Is(err, sql.ErrNoRows) {
+		err = s.q().QueryRowContext(ctx, `select id from documents where thread_id = ?`, doc.ThreadID).Scan(&id)
+	}
 	if err != nil {
 		return 0, fmt.Errorf("upsert document: %w", err)
 	}

--- a/internal/store/documents_test.go
+++ b/internal/store/documents_test.go
@@ -43,4 +43,21 @@ func TestUpsertDocumentIndexesFTS(t *testing.T) {
 	if count != 1 {
 		t.Fatalf("fts count: got %d want 1", count)
 	}
+
+	if _, err := st.UpsertDocument(ctx, Document{
+		ThreadID:   threadID,
+		Title:      "download stalls",
+		RawText:    "download stalls on large files",
+		DedupeText: "download stalls large files",
+		UpdatedAt:  "2026-04-26T01:00:00Z",
+	}); err != nil {
+		t.Fatalf("unchanged document: %v", err)
+	}
+	var updatedAt string
+	if err := st.DB().QueryRowContext(ctx, `select updated_at from documents where thread_id = ?`, threadID).Scan(&updatedAt); err != nil {
+		t.Fatalf("document timestamp: %v", err)
+	}
+	if updatedAt != "2026-04-26T00:00:00Z" {
+		t.Fatalf("unchanged document updated_at = %q", updatedAt)
+	}
 }

--- a/internal/store/embedding_tasks.go
+++ b/internal/store/embedding_tasks.go
@@ -35,7 +35,7 @@ type EmbeddingTaskOptions struct {
 const (
 	MaxEmbeddingTextRunes       = 6_000
 	MaxEmbeddingTextBytes       = 7_000
-	embeddingContentHashVersion = "embedding:v4"
+	embeddingContentHashVersion = "embedding:v5"
 )
 
 func (s *Store) ListEmbeddingTasks(ctx context.Context, options EmbeddingTaskOptions) ([]EmbeddingTask, error) {
@@ -112,13 +112,15 @@ func embeddingTextForBasisWithMeta(basis, title, body, rawText, dedupeText, keyS
 	var text string
 	switch basis {
 	case "", "title_original":
-		parts := []string{strings.TrimSpace(title)}
-		if strings.TrimSpace(body) != "" {
-			parts = append(parts, strings.TrimSpace(body))
-		} else if strings.TrimSpace(rawText) != "" {
-			parts = append(parts, strings.TrimSpace(rawText))
+		if strings.TrimSpace(rawText) != "" {
+			text = strings.TrimSpace(rawText)
+		} else {
+			parts := []string{strings.TrimSpace(title)}
+			if strings.TrimSpace(body) != "" {
+				parts = append(parts, strings.TrimSpace(body))
+			}
+			text = strings.TrimSpace(strings.Join(parts, "\n\n"))
 		}
-		text = strings.TrimSpace(strings.Join(parts, "\n\n"))
 	case "dedupe_text":
 		text = strings.TrimSpace(dedupeText)
 	case "llm_key_summary":

--- a/internal/store/embedding_tasks_test.go
+++ b/internal/store/embedding_tasks_test.go
@@ -90,6 +90,17 @@ func TestEmbeddingTextForBasisCapsLongInputs(t *testing.T) {
 	}
 }
 
+func TestTitleOriginalEmbeddingPrefersCanonicalDocumentText(t *testing.T) {
+	rawText := "# Refresh cache\n\nOriginal body\n\nChanged files:\n- internal/cache/store.go\n\nCommits:\n- fix: refresh manifest"
+	text, err := embeddingTextForBasis("title_original", "Refresh cache", "Original body", rawText, "", "")
+	if err != nil {
+		t.Fatalf("embedding text: %v", err)
+	}
+	if text != rawText {
+		t.Fatalf("embedding text = %q, want canonical document", text)
+	}
+}
+
 func TestEmbeddingTextForBasisCapsTokenDenseInputsByBytes(t *testing.T) {
 	body := strings.Repeat("界", MaxEmbeddingTextRunes)
 	text, meta, err := embeddingTextForBasisWithMeta("title_original", "oversized unicode", body, "", "", "")

--- a/internal/store/embedding_tasks_test.go
+++ b/internal/store/embedding_tasks_test.go
@@ -140,6 +140,17 @@ func TestEmbeddingContentHashVersionTracksCurrentInputCaps(t *testing.T) {
 	}
 }
 
+func TestSupportsEmbeddingBasis(t *testing.T) {
+	for _, basis := range []string{"", "title_original", "dedupe_text", "llm_key_summary"} {
+		if !SupportsEmbeddingBasis(basis) {
+			t.Fatalf("supported basis rejected: %q", basis)
+		}
+	}
+	if SupportsEmbeddingBasis("missing") {
+		t.Fatal("unsupported basis accepted")
+	}
+}
+
 func TestListEmbeddingTasksIncludeClosed(t *testing.T) {
 	ctx := context.Background()
 	st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))

--- a/internal/store/portable.go
+++ b/internal/store/portable.go
@@ -200,7 +200,7 @@ func (s *Store) canonicalizePortableSchema(ctx context.Context, bodyChars int, s
 		"body_chars":   fmt.Sprintf("%d", bodyChars),
 		"capabilities": "body_excerpts,comment_excerpts,pr_details,pr_files,pr_commits,pr_checks,pr_review_threads,workflow_runs,raw_json_stripped",
 		"includes":     "repositories,threads,comments,pull_request_details,pull_request_files,pull_request_commits,pull_request_checks,pull_request_review_threads,pull_request_review_thread_syncs,github_workflow_runs,thread_fingerprints",
-		"excluded":     "raw_json,documents,fts,vectors,code_snapshots,cluster_events,run_history,similarity_edges,blobs",
+		"excluded":     "raw_json,documents,fts,vectors,code_snapshots,code_documents,cluster_events,run_history,similarity_edges,blobs",
 		"exported_at":  time.Now().UTC().Format(timeLayout),
 		"source_path":  s.path,
 	}
@@ -272,6 +272,13 @@ func (s *Store) clearPortableRawJSON(ctx context.Context) (int64, error) {
 
 func canonicalPortableDroppedTables() []string {
 	return []string{
+		"code_documents_fts",
+		"code_documents_fts_config",
+		"code_documents_fts_data",
+		"code_documents_fts_docsize",
+		"code_documents_fts_idx",
+		"code_documents",
+		"code_snapshots",
 		"documents_fts",
 		"documents_fts_config",
 		"documents_fts_data",

--- a/internal/store/pull_requests.go
+++ b/internal/store/pull_requests.go
@@ -97,6 +97,20 @@ func (s *Store) UpsertPullRequestCache(ctx context.Context, detail PullRequestDe
 	})
 }
 
+func (s *Store) UpsertPullRequestCacheAndDocument(ctx context.Context, detail PullRequestDetail, files []PullRequestFile, commits []PullRequestCommit, checks []PullRequestCheck, runs []WorkflowRun, document Document) error {
+	persist := func(st *Store) error {
+		if err := st.upsertPullRequestCache(ctx, detail, files, commits, checks, runs); err != nil {
+			return err
+		}
+		_, err := st.UpsertDocument(ctx, document)
+		return err
+	}
+	if s.queries == nil {
+		return s.WithTx(ctx, persist)
+	}
+	return persist(s)
+}
+
 func (s *Store) upsertPullRequestCache(ctx context.Context, detail PullRequestDetail, files []PullRequestFile, commits []PullRequestCommit, checks []PullRequestCheck, runs []WorkflowRun) error {
 	if err := s.qsql().UpsertPullRequestDetail(ctx, storedb.UpsertPullRequestDetailParams{
 		ThreadID:         detail.ThreadID,

--- a/internal/store/pull_requests_test.go
+++ b/internal/store/pull_requests_test.go
@@ -92,3 +92,38 @@ func TestPullRequestCacheRoundTripAndWorkflowFilters(t *testing.T) {
 		t.Fatalf("updated cache = %+v", cache)
 	}
 }
+
+func TestPullRequestCacheAndDocumentRollsBackTogether(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	repoID, threadIDs := seedVectorThreads(t, ctx, st)
+	threadID := threadIDs[1]
+	err = st.UpsertPullRequestCacheAndDocument(ctx,
+		PullRequestDetail{
+			ThreadID: threadID, RepoID: repoID, Number: 302,
+			RawJSON: "{}", FetchedAt: "2026-05-05T10:00:00Z", UpdatedAt: "2026-05-05T10:00:00Z",
+		},
+		[]PullRequestFile{{ThreadID: threadID, Path: "cache.go", RawJSON: "{}", FetchedAt: "2026-05-05T10:00:00Z"}},
+		nil, nil, nil,
+		Document{
+			ThreadID: threadID + 999, Title: "invalid", RawText: "invalid",
+			DedupeText: "invalid", UpdatedAt: "2026-05-05T10:00:00Z",
+		},
+	)
+	if err == nil {
+		t.Fatal("invalid document unexpectedly succeeded")
+	}
+	for _, table := range []string{"pull_request_details", "pull_request_files"} {
+		var count int
+		if err := st.DB().QueryRowContext(ctx, `select count(*) from `+table+` where thread_id = ?`, threadID).Scan(&count); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		if count != 0 {
+			t.Fatalf("%s rows after rollback = %d", table, count)
+		}
+	}
+}

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -264,6 +264,55 @@ create trigger if not exists documents_au after update on documents begin
   values (new.id, new.title, new.body, new.raw_text, new.dedupe_text);
 end;
 
+create table if not exists code_snapshots (
+  id integer primary key,
+  repo_id integer not null references repositories(id) on delete cascade,
+  source_root text not null,
+  git_sha text not null,
+  worktree_dirty integer not null default 0,
+  file_count integer not null,
+  byte_count integer not null,
+  indexed_at text not null
+);
+
+create table if not exists code_documents (
+  id integer primary key,
+  snapshot_id integer not null references code_snapshots(id) on delete cascade,
+  repo_id integer not null references repositories(id) on delete cascade,
+  path text not null,
+  language text not null,
+  content_hash text not null,
+  text_content text not null,
+  byte_size integer not null,
+  updated_at text not null,
+  unique(snapshot_id, path)
+);
+
+create virtual table if not exists code_documents_fts using fts5(
+  path,
+  language,
+  text_content,
+  content='code_documents',
+  content_rowid='id'
+);
+
+create trigger if not exists code_documents_ai after insert on code_documents begin
+  insert into code_documents_fts(rowid, path, language, text_content)
+  values (new.id, new.path, new.language, new.text_content);
+end;
+
+create trigger if not exists code_documents_ad after delete on code_documents begin
+  insert into code_documents_fts(code_documents_fts, rowid, path, language, text_content)
+  values ('delete', old.id, old.path, old.language, old.text_content);
+end;
+
+create trigger if not exists code_documents_au after update on code_documents begin
+  insert into code_documents_fts(code_documents_fts, rowid, path, language, text_content)
+  values ('delete', old.id, old.path, old.language, old.text_content);
+  insert into code_documents_fts(rowid, path, language, text_content)
+  values (new.id, new.path, new.language, new.text_content);
+end;
+
 create table if not exists document_summaries (
   id integer primary key,
   thread_id integer not null references threads(id) on delete cascade,
@@ -505,6 +554,8 @@ create index if not exists idx_pull_request_review_threads_thread_resolved on pu
 create index if not exists idx_pull_request_review_thread_syncs_fetched on pull_request_review_thread_syncs(fetched_at);
 create index if not exists idx_github_workflow_runs_repo_branch on github_workflow_runs(repo_id, head_branch, run_id);
 create index if not exists idx_github_workflow_runs_repo_sha on github_workflow_runs(repo_id, head_sha, run_id);
+create index if not exists idx_code_snapshots_repo_indexed on code_snapshots(repo_id, indexed_at, id);
+create index if not exists idx_code_documents_repo_path on code_documents(repo_id, path);
 create index if not exists idx_thread_fingerprints_hash on thread_fingerprints(fingerprint_hash);
 create index if not exists idx_thread_vectors_basis_model on thread_vectors(basis, model);
 create index if not exists idx_sync_runs_repo_status_id on sync_runs(repo_id, status, id);

--- a/internal/store/sqlc/queries.sql
+++ b/internal/store/sqlc/queries.sql
@@ -156,6 +156,10 @@ on conflict(thread_id) do update set
   raw_text=excluded.raw_text,
   dedupe_text=excluded.dedupe_text,
   updated_at=excluded.updated_at
+where documents.title is not excluded.title
+   or documents.body is not excluded.body
+   or documents.raw_text is not excluded.raw_text
+   or documents.dedupe_text is not excluded.dedupe_text
 returning id;
 
 -- name: ListEmbeddingTasks :many

--- a/internal/store/sqlc/schema.sql
+++ b/internal/store/sqlc/schema.sql
@@ -194,6 +194,30 @@ create table documents (
   updated_at text not null
 );
 
+create table code_snapshots (
+  id integer primary key,
+  repo_id integer not null references repositories(id) on delete cascade,
+  source_root text not null,
+  git_sha text not null,
+  worktree_dirty integer not null default 0,
+  file_count integer not null,
+  byte_count integer not null,
+  indexed_at text not null
+);
+
+create table code_documents (
+  id integer primary key,
+  snapshot_id integer not null references code_snapshots(id) on delete cascade,
+  repo_id integer not null references repositories(id) on delete cascade,
+  path text not null,
+  language text not null,
+  content_hash text not null,
+  text_content text not null,
+  byte_size integer not null,
+  updated_at text not null,
+  unique(snapshot_id, path)
+);
+
 create table thread_vectors (
   thread_id integer not null references threads(id) on delete cascade,
   basis text not null,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	schemaVersion = 2
+	schemaVersion = 3
 	timeLayout    = time.RFC3339Nano
 )
 

--- a/internal/store/storedb/models.go
+++ b/internal/store/storedb/models.go
@@ -45,6 +45,29 @@ type ClusterRun struct {
 	ErrorText  sql.NullString `json:"error_text"`
 }
 
+type CodeDocument struct {
+	ID          int64  `json:"id"`
+	SnapshotID  int64  `json:"snapshot_id"`
+	RepoID      int64  `json:"repo_id"`
+	Path        string `json:"path"`
+	Language    string `json:"language"`
+	ContentHash string `json:"content_hash"`
+	TextContent string `json:"text_content"`
+	ByteSize    int64  `json:"byte_size"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+type CodeSnapshot struct {
+	ID            int64  `json:"id"`
+	RepoID        int64  `json:"repo_id"`
+	SourceRoot    string `json:"source_root"`
+	GitSha        string `json:"git_sha"`
+	WorktreeDirty int64  `json:"worktree_dirty"`
+	FileCount     int64  `json:"file_count"`
+	ByteCount     int64  `json:"byte_count"`
+	IndexedAt     string `json:"indexed_at"`
+}
+
 type Comment struct {
 	ID            int64          `json:"id"`
 	ThreadID      int64          `json:"thread_id"`

--- a/internal/store/storedb/queries.sql.go
+++ b/internal/store/storedb/queries.sql.go
@@ -1324,6 +1324,10 @@ on conflict(thread_id) do update set
   raw_text=excluded.raw_text,
   dedupe_text=excluded.dedupe_text,
   updated_at=excluded.updated_at
+where documents.title is not excluded.title
+   or documents.body is not excluded.body
+   or documents.raw_text is not excluded.raw_text
+   or documents.dedupe_text is not excluded.dedupe_text
 returning id
 `
 

--- a/internal/syncer/pull_details.go
+++ b/internal/syncer/pull_details.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/openclaw/gitcrawl/internal/documents"
 	gh "github.com/openclaw/gitcrawl/internal/github"
 	"github.com/openclaw/gitcrawl/internal/store"
 )
@@ -73,7 +74,12 @@ func (s *Syncer) persistPullRequestDetails(ctx context.Context, st *store.Store,
 	commits := mapPullCommits(thread.ID, rows.commitsRaw, fetchedAt)
 	checks := mapPullChecks(thread.ID, rows.checksRaw, fetchedAt)
 	runs := mapWorkflowRuns(thread.RepoID, rows.runsRaw, fetchedAt)
-	if err := st.UpsertPullRequestCache(ctx, detail, files, commits, checks, runs); err != nil {
+	comments, err := st.ListComments(ctx, thread.ID)
+	if err != nil {
+		return pullDetailStats{}, err
+	}
+	document := documents.BuildWithContext(thread, comments, files, commits)
+	if err := st.UpsertPullRequestCacheAndDocument(ctx, detail, files, commits, checks, runs, document); err != nil {
 		return pullDetailStats{}, err
 	}
 	return pullDetailStats{files: len(files), commits: len(commits), checks: len(checks), runs: len(runs)}, nil

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -249,7 +249,19 @@ func (s *Syncer) Sync(ctx context.Context, options Options) (Stats, error) {
 					attempt.WorkflowRunsSynced += detailStats.runs
 				}
 			}
-			if _, err := st.UpsertDocument(ctx, documents.BuildWithComments(thread, comments)); err != nil {
+			var pullFiles []store.PullRequestFile
+			var pullCommits []store.PullRequestCommit
+			if thread.Kind == "pull_request" {
+				pullFiles, err = st.PullRequestFiles(ctx, thread.ID)
+				if err != nil {
+					return err
+				}
+				pullCommits, err = st.PullRequestCommits(ctx, thread.ID)
+				if err != nil {
+					return err
+				}
+			}
+			if _, err := st.UpsertDocument(ctx, documents.BuildWithContext(thread, comments, pullFiles, pullCommits)); err != nil {
 				return err
 			}
 			attempt.ThreadsSynced++

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -597,6 +597,8 @@ func TestSyncHydratesPullRequestDetails(t *testing.T) {
 	if fetchedAt == "" {
 		t.Fatal("missing review thread sync marker")
 	}
+	assertDocumentFTSCount(t, st, "internal cache", 1)
+	assertDocumentFTSCount(t, st, "feat cache", 1)
 }
 
 func TestPullRequestDetailsUseFetchTimestampWhenPersistedLater(t *testing.T) {
@@ -661,6 +663,8 @@ func TestPullRequestDetailsUseFetchTimestampWhenPersistedLater(t *testing.T) {
 	if len(runs) != 1 || runs[0].FetchedAt != fetchTime {
 		t.Fatalf("run timestamps = %+v, want %q", runs, fetchTime)
 	}
+	assertDocumentFTSCount(t, st, "internal cache", 1)
+	assertDocumentFTSCount(t, st, "feat cache", 1)
 }
 
 func TestSyncPullRequestDetailsFailsOnReviewThreadFetchError(t *testing.T) {


### PR DESCRIPTION
## Summary

- enrich PR thread documents and default embeddings with changed file paths and commit subjects
- add bounded local indexing for tracked monorepo source through `gitcrawl code index`
- add `search --scope threads|code|all` with code kept out of semantic clustering
- exclude local source content from portable stores and cloud SQLite snapshots

## Safety

- scan only stage-0 regular Git blobs through descriptor-relative rooted reads
- bound file count, per-file bytes, and aggregate bytes
- atomically replace successful snapshots while preserving the prior corpus on failure
- reject portable-store runtime mirrors for code indexing

## Verification

- `make generate-sqlc`
- `go test ./...`
- real CLI index/search smoke test
- autoreview clean with no accepted/actionable findings
