### PR TITLE
Use platform-native runtime paths

### DIFF
--- a/.agents/skills/gitcrawl/SKILL.md
+++ b/.agents/skills/gitcrawl/SKILL.md
@@ -11,10 +11,25 @@ requested scope, or the user asks for current external context.
 
 ## Sources
 
-- Config: `~/.config/gitcrawl/config.toml`
-- DB: resolve with `gitcrawl doctor --json`; portable-store installs may point at `~/.config/gitcrawl/stores/gitcrawl-store/data/openclaw__openclaw.sync.db` instead of the default local DB
-- Cache: `~/.config/gitcrawl/cache`
-- Vectors: `~/.config/gitcrawl/vectors`
+- Config: resolve with `gitcrawl doctor --json`; fresh macOS installs default to
+  `~/Library/Application Support/gitcrawl/config.toml`, while Linux honors
+  `${XDG_CONFIG_HOME:-~/.config}/gitcrawl/config.toml`
+- DB: resolve with `gitcrawl doctor --json`; fresh macOS installs default to
+  `~/Library/Application Support/gitcrawl/gitcrawl.db`, while Linux honors
+  `${XDG_DATA_HOME:-~/.local/share}/gitcrawl/gitcrawl.db`; portable-store
+  installs may point at a configured store database instead of the default local
+  DB
+- Cache: resolve with `gitcrawl init --json` for new installs or from
+  `cache_dir` in config; fresh macOS installs default to
+  `~/Library/Caches/gitcrawl`, while Linux honors
+  `${XDG_CACHE_HOME:-~/.cache}/gitcrawl`
+- Vectors: resolve with `gitcrawl init --json` for new installs or from
+  `vector_dir` in config; fresh macOS installs default to
+  `~/Library/Application Support/gitcrawl/vectors`, while Linux honors
+  `${XDG_DATA_HOME:-~/.local/share}/gitcrawl/vectors`
+- Legacy installs may still resolve config, database, cache, vectors, and logs
+  under `~/.config/gitcrawl/`; check the active config before assuming a
+  migrated path.
 - Repo: `openclaw/gitcrawl`; on ClawSweeper this is checked out at `~/clawsweeper-workspace/gitcrawl`
 - Preferred CLI: `gitcrawl`; fallback to `go run ./cmd/gitcrawl` from a verified repo checkout if the installed binary is stale
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,7 @@
 
 ## 0.6.1 - Unreleased
 
-- Use platform-native default config, data, cache, and log paths for new
-  installs while preserving existing `~/.config/gitcrawl` installs until the new
-  platform path exists. On macOS this moves fresh installs under
-  `~/Library/Application Support/gitcrawl` and `~/Library/Caches/gitcrawl`.
-  Linux continues to honor XDG base directory variables with the usual
-  `~/.config`, `~/.local/share`, `~/.cache`, and `~/.local/state` fallbacks.
+- Use platform-native default config, data, cache, and log paths for new installs while preserving existing `~/.config/gitcrawl` installs until the new platform path exists; macOS uses Application Support and Caches, while Linux continues to honor XDG base directory variables, thanks @joshka.
 
 ## 0.6.0 - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 0.6.1 - Unreleased
 
+- Use platform-native default config, data, cache, and log paths for new
+  installs while preserving existing `~/.config/gitcrawl` installs until the new
+  platform path exists. On macOS this moves fresh installs under
+  `~/Library/Application Support/gitcrawl` and `~/Library/Caches/gitcrawl`.
+  Linux continues to honor XDG base directory variables with the usual
+  `~/.config`, `~/.local/share`, `~/.cache`, and `~/.local/state` fallbacks.
+
 ## 0.6.0 - 2026-06-11
 
 - Update `crawlkit` to v0.12.0.

--- a/README.md
+++ b/README.md
@@ -79,11 +79,15 @@ The TUI starts at `--min-size 5` and `--sort size`, like ghcrawl's saved default
 
 ## Local Defaults
 
