### PR TITLE
ci: add deadcode check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,13 @@ jobs:
         run: go vet ./...
 
       - name: Deadcode
-        run: go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...
+        run: |
+          output_file=$(mktemp)
+          go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./... > "$output_file"
+          if [ -s "$output_file" ]; then
+            cat "$output_file"
+            exit 1
+          fi
 
       - name: Test with coverage
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      - name: Deadcode
+        run: go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...
+
       - name: Test with coverage
         run: |
           go test ./... -covermode=atomic -coverprofile=coverage.out

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -265,16 +265,6 @@ func parseKongContext(target any, args []string, name string, stdout, stderr io.
 	return parser.Parse(args)
 }
 
-func selectedKongCommand(ctx *kong.Context) string {
-	var selected string
-	for _, path := range ctx.Path {
-		if path.Command != nil {
-			selected = path.Command.Name
-		}
-	}
-	return selected
-}
-
 func (a *App) runConfigure(args []string) error {
 	fs := flag.NewFlagSet("configure", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)

--- a/internal/cli/gh_path.go
+++ b/internal/cli/gh_path.go
@@ -2,61 +2,12 @@ package cli
 
 import (
 	"crypto/sha256"
-	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 )
-
-func resolveRealGHPath() (string, error) {
-	envPath := strings.TrimSpace(os.Getenv("GITCRAWL_GH_PATH"))
-	candidates := []string{}
-	if envPath != "" {
-		candidates = append(candidates, envPath)
-	}
-	candidates = append(candidates,
-		"/opt/homebrew/opt/gh/bin/gh",
-		"/usr/local/opt/gh/bin/gh",
-		"/usr/local/bin/gh",
-		"/usr/bin/gh",
-	)
-	if lookPath, err := exec.LookPath("gh"); err == nil {
-		candidates = append(candidates, lookPath)
-	}
-
-	seen := map[string]bool{}
-	for _, candidate := range candidates {
-		candidate = strings.TrimSpace(candidate)
-		if candidate == "" || seen[candidate] {
-			continue
-		}
-		seen[candidate] = true
-		info, err := os.Stat(candidate)
-		if err != nil || info.IsDir() {
-			if envPath != "" && candidate == envPath {
-				return "", fmt.Errorf("real gh not found at GITCRAWL_GH_PATH %q", envPath)
-			}
-			continue
-		}
-		if isGitcrawlShimPath(candidate) {
-			if envPath != "" && candidate == envPath {
-				return "", fmt.Errorf("GITCRAWL_GH_PATH points to the gitcrawl shim (%s); set it to the real gh binary", envPath)
-			}
-			continue
-		}
-		if !usableRealGHPath(candidate) {
-			if envPath != "" && candidate == envPath {
-				return "", fmt.Errorf("GITCRAWL_GH_PATH points to the gitcrawl shim (%s); set it to the real gh binary", envPath)
-			}
-			continue
-		}
-		return candidate, nil
-	}
-	return "", fmt.Errorf("real gh not found; set GITCRAWL_GH_PATH")
-}
 
 func isGitcrawlShimPath(path string) bool {
 	if path == "" {

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -431,10 +431,6 @@ func sqliteStoreOpenHealth(ctx context.Context, path string) error {
 	return st.Close()
 }
 
-func sqliteStoreCachedHealth(ctx context.Context, path, statePath string) error {
-	return portableMirrorCachedHealth(ctx, path, "", statePath)
-}
-
 func portableMirrorCachedHealth(ctx context.Context, mirrorPath, sourceDBPath, statePath string) error {
 	manifestModTime, manifestSize, err := portableDBManifestStamp(sourceDBPath)
 	if err != nil {
@@ -469,10 +465,6 @@ func sqliteStoreCachedHealthWithManifest(ctx context.Context, path, sourceDBPath
 		return err
 	}
 	return markSQLiteStoreHealthVerifiedWithManifest(path, statePath, manifestModTime, manifestSize)
-}
-
-func markSQLiteStoreHealthVerified(path, statePath string) error {
-	return markPortableMirrorHealthVerified(path, statePath, "")
 }
 
 func markPortableMirrorHealthVerified(path, statePath, sourceDBPath string) error {


### PR DESCRIPTION
## Summary
- add an enforced Go deadcode CI gate pinned to `golang.org/x/tools/cmd/deadcode@v0.45.0`
- remove unreachable helpers reported by deadcode\n- make the workflow fail when deadcode emits findings

## Validation
- `git diff --check`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `go test -count=1 ./...`
- `go build ./cmd/gitcrawl`
- `autoreview --mode branch --base origin/main --no-web-search --thinking low` clean
