### PR TITLE
docs: add mac resource ops pointer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# gitcrawl Agent Notes
+
+## Mac resource pressure
+
+If work changes local process/session/tooling behavior, read `~/Projects/personal/mac-resource-ops/VISION.md` and `~/Projects/personal/mac-resource-ops/docs/resource-graph.md` first. Prefer bounded commands, lazy loading, explicit cleanup paths, and crabbox/offload for heavy loops. Do not leave new persistent local pressure undocumented.


### PR DESCRIPTION
## Summary

Adds a short `mac-resource-ops` pointer to `AGENTS.md` so future agents check the canonical local resource-pressure docs before changing local process/session/tooling behavior.

## Why

This repo is part of Luke's local agent/runtime/tooling surface. The pointer keeps repo-local instructions small while routing agents to:

- `~/Projects/personal/mac-resource-ops/VISION.md`
- `~/Projects/personal/mac-resource-ops/docs/resource-graph.md`

## Validation

- Diff is limited to `AGENTS.md`.
- `git diff --check -- AGENTS.md` passed before push.
- Pointer presence verified in the pushed branch.

## Notes

No runtime code, config, deploy, or behavior changes.