-- config: `~/.config/gitcrawl/config.toml`
-- database: `~/.config/gitcrawl/gitcrawl.db`
-- cache: `~/.config/gitcrawl/cache`
-- vectors: `~/.config/gitcrawl/vectors`
-- logs: `~/.config/gitcrawl/logs`
+- Linux config: `${XDG_CONFIG_HOME:-~/.config}/gitcrawl/config.toml`
+- Linux database/vectors: `${XDG_DATA_HOME:-~/.local/share}/gitcrawl/`
+- Linux cache: `${XDG_CACHE_HOME:-~/.cache}/gitcrawl/`
+- Linux logs: `${XDG_STATE_HOME:-~/.local/state}/gitcrawl/logs/`
+- macOS config/database/vectors/logs: `~/Library/Application Support/gitcrawl/`
+- macOS cache: `~/Library/Caches/gitcrawl/`
+
+Existing installs with `~/.config/gitcrawl/config.toml` continue to load that
+config until the new platform config path exists.
 
 ## Requirements
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -124,14 +124,24 @@ Gitcrawl portable stores carry repo snapshots only. They do not carry an Octopoo
 Default config path:
 
 ```text
-~/.config/gitcrawl/config.toml
+Linux: ${XDG_CONFIG_HOME:-~/.config}/gitcrawl/config.toml
+macOS: ~/Library/Application Support/gitcrawl/config.toml
 ```
 
 Default database path:
 
 ```text
-~/.config/gitcrawl/gitcrawl.db
+Linux: ${XDG_DATA_HOME:-~/.local/share}/gitcrawl/gitcrawl.db
+macOS: ~/Library/Application Support/gitcrawl/gitcrawl.db
 ```
+
+Existing installs with `~/.config/gitcrawl/config.toml` continue to load that
+config when the new platform config path does not exist.
+
+Path selection is intentionally incremental: existing legacy config, database,
+cache, vector, and log paths are reused per component only while the matching
+new platform path does not exist. Explicit `--config`, `GITCRAWL_CONFIG`,
+`GITCRAWL_DB_PATH`, and configured portable-store paths remain authoritative.
 
 Primary environment variables:
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -56,7 +56,11 @@ clusters.
 
 ## Embedding
 
-An **embedding** is a vector representation of a thread's document, produced by an OpenAI model (default `text-embedding-3-small`, 1024 dimensions). Vectors live in `~/.config/gitcrawl/vectors` and are referenced from the `thread_vectors` table.
+An **embedding** is a vector representation of a thread's document, produced by
+an OpenAI model (default `text-embedding-3-small`, 1024 dimensions). Vectors
+live under the platform default data directory and are referenced from the
+`thread_vectors` table. Existing legacy installs may still use
+`~/.config/gitcrawl/vectors`.
 
 The **embedding basis** controls what text gets embedded. The default `title_original` uses title plus an excerpt of the original body. This is configurable via `gitcrawl configure --embedding-basis ...` but only `title_original` is currently implemented.
 
@@ -106,13 +110,21 @@ Every sync, embed, and cluster operation records a **run** in `run_records` with
 
 A **portable store** is a Git-backed publish target for a `gitcrawl.db` plus its derived bodies, designed for sharing a local cache across agents or machines without a hosted service.
 
-`gitcrawl init --portable-store https://github.com/org/repo` clones a portable store into `~/.config/gitcrawl/portable/`, points the runtime at it, and `gitcrawl portable prune --body-chars 256` keeps the published payload small while retaining comments, PR details, checks, and workflow runs. Read-only commands run against portable stores refresh the checkout before reading. See [Portable stores](/portable-stores/).
+`gitcrawl init --portable-store https://github.com/org/repo` clones a portable
+store under `<config-dir>/stores/<repo-name>` by default, points the runtime at
+it, and `gitcrawl portable prune --body-chars 256` keeps the published payload
+small while retaining comments, PR details, checks, and workflow runs. Read-only
+commands run against portable stores refresh the checkout before reading. See
+[Portable stores](/portable-stores/).
 
 ## Cache
 
-The `cache/` directory under `~/.config/gitcrawl/` holds:
+The platform default cache directory holds:
 
 - local runtime caches used by sync/search/cluster workflows.
 - hydrated PR detail rows in SQLite for local review and TUI workflows.
+
+Existing legacy installs may still use `~/.config/gitcrawl/cache`. Gitcrawl no
+longer uses a `cache/pr` directory for PR details; those rows live in SQLite.
 
 The old `gitcrawl gh` command cache moved to Octopool.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,15 +25,48 @@ For each setting, gitcrawl looks in this order and uses the first match:
 
 ## Default paths
 
-| Path | Purpose |
-| --- | --- |
-| `~/.config/gitcrawl/config.toml` | Configuration file |
-| `~/.config/gitcrawl/gitcrawl.db` | SQLite database |
-| `~/.config/gitcrawl/cache/` | Local caches |
-| `~/.config/gitcrawl/vectors/` | Vector store backing embeddings |
-| `~/.config/gitcrawl/logs/` | Operational logs |
+Linux uses XDG Base Directory paths. macOS uses the platform's `~/Library`
+locations unless you set XDG environment variables.
 
