### PR TITLE
[codex] Share SQL LIKE escaping with CrawlKit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.6.2 - Unreleased
 
-- Use CrawlKit's shared safe tokenized FTS5 query builder and refresh dependencies.
+- Use CrawlKit's shared safe tokenized FTS5 query and SQL LIKE builders, treating `%`, `_`, and backslashes literally in fallback searches, and refresh dependencies.
 
 ## 0.6.1 - 2026-06-19
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/mattn/go-isatty v0.0.22
-	github.com/openclaw/crawlkit v0.12.3-0.20260619121233-9a636444e780
+	github.com/openclaw/crawlkit v0.12.3-0.20260619123950-797628aa9708
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/sys v0.46.0
 )

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.12.3-0.20260619121233-9a636444e780 h1:tIY78FG5kTDLqhbtDfEkgrYNXojKtNxIOwXposua5rs=
-github.com/openclaw/crawlkit v0.12.3-0.20260619121233-9a636444e780/go.mod h1:zOJv5WPWO1AuuXO7zW8NRTxb/ZTkIQXYPrx3StmnMUI=
+github.com/openclaw/crawlkit v0.12.3-0.20260619123950-797628aa9708 h1:zkU7J3m4k6NR9756D0nKudyesPnTToTFsAlfDO0fKlg=
+github.com/openclaw/crawlkit v0.12.3-0.20260619123950-797628aa9708/go.mod h1:zOJv5WPWO1AuuXO7zW8NRTxb/ZTkIQXYPrx3StmnMUI=
 github.com/pelletier/go-toml/v2 v2.4.0 h1:Mwu0mAkUKbittDs3/ADDWXqMmq3EOK2VHiuCkV00Row=
 github.com/pelletier/go-toml/v2 v2.4.0/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/store/code_documents.go
+++ b/internal/store/code_documents.go
@@ -148,7 +148,7 @@ func (s *Store) searchCodeDocumentsLike(ctx context.Context, snapshot CodeSnapsh
 	if needle == "" {
 		return []CodeSearchHit{}, nil
 	}
-	pattern := "%" + escapeLike(needle) + "%"
+	pattern := "%" + crawlstore.EscapeLike(needle) + "%"
 	rows, err := s.q().QueryContext(ctx, `
 		select id, path, language, substr(text_content, 1, 320)
 		from code_documents

--- a/internal/store/coverage_test.go
+++ b/internal/store/coverage_test.go
@@ -674,9 +674,6 @@ func TestSearchAndStoreErrorBranches(t *testing.T) {
 	if got := threadSearchOrder(true); !strings.Contains(got, "bm25") {
 		t.Fatalf("fts order = %q", got)
 	}
-	if got := escapeLike(`a%b_c\`); got != `a\%b\_c\\` {
-		t.Fatalf("escape = %q", got)
-	}
 }
 
 func TestOpenBackfillsLegacyPortableColumns(t *testing.T) {

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -84,7 +84,7 @@ func (s *Store) searchThreads(ctx context.Context, repoID int64, query string, l
 	if needle == "" {
 		return nil, nil
 	}
-	pattern := "%" + escapeLike(needle) + "%"
+	pattern := "%" + crawlstore.EscapeLike(needle) + "%"
 	bodyExpr := s.threadBodyExpr(ctx, "")
 	rows, err := s.db.QueryContext(ctx, `
 		select id, number, kind, state, title, html_url, author_login,
@@ -167,7 +167,7 @@ func (s *Store) searchThreadsLike(ctx context.Context, options ThreadSearchOptio
 	needle := strings.TrimSpace(strings.ToLower(options.Query))
 	bodyExpr := s.threadBodyExpr(ctx, "t")
 	if needle != "" {
-		pattern := "%" + escapeLike(needle) + "%"
+		pattern := "%" + crawlstore.EscapeLike(needle) + "%"
 		where = append(where, `(lower(t.title) like ? escape '\' or lower(coalesce(`+bodyExpr+`, '')) like ? escape '\')`)
 		args = append(args, pattern, pattern)
 	}
@@ -246,16 +246,4 @@ func scanThreadRows(rows *sql.Rows) ([]Thread, error) {
 		return nil, fmt.Errorf("iterate threads: %w", err)
 	}
 	return out, nil
-}
-
-func escapeLike(value string) string {
-	var b strings.Builder
-	for _, r := range value {
-		switch r {
-		case '\\', '%', '_':
-			b.WriteRune('\\')
-		}
-		b.WriteRune(r)
-	}
-	return b.String()
 }

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -73,6 +73,43 @@ func TestSearchDocumentsEscapesFTSQuery(t *testing.T) {
 	}
 }
 
+func TestSearchDocumentsTreatsLikeWildcardsLiterally(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+
+	repoID, err := st.UpsertRepository(ctx, Repository{Owner: "openclaw", Name: "gitcrawl", FullName: "openclaw/gitcrawl", RawJSON: "{}", UpdatedAt: "2026-04-26T00:00:00Z"})
+	if err != nil {
+		t.Fatalf("repo: %v", err)
+	}
+	for _, thread := range []Thread{
+		{RepoID: repoID, GitHubID: "wildcard-1", Number: 10, Kind: "issue", State: "open", Title: "100% ready", HTMLURL: "https://github.com/openclaw/gitcrawl/issues/10", LabelsJSON: "[]", AssigneesJSON: "[]", RawJSON: "{}", ContentHash: "wildcard-1", UpdatedAt: "2026-04-26T00:00:00Z"},
+		{RepoID: repoID, GitHubID: "wildcard-2", Number: 11, Kind: "issue", State: "open", Title: "ordinary title", HTMLURL: "https://github.com/openclaw/gitcrawl/issues/11", LabelsJSON: "[]", AssigneesJSON: "[]", RawJSON: "{}", ContentHash: "wildcard-2", UpdatedAt: "2026-04-26T00:00:00Z"},
+	} {
+		if _, err := st.UpsertThread(ctx, thread); err != nil {
+			t.Fatalf("thread %d: %v", thread.Number, err)
+		}
+	}
+
+	hits, err := st.SearchDocuments(ctx, repoID, "%", 10)
+	if err != nil {
+		t.Fatalf("search percent: %v", err)
+	}
+	if len(hits) != 1 || hits[0].Number != 10 {
+		t.Fatalf("percent hits = %#v", hits)
+	}
+	hits, err = st.SearchDocuments(ctx, repoID, "_", 10)
+	if err != nil {
+		t.Fatalf("search underscore: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("underscore hits = %#v", hits)
+	}
+}
+
 func TestSearchThreadsFiltersAuthorAssigneeAndLabels(t *testing.T) {
 	ctx := context.Background()
 	st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))


### PR DESCRIPTION
## Summary

- replace Gitcrawl's duplicate SQL LIKE escaping helper with CrawlKit's shared implementation
- treat `%`, `_`, and backslashes literally across thread, document, and code fallback searches
- update CrawlKit and add end-to-end wildcard regression coverage

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- total coverage: 85.1%
- autoreview: clean