-Override the config root by setting `GITCRAWL_CONFIG=/path/to/config.toml` or by passing `--config` to any command.
+| Platform | Path | Purpose |
+| --- | --- | --- |
+| Linux | `${XDG_CONFIG_HOME:-~/.config}/gitcrawl/config.toml` | Configuration file |
+| Linux | `${XDG_DATA_HOME:-~/.local/share}/gitcrawl/gitcrawl.db` | SQLite database |
+| Linux | `${XDG_CACHE_HOME:-~/.cache}/gitcrawl/` | Local caches |
+| Linux | `${XDG_DATA_HOME:-~/.local/share}/gitcrawl/vectors/` | Vector store backing embeddings |
+| Linux | `${XDG_STATE_HOME:-~/.local/state}/gitcrawl/logs/` | Operational logs |
+| macOS | `~/Library/Application Support/gitcrawl/config.toml` | Configuration file |
+| macOS | `~/Library/Application Support/gitcrawl/gitcrawl.db` | SQLite database |
+| macOS | `~/Library/Caches/gitcrawl/` | Local caches |
+| macOS | `~/Library/Application Support/gitcrawl/vectors/` | Vector store backing embeddings |
+| macOS | `~/Library/Application Support/gitcrawl/logs/` | Operational logs |
+
+Existing installs with `~/.config/gitcrawl/config.toml` continue to load that
+config when the new platform config path does not exist. Override the config
+path by setting `GITCRAWL_CONFIG=/path/to/config.toml` or by passing `--config`
+to any command.
+
+### Path selection edge cases
+
+- `--config` and `GITCRAWL_CONFIG` are exact config-path overrides. They do not
+  move an existing database, cache, vector, log, or portable-store checkout by
+  themselves; those paths come from the loaded config or defaults.
+- Absolute XDG environment variables are honored even on macOS. Relative XDG
+  values are ignored and gitcrawl falls back to the platform default for that
+  path.
+- Legacy fallback is per path, not all-or-nothing. If
+  `~/.config/gitcrawl/config.toml`, `gitcrawl.db`, `cache/`, `vectors/`, or
+  `logs/` exists and the corresponding new platform path does not, gitcrawl
+  reuses that legacy path. If the new platform path exists, the new path wins
+  for that component.
+- Creating `~/Library/Application Support/gitcrawl/config.toml` on macOS opts
+  the config file into the new platform location. It does not delete or migrate
+  the old `~/.config/gitcrawl/` tree.
+- Portable stores default to `<config-dir>/stores/<repo-name>` when
+  `--store-dir` is omitted. Existing configs with
+  `[portable_store].checkout_dir` keep using that explicit checkout.
+- Older docs showed `cache/pr`; current gitcrawl stores PR detail data in
+  SQLite tables instead of a `cache/pr` directory.
 
 ## `config.toml`
 
@@ -53,7 +86,7 @@ OPENAI_API_KEY = "<openai-api-key>"
 [portable_store]
 url = "https://github.com/org/portable-store.git"
 db_path = "data/openclaw__openclaw.sync.db"
-checkout_dir = "/Users/me/.config/gitcrawl/portable"
+checkout_dir = "/Users/me/Library/Application Support/gitcrawl/stores/portable-store"
 ```
 
 ### Notable fields

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -98,7 +98,7 @@ Each call records a fresh override row, so the audit history is preserved.
 `gitcrawl cluster-detail` returns active overrides as part of the JSON payload, and `gitcrawl runs --kind cluster` lists when each clustering run was performed. To inspect raw override history you can query SQLite directly:
 
 ```bash
-sqlite3 ~/.config/gitcrawl/gitcrawl.db \
+sqlite3 "$(gitcrawl doctor --json | jq -r .db_path)" \
   "SELECT cluster_id, thread_number, kind, reason, created_at
    FROM cluster_member_overrides ORDER BY created_at DESC LIMIT 20;"
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ A local-first GitHub triage tool for maintainers and agents. Sync issues and PRs
 
 `gitcrawl` mirrors a GitHub repository's issues and pull requests into local SQLite, then layers semantic clustering and full-text search on top so a maintainer (or an agent acting on their behalf) can triage threads without burning live search quota.
 
-- **Local SQLite first.** All issues, PRs, comments, reviews, files, commits, checks, and workflow runs land in `~/.config/gitcrawl/gitcrawl.db`. Queries hit the disk, not GitHub.
+- **Local SQLite first.** All issues, PRs, comments, reviews, files, commits, checks, and workflow runs land in the platform default SQLite database. Queries hit the disk, not GitHub.
 - **Octopool for `gh`.** The old `gitcrawl gh` cache moved to Octopool, which owns the shared org-authenticated GitHub relay.
 - **Semantic clustering.** OpenAI embeddings group related reports, with deterministic GitHub reference evidence (`#123`, `pull/123`) preventing weak similarity bridges from forming mega-clusters.
 - **Terminal UI.** `gitcrawl tui` is a keyboard- and mouse-driven cluster browser with bidirectional sort, jump-to-number, neighbors, and member-level governance actions.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -85,7 +85,7 @@ See [the gh shim guide](/gh-shim/) for migration details.
 ## Verify the install
 
 ```bash
-gitcrawl init           # creates ~/.config/gitcrawl/{config.toml,gitcrawl.db,...}
+gitcrawl init           # creates config and data under platform default paths
 gitcrawl doctor         # confirms config, database, and credential discovery
 gitcrawl doctor --json  # same, machine-readable
 ```
@@ -96,4 +96,4 @@ gitcrawl doctor --json  # same, machine-readable
 
 - **Release archives:** download the new tarball and replace the binary.
 - **Source builds:** `git pull && go build ...` — the version string comes from `git describe`.
-- **Configuration is forward-compatible.** Existing `config.toml` and `gitcrawl.db` files are reused across versions; no migration step is needed for normal point releases.
+- **Configuration is forward-compatible.** Existing `config.toml` and `gitcrawl.db` files are reused across versions; no migration step is needed for normal point releases. Existing `~/.config/gitcrawl/config.toml` installs continue to load from that path until the new platform config path exists.

--- a/docs/portable-stores.md
+++ b/docs/portable-stores.md
@@ -26,14 +26,22 @@ A portable store is just a Git repository whose contents include a SQLite databa
 ```bash
 gitcrawl init \
   --portable-store https://github.com/openclaw/gitcrawl-store.git \
-  --portable-db data/openclaw__openclaw.sync.db \
-  --store-dir ~/.config/gitcrawl/portable
+  --portable-db data/openclaw__openclaw.sync.db
 ```
+
+When `--store-dir` is omitted, gitcrawl clones the store under
+`<config-dir>/stores/<repo-name>`. For the example above, a fresh macOS install
+uses `~/Library/Application Support/gitcrawl/stores/gitcrawl-store`; a Linux
+install using the default config location uses
+`~/.config/gitcrawl/stores/gitcrawl-store`. Pass `--store-dir` when you want a
+fixed checkout path.
 
 `init` will:
 
-1. Clone the portable store to `--store-dir`
-2. Wire `~/.config/gitcrawl/config.toml` to use the database at `--portable-db` inside that checkout
+1. Clone the portable store next to the active config, or to `--store-dir` if provided
+2. Wire the active `config.toml` to use the database at `--portable-db` inside
+   that checkout. With the Linux default config location, that file is
+   `~/.config/gitcrawl/config.toml`.
 3. Create the runtime cache, vector, and log directories in the standard locations
 
 JSON output reports `portable_store_url`, `portable_store_dir`, and `portable_store: cloned|pulled|reset-pulled` so automation can tell what happened.
@@ -100,8 +108,9 @@ gitcrawl refresh owner/repo
 # Prune for a small, shareable footprint.
 gitcrawl portable prune --body-chars 256
 
-# Commit and push using normal Git.
-cd ~/.config/gitcrawl/portable
+# Commit and push using normal Git from the configured portable checkout.
+cd ~/Library/Application\ Support/gitcrawl/stores/gitcrawl-store
+# Linux default: cd ~/.config/gitcrawl/stores/gitcrawl-store
 git add data/openclaw__openclaw.sync.db
 git commit -m "data: refresh openclaw/gitcrawl"
 git push

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -22,17 +22,21 @@ cd gitcrawl
 mkdir -p "$HOME/bin"
 go build -o "$HOME/bin/gitcrawl" ./cmd/gitcrawl
 
-# Create config + database under ~/.config/gitcrawl.
+# Create config + database under the platform default runtime paths.
 gitcrawl init
 ```
 
 Defaults written:
 
-- `~/.config/gitcrawl/config.toml`
-- `~/.config/gitcrawl/gitcrawl.db`
-- `~/.config/gitcrawl/cache/`
-- `~/.config/gitcrawl/vectors/`
-- `~/.config/gitcrawl/logs/`
+- Linux config: `${XDG_CONFIG_HOME:-~/.config}/gitcrawl/config.toml`
+- Linux database/vectors: `${XDG_DATA_HOME:-~/.local/share}/gitcrawl/`
+- Linux cache: `${XDG_CACHE_HOME:-~/.cache}/gitcrawl/`
+- Linux logs: `${XDG_STATE_HOME:-~/.local/state}/gitcrawl/logs/`
+- macOS config/database/vectors/logs: `~/Library/Application Support/gitcrawl/`
+- macOS cache: `~/Library/Caches/gitcrawl/`
+
+Existing installs with `~/.config/gitcrawl/config.toml` continue to load that
+config when the new platform config path does not exist.
 
 ## 2. Set credentials
 
@@ -41,7 +45,7 @@ export GITHUB_TOKEN="<github-token>"                 # required for sync
 export OPENAI_API_KEY="<openai-api-key>"             # required for embeddings
 ```
 
-Either set them in your shell profile or store them in `~/.config/gitcrawl/config.toml`:
+Either set them in your shell profile or store them in `config.toml`:
 
 ```toml
 [env]

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -15,16 +15,23 @@ Lookup tables for paths, environment variables, and defaults.
 
 ## Paths
 
-| Path | Purpose |
-| --- | --- |
-| `~/.config/gitcrawl/config.toml` | Configuration file |
-| `~/.config/gitcrawl/gitcrawl.db` | SQLite database |
-| `~/.config/gitcrawl/cache/` | Local runtime caches |
-| `~/.config/gitcrawl/vectors/` | Vector store backing embeddings |
-| `~/.config/gitcrawl/logs/` | Operational logs |
-| `~/.config/gitcrawl/portable/` | Portable-store checkout (when configured) |
+| Platform | Path | Purpose |
+| --- | --- | --- |
+| Linux | `${XDG_CONFIG_HOME:-~/.config}/gitcrawl/config.toml` | Configuration file |
+| Linux | `${XDG_DATA_HOME:-~/.local/share}/gitcrawl/gitcrawl.db` | SQLite database |
+| Linux | `${XDG_CACHE_HOME:-~/.cache}/gitcrawl/` | Local runtime caches |
+| Linux | `${XDG_DATA_HOME:-~/.local/share}/gitcrawl/vectors/` | Vector store backing embeddings |
+| Linux | `${XDG_STATE_HOME:-~/.local/state}/gitcrawl/logs/` | Operational logs |
+| macOS | `~/Library/Application Support/gitcrawl/config.toml` | Configuration file |
+| macOS | `~/Library/Application Support/gitcrawl/gitcrawl.db` | SQLite database |
+| macOS | `~/Library/Caches/gitcrawl/` | Local runtime caches |
+| macOS | `~/Library/Application Support/gitcrawl/vectors/` | Vector store backing embeddings |
+| macOS | `~/Library/Application Support/gitcrawl/logs/` | Operational logs |
+| Legacy installs | `~/.config/gitcrawl/` | Preserved config, database, cache, vectors, logs, and stores until the corresponding new path exists |
 
-Override the config root with `--config <path>` or `GITCRAWL_CONFIG`.
+Existing installs with `~/.config/gitcrawl/config.toml` continue to load that
+config when the new platform config path does not exist. Override the config
+path with `--config <path>` or `GITCRAWL_CONFIG`.
 
 ## Environment variables
 
@@ -32,8 +39,8 @@ Override the config root with `--config <path>` or `GITCRAWL_CONFIG`.
 
 | Variable | Default | Used by | Purpose |
 | --- | --- | --- | --- |
-| `GITCRAWL_CONFIG` | `~/.config/gitcrawl/config.toml` | All commands | Override config path |
-| `GITCRAWL_DB_PATH` | `~/.config/gitcrawl/gitcrawl.db` | All commands | Override database path |
+| `GITCRAWL_CONFIG` | Platform default config path | All commands | Override config path |
+| `GITCRAWL_DB_PATH` | Platform default database path | All commands | Override database path |
 | `GITCRAWL_TUI_LAYOUT` | `columns` | `tui` | Override default wide-screen layout |
 | `GITHUB_TOKEN` | _(none)_ | `sync` | GitHub API token |
 | `OPENAI_API_KEY` | _(none)_ | `embed`, `refresh` | OpenAI API key |
@@ -111,22 +118,47 @@ Override the config root with `--config <path>` or `GITCRAWL_CONFIG`.
 
 stderr always carries error messages. stdout is reserved for command output.
 
-## File-system layout (worked example)
+## File-System Layout
 
-```
+Linux:
+
+```text
 ~/.config/gitcrawl/
+├── config.toml
+└── stores/
+    └── gitcrawl-store/          # portable-store checkout (optional)
+        └── data/
+            └── owner__repo.sync.db
+
+~/.local/share/gitcrawl/
+├── gitcrawl.db                  # SQLite mirror
+├── gitcrawl.db-shm              # SQLite shared-memory file
+├── gitcrawl.db-wal              # SQLite write-ahead log
+└── vectors/                     # vector store backing embeddings
+
+~/.cache/gitcrawl/               # local runtime cache
+```
+
+macOS:
+
+```text
+~/Library/Application Support/gitcrawl/
 ├── config.toml
 ├── gitcrawl.db                  # SQLite mirror
 ├── gitcrawl.db-shm              # SQLite shared-memory file
 ├── gitcrawl.db-wal              # SQLite write-ahead log
-├── cache/
-│   └── pr/                      # local runtime cache
 ├── vectors/                     # vector store backing embeddings
 ├── logs/
-└── portable/                    # portable-store checkout (optional)
-    └── data/
-        └── owner__repo.sync.db
+└── stores/
+    └── gitcrawl-store/          # portable-store checkout (optional)
+        └── data/
+            └── owner__repo.sync.db
+
+~/Library/Caches/gitcrawl/       # local runtime cache
 ```
+
+Older docs showed `cache/pr`; current Gitcrawl stores PR details in SQLite
+instead of a `cache/pr` directory.
 
 ## See also
 

--- a/internal/cli/gh_rate_limit_test.go
+++ b/internal/cli/gh_rate_limit_test.go
@@ -15,6 +15,7 @@ func TestSharedRateLimitStateRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.toml")
+	t.Setenv("GITHUB_TOKEN", "")
 	cfg := config.Default()
 	cfg.CacheDir = filepath.Join(dir, "cache")
 	cfg.Env = map[string]string{"GITHUB_TOKEN": "gh-token"}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,7 +54,12 @@ type TokenResolution struct {
 	Source string
 }
 
-var appConfig = crawlconfig.App{Name: "gitcrawl", ConfigEnv: DefaultConfigEnv}
+var appConfig = crawlconfig.App{
+	Name:          "gitcrawl",
+	ConfigEnv:     DefaultConfigEnv,
+	LegacyBaseDir: "~/.config/gitcrawl",
+	PlatformDirs:  true,
+}
 
 func Default() Config {
 	paths, err := appConfig.DefaultPaths()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -44,6 +45,164 @@ func TestResolvePathUsesEnv(t *testing.T) {
 
 	if got := ResolvePath(""); got != path {
 		t.Fatalf("resolve path: got %q want %q", got, path)
+	}
+}
+
+func TestDefaultPathsUseXDGDirs(t *testing.T) {
+	home := t.TempDir()
+	configHome := filepath.Join(home, "xdg-config")
+	dataHome := filepath.Join(home, "xdg-data")
+	cacheHome := filepath.Join(home, "xdg-cache")
+	stateHome := filepath.Join(home, "xdg-state")
+	setTestHome(t, home)
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	t.Setenv("XDG_CACHE_HOME", cacheHome)
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	cfg := Default()
+	if cfg.DBPath != filepath.Join(dataHome, "gitcrawl", "gitcrawl.db") {
+		t.Fatalf("db path = %q", cfg.DBPath)
+	}
+	if cfg.CacheDir != filepath.Join(cacheHome, "gitcrawl") {
+		t.Fatalf("cache dir = %q", cfg.CacheDir)
+	}
+	if cfg.VectorDir != filepath.Join(dataHome, "gitcrawl", "vectors") {
+		t.Fatalf("vector dir = %q", cfg.VectorDir)
+	}
+	if cfg.LogDir != filepath.Join(stateHome, "gitcrawl", "logs") {
+		t.Fatalf("log dir = %q", cfg.LogDir)
+	}
+	if got := ResolvePath(""); got != filepath.Join(configHome, "gitcrawl", "config.toml") {
+		t.Fatalf("config path = %q", got)
+	}
+}
+
+func TestDefaultPathsUsePlatformFallbacks(t *testing.T) {
+	home := t.TempDir()
+	configHome, dataHome, cacheHome, stateHome := defaultPlatformTestDirs(home)
+	setTestHome(t, home)
+	clearXDGEnv(t)
+
+	cfg := Default()
+	if cfg.DBPath != filepath.Join(dataHome, "gitcrawl", "gitcrawl.db") {
+		t.Fatalf("db path = %q", cfg.DBPath)
+	}
+	if cfg.CacheDir != filepath.Join(cacheHome, "gitcrawl") {
+		t.Fatalf("cache dir = %q", cfg.CacheDir)
+	}
+	if cfg.VectorDir != filepath.Join(dataHome, "gitcrawl", "vectors") {
+		t.Fatalf("vector dir = %q", cfg.VectorDir)
+	}
+	if cfg.LogDir != filepath.Join(stateHome, "gitcrawl", "logs") {
+		t.Fatalf("log dir = %q", cfg.LogDir)
+	}
+	if got := ResolvePath(""); got != filepath.Join(configHome, "gitcrawl", "config.toml") {
+		t.Fatalf("config path = %q", got)
+	}
+}
+
+func TestDefaultPathsPreferExistingLegacyInstallPaths(t *testing.T) {
+	home := t.TempDir()
+	legacy := filepath.Join(home, ".config", "gitcrawl")
+	if err := os.MkdirAll(filepath.Join(legacy, "cache"), 0o755); err != nil {
+		t.Fatalf("mkdir cache: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(legacy, "logs"), 0o755); err != nil {
+		t.Fatalf("mkdir logs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "gitcrawl.db"), nil, 0o600); err != nil {
+		t.Fatalf("write db: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "config.toml"), nil, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	setTestHome(t, home)
+	clearXDGEnv(t)
+
+	cfg := Default()
+	if cfg.DBPath != filepath.Join(legacy, "gitcrawl.db") {
+		t.Fatalf("db path = %q", cfg.DBPath)
+	}
+	if cfg.CacheDir != filepath.Join(legacy, "cache") {
+		t.Fatalf("cache dir = %q", cfg.CacheDir)
+	}
+	if cfg.VectorDir != filepath.Join(legacy, "vectors") {
+		t.Fatalf("vector dir = %q", cfg.VectorDir)
+	}
+	if cfg.LogDir != filepath.Join(legacy, "logs") {
+		t.Fatalf("log dir = %q", cfg.LogDir)
+	}
+	if got := ResolvePath(""); got != filepath.Join(legacy, "config.toml") {
+		t.Fatalf("config path = %q", got)
+	}
+}
+
+func TestDefaultPathsKeepLegacyInstallWithXDGEnv(t *testing.T) {
+	home := t.TempDir()
+	legacy := filepath.Join(home, ".config", "gitcrawl")
+	configHome := filepath.Join(home, "xdg-config")
+	dataHome := filepath.Join(home, "xdg-data")
+	cacheHome := filepath.Join(home, "xdg-cache")
+	stateHome := filepath.Join(home, "xdg-state")
+	if err := os.MkdirAll(filepath.Join(legacy, "cache"), 0o755); err != nil {
+		t.Fatalf("mkdir cache: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(legacy, "logs"), 0o755); err != nil {
+		t.Fatalf("mkdir logs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "gitcrawl.db"), nil, 0o600); err != nil {
+		t.Fatalf("write db: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "config.toml"), nil, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	setTestHome(t, home)
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("XDG_DATA_HOME", dataHome)
+	t.Setenv("XDG_CACHE_HOME", cacheHome)
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	cfg := Default()
+	if cfg.DBPath != filepath.Join(legacy, "gitcrawl.db") {
+		t.Fatalf("db path = %q", cfg.DBPath)
+	}
+	if cfg.CacheDir != filepath.Join(legacy, "cache") {
+		t.Fatalf("cache dir = %q", cfg.CacheDir)
+	}
+	if cfg.VectorDir != filepath.Join(legacy, "vectors") {
+		t.Fatalf("vector dir = %q", cfg.VectorDir)
+	}
+	if cfg.LogDir != filepath.Join(legacy, "logs") {
+		t.Fatalf("log dir = %q", cfg.LogDir)
+	}
+	if got := ResolvePath(""); got != filepath.Join(legacy, "config.toml") {
+		t.Fatalf("config path = %q", got)
+	}
+}
+
+func TestDefaultPathsPreferNewConfigOverLegacy(t *testing.T) {
+	home := t.TempDir()
+	configHome, _, _, _ := defaultPlatformTestDirs(home)
+	legacyConfig := filepath.Join(home, ".config", "gitcrawl", "config.toml")
+	newConfig := filepath.Join(configHome, "gitcrawl", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(legacyConfig), 0o755); err != nil {
+		t.Fatalf("mkdir legacy: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(newConfig), 0o755); err != nil {
+		t.Fatalf("mkdir new: %v", err)
+	}
+	if err := os.WriteFile(legacyConfig, nil, 0o600); err != nil {
+		t.Fatalf("write legacy: %v", err)
+	}
+	if err := os.WriteFile(newConfig, nil, 0o600); err != nil {
+		t.Fatalf("write new: %v", err)
+	}
+	setTestHome(t, home)
+	clearXDGEnv(t)
+
+	if got := ResolvePath(""); got != newConfig {
+		t.Fatalf("config path = %q", got)
 	}
 }
 
@@ -422,7 +581,11 @@ func TestLoadRejectsInvalidConfig(t *testing.T) {
 
 func TestResolvePathAndSaveErrorBranches(t *testing.T) {
 	t.Setenv(DefaultConfigEnv, "")
-	if got := ResolvePath(""); !strings.HasSuffix(got, filepath.Join(".config", "gitcrawl", "config.toml")) {
+	home := t.TempDir()
+	configHome, _, _, _ := defaultPlatformTestDirs(home)
+	setTestHome(t, home)
+	clearXDGEnv(t)
+	if got := ResolvePath(""); got != filepath.Join(configHome, "gitcrawl", "config.toml") {
 		t.Fatalf("default config path = %q", got)
 	}
 	if got := ResolvePath("~/custom.toml"); !strings.Contains(got, "custom.toml") {
@@ -431,6 +594,38 @@ func TestResolvePathAndSaveErrorBranches(t *testing.T) {
 	dir := t.TempDir()
 	if err := Save(dir, Default()); err == nil {
 		t.Fatal("saving to directory should fail")
+	}
+}
+
+func setTestHome(t *testing.T, home string) {
+	t.Helper()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("LOCALAPPDATA", filepath.Join(home, "AppData", "Local"))
+	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
+}
+
+func clearXDGEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("XDG_STATE_HOME", "")
+}
+
+func defaultPlatformTestDirs(home string) (configHome, dataHome, cacheHome, stateHome string) {
+	switch runtime.GOOS {
+	case "darwin":
+		appSupport := filepath.Join(home, "Library", "Application Support")
+		return appSupport, appSupport, filepath.Join(home, "Library", "Caches"), appSupport
+	case "windows":
+		localAppData := filepath.Join(home, "AppData", "Local")
+		return localAppData, localAppData, filepath.Join(localAppData, "cache"), localAppData
+	default:
+		return filepath.Join(home, ".config"),
+			filepath.Join(home, ".local", "share"),
+			filepath.Join(home, ".cache"),
+			filepath.Join(home, ".local", "state")
 	}
 }
 


### PR DESCRIPTION
## Summary

- default fresh installs to crawlkit platform-native config, data, cache, vector, and log paths
- keep existing `~/.config/gitcrawl` installs working until the corresponding new platform path exists
- document the macOS `~/Library/Application Support/gitcrawl` and `~/Library/Caches/gitcrawl` layout, Linux XDG behavior, and legacy fallback behavior
- update the repo-local gitcrawl agent skill so future agent runs do not assume the old dot-config-only layout

## Compatibility notes

This is intended to match the Discrawl platform-path setup from [openclaw/discrawl#64](https://github.com/openclaw/discrawl/pull/64) while avoiding startup regressions for existing Gitcrawl users.

The code sets `LegacyBaseDir: "~/.config/gitcrawl"` and `PlatformDirs: true` on the crawlkit app config. Fresh installs resolve platform-native defaults. Existing legacy config, database, cache, vector, and log paths are reused per component only while the matching new platform path does not exist, so partial/mixed layouts are possible during gradual migration. If a user creates the new platform config path, it wins over the legacy config path, which gives users an explicit migration path without making an existing install fail to start.

Other documented edge cases:

- `--config` and `GITCRAWL_CONFIG` are exact config-path overrides; they do not move the database/cache/vector/log paths by themselves.
- Absolute XDG environment variables are honored even on macOS; relative XDG values are ignored.
- Portable stores default to `<config-dir>/stores/<repo-name>` when `--store-dir` is omitted. Existing configured `checkout_dir` values continue to be used.
- Older docs showed `cache/pr`; current Gitcrawl stores PR detail data in SQLite tables instead of a `cache/pr` directory.

The new tests cover:

- XDG config/data/cache/state overrides
- platform fallback paths when XDG env is unset
- existing legacy `~/.config/gitcrawl` installs
- legacy installs even when XDG env vars are set
- preferring the new platform config once it exists

## Testing

- `GOWORK=off go test ./...` passed
- `GOWORK=off go test ./internal/cli ./internal/config` passed after doc/rationale follow-ups
- `git diff --check` passed
- `GOBIN="$HOME/bin" go install ./cmd/gitcrawl && "$HOME/bin/gitcrawl" --version` installed from source and printed `dev`
- fresh isolated macOS-style `go run ./cmd/gitcrawl init --json` resolved:
  - config: `~/Library/Application Support/gitcrawl/config.toml`
  - database: `~/Library/Application Support/gitcrawl/gitcrawl.db`
  - cache: `~/Library/Caches/gitcrawl`
  - vectors: `~/Library/Application Support/gitcrawl/vectors`
- isolated XDG `go run ./cmd/gitcrawl init --json` resolved config/data/cache/vector paths under the supplied `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, and `XDG_CACHE_HOME`
- isolated legacy `~/.config/gitcrawl` setup with existing `config.toml` and `gitcrawl.db` kept using the legacy config and database paths in `go run ./cmd/gitcrawl doctor --json`
- local installed-binary smoke against `ratatui/templates` worked earlier in this branch work: metadata sync completed for 132 threads, targeted comment hydration for #130 synced 4 comments, and `gitcrawl doctor --json` reported 1 repo / 132 threads / 12 open threads

`markdownlint-cli2` was also tried, but this repo currently reports broad pre-existing markdownlint failures across the selected docs, so it was not used as a gate for this focused path-change PR.

