### PR TITLE
Preserve duplicate PR file rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 0.6.2 - Unreleased
 
 - Use CrawlKit's shared safe tokenized FTS5 query and SQL LIKE builders, treating `%`, `_`, and backslashes literally in fallback searches, and refresh dependencies.
+- Preserve duplicate PR file entries returned by GitHub, such as a removed file
+  and an added file with the same path in one PR, by storing the fetched file
+  list as a position-keyed snapshot.
 
 ## 0.6.1 - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,6 @@
 ## 0.6.2 - Unreleased
 
 - Use CrawlKit's shared safe tokenized FTS5 query and SQL LIKE builders, treating `%`, `_`, and backslashes literally in fallback searches, and refresh dependencies.
-- Preserve duplicate PR file entries returned by GitHub, such as a removed file
-  and an added file with the same path in one PR, by storing the fetched file
-  list as a position-keyed snapshot.
-
 ## 0.6.1 - 2026-06-19
 
 - Use platform-native default config, data, cache, and log paths for new installs while preserving existing `~/.config/gitcrawl` installs until the new platform path exists; macOS uses Application Support and Caches, while Linux continues to honor XDG base directory variables, thanks @joshka.

--- a/internal/store/pull_requests.go
+++ b/internal/store/pull_requests.go
@@ -27,6 +27,7 @@ type PullRequestDetail struct {
 
 type PullRequestFile struct {
 	ThreadID     int64  `json:"thread_id"`
+	Position     int    `json:"position"`
 	Path         string `json:"path"`
 	Status       string `json:"status,omitempty"`
 	Additions    int    `json:"additions"`
@@ -133,9 +134,15 @@ func (s *Store) upsertPullRequestCache(ctx context.Context, detail PullRequestDe
 	if err := s.qsql().DeletePullRequestFiles(ctx, detail.ThreadID); err != nil {
 		return fmt.Errorf("clear pull request files: %w", err)
 	}
-	for _, file := range files {
+	// The GitHub PR files endpoint returns a snapshot array, not stable file
+	// identities. A path can appear more than once in one response, so replace
+	// the PR's file list and key rows by response position within that snapshot.
+	// See https://github.com/openclaw/gitcrawl/issues/77 for the duplicate-path
+	// bug and why position is snapshot-local rather than a durable file identity.
+	for position, file := range files {
 		if err := s.qsql().InsertPullRequestFile(ctx, storedb.InsertPullRequestFileParams{
 			ThreadID:     detail.ThreadID,
+			Position:     int64(position),
 			Path:         file.Path,
 			Status:       nullString(file.Status),
 			Additions:    int64(file.Additions),
@@ -250,7 +257,7 @@ func (s *Store) PullRequestCache(ctx context.Context, repoID int64, number int) 
 }
 
 func (s *Store) PullRequestFiles(ctx context.Context, threadID int64) ([]PullRequestFile, error) {
-	rows, err := s.qsql().PullRequestFiles(ctx, threadID)
+	rows, err := s.pullRequestFiles(ctx, threadID)
 	if err != nil {
 		return nil, fmt.Errorf("list pull request files: %w", err)
 	}
@@ -258,6 +265,7 @@ func (s *Store) PullRequestFiles(ctx context.Context, threadID int64) ([]PullReq
 	for _, row := range rows {
 		out = append(out, PullRequestFile{
 			ThreadID:     row.ThreadID,
+			Position:     int(row.Position),
 			Path:         row.Path,
 			Status:       stringValue(row.Status),
 			Additions:    int(row.Additions),
@@ -268,6 +276,51 @@ func (s *Store) PullRequestFiles(ctx context.Context, threadID int64) ([]PullReq
 			RawJSON:      row.RawJson,
 			FetchedAt:    row.FetchedAt,
 		})
+	}
+	return out, nil
+}
+
+func (s *Store) pullRequestFiles(ctx context.Context, threadID int64) ([]storedb.PullRequestFile, error) {
+	if s.queries != nil {
+		return s.qsql().PullRequestFiles(ctx, threadID)
+	}
+	if s.hasColumn(ctx, "pull_request_files", "position") {
+		return s.qsql().PullRequestFiles(ctx, threadID)
+	}
+	return s.pullRequestFilesLegacy(ctx, threadID)
+}
+
+func (s *Store) pullRequestFilesLegacy(ctx context.Context, threadID int64) ([]storedb.PullRequestFile, error) {
+	rows, err := s.q().QueryContext(ctx, `
+		select thread_id, path, status, additions, deletions, changes, previous_path, patch, raw_json, fetched_at
+		from pull_request_files
+		where thread_id = ?
+		order by path`, threadID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []storedb.PullRequestFile
+	for rows.Next() {
+		var row storedb.PullRequestFile
+		if err := rows.Scan(
+			&row.ThreadID,
+			&row.Path,
+			&row.Status,
+			&row.Additions,
+			&row.Deletions,
+			&row.Changes,
+			&row.PreviousPath,
+			&row.Patch,
+			&row.RawJson,
+			&row.FetchedAt,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 	return out, nil
 }

--- a/internal/store/pull_requests_test.go
+++ b/internal/store/pull_requests_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"path/filepath"
 	"testing"
 )
@@ -90,6 +91,181 @@ func TestPullRequestCacheRoundTripAndWorkflowFilters(t *testing.T) {
 	}
 	if cache.Detail.HeadSHA != "head-v2" || len(cache.Files) != 1 || len(cache.Commits) != 0 || len(cache.Checks) != 0 {
 		t.Fatalf("updated cache = %+v", cache)
+	}
+}
+
+func TestPullRequestCacheAllowsDuplicateFilePaths(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	repoID, threadIDs := seedVectorThreads(t, ctx, st)
+	threadID := threadIDs[1]
+	fetchedAt := "2026-05-05T10:00:00Z"
+
+	detail := PullRequestDetail{
+		ThreadID:  threadID,
+		RepoID:    repoID,
+		Number:    302,
+		RawJSON:   "{}",
+		FetchedAt: fetchedAt,
+		UpdatedAt: fetchedAt,
+	}
+	files := []PullRequestFile{
+		// Regression for GitHub PR file lists that contain separate removed and
+		// added entries with the same filename, as seen in jj-vcs/jj#9355.
+		{
+			Path:      "docs/governance/GOVERNANCE.md",
+			Status:    "removed",
+			Deletions: 1,
+			Changes:   1,
+			RawJSON:   `{"filename":"docs/governance/GOVERNANCE.md","status":"removed"}`,
+			FetchedAt: fetchedAt,
+		},
+		{
+			Path:      "docs/governance/GOVERNANCE.md",
+			Status:    "added",
+			Additions: 161,
+			Changes:   161,
+			RawJSON:   `{"filename":"docs/governance/GOVERNANCE.md","status":"added"}`,
+			FetchedAt: fetchedAt,
+		},
+	}
+
+	if err := st.UpsertPullRequestCache(ctx, detail, files, nil, nil, nil); err != nil {
+		t.Fatalf("upsert duplicate-path pr files: %v", err)
+	}
+	cache, err := st.PullRequestCache(ctx, repoID, 302)
+	if err != nil {
+		t.Fatalf("pull request cache: %v", err)
+	}
+	if len(cache.Files) != 2 {
+		t.Fatalf("files len = %d, want 2: %+v", len(cache.Files), cache.Files)
+	}
+	if cache.Files[0].Status != "removed" || cache.Files[0].Position != 0 ||
+		cache.Files[1].Status != "added" || cache.Files[1].Position != 1 {
+		t.Fatalf("files = %+v", cache.Files)
+	}
+
+	if err := st.UpsertPullRequestCache(ctx, detail, files[:1], nil, nil, nil); err != nil {
+		t.Fatalf("replace duplicate-path pr files: %v", err)
+	}
+	cache, err = st.PullRequestCache(ctx, repoID, 302)
+	if err != nil {
+		t.Fatalf("updated pull request cache: %v", err)
+	}
+	if len(cache.Files) != 1 || cache.Files[0].Status != "removed" || cache.Files[0].Position != 0 {
+		t.Fatalf("updated files = %+v", cache.Files)
+	}
+}
+
+func TestOpenMigratesLegacyPullRequestFilesToPositionKey(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "gitcrawl.db")
+	st, err := Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	repoID, threadIDs := seedVectorThreads(t, ctx, st)
+	threadID := threadIDs[1]
+	fetchedAt := "2026-05-05T10:00:00Z"
+
+	detail := PullRequestDetail{
+		ThreadID:  threadID,
+		RepoID:    repoID,
+		Number:    302,
+		RawJSON:   "{}",
+		FetchedAt: fetchedAt,
+		UpdatedAt: fetchedAt,
+	}
+	legacyFiles := []PullRequestFile{
+		{Path: "z.go", Status: "modified", Additions: 2, Changes: 2, RawJSON: `{"filename":"z.go"}`, FetchedAt: fetchedAt},
+		{Path: "a.go", Status: "added", Additions: 1, Changes: 1, RawJSON: `{"filename":"a.go"}`, FetchedAt: fetchedAt},
+	}
+	if err := st.UpsertPullRequestCache(ctx, detail, legacyFiles, nil, nil, nil); err != nil {
+		t.Fatalf("seed pr cache: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open raw db: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `
+		drop index if exists idx_pull_request_files_path;
+		drop index if exists idx_pull_request_files_thread_path;
+		alter table pull_request_files rename to pull_request_files_current;
+		create table pull_request_files (
+			thread_id integer not null references threads(id) on delete cascade,
+			path text not null,
+			status text,
+			additions integer not null default 0,
+			deletions integer not null default 0,
+			changes integer not null default 0,
+			previous_path text,
+			patch text,
+			raw_json text not null,
+			fetched_at text not null,
+			primary key(thread_id, path)
+		);
+		insert into pull_request_files(thread_id, path, status, additions, deletions, changes, previous_path, patch, raw_json, fetched_at)
+			select thread_id, path, status, additions, deletions, changes, previous_path, patch, raw_json, fetched_at
+			from pull_request_files_current;
+		drop table pull_request_files_current;
+		create index if not exists idx_pull_request_files_path on pull_request_files(path);
+		pragma user_version = 3;
+	`)
+	if err != nil {
+		t.Fatalf("seed legacy pull_request_files table: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close raw db: %v", err)
+	}
+
+	st, err = Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open migrated store: %v", err)
+	}
+	defer st.Close()
+	if !st.pullRequestFilesHavePositionKey(ctx) {
+		t.Fatal("pull_request_files primary key was not migrated")
+	}
+	var version int
+	if err := st.DB().QueryRowContext(ctx, `pragma user_version`).Scan(&version); err != nil {
+		t.Fatalf("read user_version: %v", err)
+	}
+	if version != schemaVersion {
+		t.Fatalf("user_version = %d, want %d", version, schemaVersion)
+	}
+	cache, err := st.PullRequestCache(ctx, repoID, 302)
+	if err != nil {
+		t.Fatalf("pull request cache: %v", err)
+	}
+	if len(cache.Files) != 2 ||
+		cache.Files[0].Path != "a.go" || cache.Files[0].Position != 0 ||
+		cache.Files[1].Path != "z.go" || cache.Files[1].Position != 1 {
+		t.Fatalf("migrated files = %+v", cache.Files)
+	}
+
+	duplicateFiles := []PullRequestFile{
+		{Path: "docs/governance/GOVERNANCE.md", Status: "removed", Deletions: 1, Changes: 1, RawJSON: `{"filename":"docs/governance/GOVERNANCE.md","status":"removed"}`, FetchedAt: fetchedAt},
+		{Path: "docs/governance/GOVERNANCE.md", Status: "added", Additions: 161, Changes: 161, RawJSON: `{"filename":"docs/governance/GOVERNANCE.md","status":"added"}`, FetchedAt: fetchedAt},
+	}
+	if err := st.UpsertPullRequestCache(ctx, detail, duplicateFiles, nil, nil, nil); err != nil {
+		t.Fatalf("upsert duplicate-path pr files after migration: %v", err)
+	}
+	cache, err = st.PullRequestCache(ctx, repoID, 302)
+	if err != nil {
+		t.Fatalf("updated pull request cache: %v", err)
+	}
+	if len(cache.Files) != 2 ||
+		cache.Files[0].Status != "removed" || cache.Files[0].Position != 0 ||
+		cache.Files[1].Status != "added" || cache.Files[1].Position != 1 {
+		t.Fatalf("duplicate files after migration = %+v", cache.Files)
 	}
 }
 

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -142,6 +142,12 @@ create table if not exists pull_request_details (
 
 create table if not exists pull_request_files (
   thread_id integer not null references threads(id) on delete cascade,
+  -- GitHub can return multiple file entries with the same filename for one PR,
+  -- for example a removed file and an added file at the same path. Store the
+  -- fetched file list as a replaceable snapshot instead of keying by path.
+  -- See https://github.com/openclaw/gitcrawl/issues/77 for the duplicate-path
+  -- bug and why position is snapshot-local rather than a durable file identity.
+  position integer not null default 0,
   path text not null,
   status text,
   additions integer not null default 0,
@@ -151,7 +157,7 @@ create table if not exists pull_request_files (
   patch text,
   raw_json text not null,
   fetched_at text not null,
-  primary key(thread_id, path)
+  primary key(thread_id, position)
 );
 
 create table if not exists pull_request_commits (
@@ -549,6 +555,7 @@ create index if not exists idx_thread_revisions_thread_created on thread_revisio
 create index if not exists idx_thread_changed_files_path on thread_changed_files(path);
 create index if not exists idx_pull_request_details_repo_number on pull_request_details(repo_id, number);
 create index if not exists idx_pull_request_files_path on pull_request_files(path);
+create index if not exists idx_pull_request_files_thread_path on pull_request_files(thread_id, path);
 create index if not exists idx_pull_request_checks_thread_status on pull_request_checks(thread_id, status, conclusion);
 create index if not exists idx_pull_request_review_threads_thread_resolved on pull_request_review_threads(thread_id, is_resolved);
 create index if not exists idx_pull_request_review_thread_syncs_fetched on pull_request_review_thread_syncs(fetched_at);

--- a/internal/store/sqlc/queries.sql
+++ b/internal/store/sqlc/queries.sql
@@ -270,8 +270,8 @@ on conflict(thread_id) do update set
 delete from pull_request_files where thread_id = sqlc.arg(thread_id);
 
 -- name: InsertPullRequestFile :exec
-insert into pull_request_files(thread_id, path, status, additions, deletions, changes, previous_path, patch, raw_json, fetched_at)
-values(sqlc.arg(thread_id), sqlc.arg(path), sqlc.narg(status), sqlc.arg(additions), sqlc.arg(deletions), sqlc.arg(changes), sqlc.narg(previous_path), sqlc.narg(patch), sqlc.arg(raw_json), sqlc.arg(fetched_at));
+insert into pull_request_files(thread_id, position, path, status, additions, deletions, changes, previous_path, patch, raw_json, fetched_at)
+values(sqlc.arg(thread_id), sqlc.arg(position), sqlc.arg(path), sqlc.narg(status), sqlc.arg(additions), sqlc.arg(deletions), sqlc.arg(changes), sqlc.narg(previous_path), sqlc.narg(patch), sqlc.arg(raw_json), sqlc.arg(fetched_at));
 
 -- name: DeletePullRequestCommits :exec
 delete from pull_request_commits where thread_id = sqlc.arg(thread_id);
@@ -310,10 +310,10 @@ from pull_request_details
 where repo_id = sqlc.arg(repo_id) and number = sqlc.arg(number);
 
 -- name: PullRequestFiles :many
-select thread_id, path, status, additions, deletions, changes, previous_path, patch, raw_json, fetched_at
+select thread_id, position, path, status, additions, deletions, changes, previous_path, patch, raw_json, fetched_at
 from pull_request_files
 where thread_id = sqlc.arg(thread_id)
-order by path;
+order by path, position;
 
 -- name: PullRequestCommits :many
 select thread_id, sha, message, author_login, author_name, committed_at, html_url, raw_json, fetched_at

--- a/internal/store/sqlc/schema.sql
+++ b/internal/store/sqlc/schema.sql
@@ -98,6 +98,12 @@ create table pull_request_details (
 
 create table pull_request_files (
   thread_id integer not null references threads(id) on delete cascade,
+  -- GitHub can return multiple file entries with the same filename for one PR,
+  -- for example a removed file and an added file at the same path. Store the
+  -- fetched file list as a replaceable snapshot instead of keying by path.
+  -- See https://github.com/openclaw/gitcrawl/issues/77 for the duplicate-path
+  -- bug and why position is snapshot-local rather than a durable file identity.
+  position integer not null default 0,
   path text not null,
   status text,
   additions integer not null default 0,
@@ -107,7 +113,7 @@ create table pull_request_files (
   patch text,
   raw_json text not null,
   fetched_at text not null,
-  primary key(thread_id, path)
+  primary key(thread_id, position)
 );
 
 create table pull_request_commits (

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	schemaVersion = 3
+	schemaVersion = 4
 	timeLayout    = time.RFC3339Nano
 )
 
@@ -248,6 +248,9 @@ func (s *Store) migrate(ctx context.Context) error {
 	if err := s.ensureThreadVectorsCompositeKey(ctx); err != nil {
 		return err
 	}
+	if err := s.ensurePullRequestFilesPositionKey(ctx); err != nil {
+		return err
+	}
 	if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`pragma user_version = %d`, schemaVersion)); err != nil {
 		return fmt.Errorf("set schema version: %w", err)
 	}
@@ -311,6 +314,88 @@ func (s *Store) ensureThreadVectorsCompositeKey(ctx context.Context) error {
 		return fmt.Errorf("commit thread vector key migration: %w", err)
 	}
 	return nil
+}
+
+func (s *Store) ensurePullRequestFilesPositionKey(ctx context.Context) error {
+	if !s.hasTable(ctx, "pull_request_files") || s.pullRequestFilesHavePositionKey(ctx) {
+		return nil
+	}
+	// Existing stores keyed PR files by path. The new key uses the fetched
+	// snapshot position so duplicate GitHub filenames can coexist. Legacy rows
+	// were unique by path, so ordering them by path gives each row a stable
+	// migration position; later syncs replace the full per-PR file snapshot.
+	// See https://github.com/openclaw/gitcrawl/issues/77 for the duplicate-path
+	// bug and why position is snapshot-local rather than a durable file identity.
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin pull request files key migration: %w", err)
+	}
+	defer tx.Rollback()
+	for _, stmt := range []string{
+		`drop index if exists idx_pull_request_files_path`,
+		`drop index if exists idx_pull_request_files_thread_path`,
+		`alter table pull_request_files rename to pull_request_files_old`,
+		`create table pull_request_files (
+			thread_id integer not null references threads(id) on delete cascade,
+			position integer not null default 0,
+			path text not null,
+			status text,
+			additions integer not null default 0,
+			deletions integer not null default 0,
+			changes integer not null default 0,
+			previous_path text,
+			patch text,
+			raw_json text not null,
+			fetched_at text not null,
+			primary key(thread_id, position)
+		)`,
+		`insert into pull_request_files(thread_id, position, path, status, additions, deletions, changes, previous_path, patch, raw_json, fetched_at)
+			select old.thread_id,
+				(select count(*) from pull_request_files_old prior where prior.thread_id = old.thread_id and prior.path < old.path),
+				old.path,
+				old.status,
+				old.additions,
+				old.deletions,
+				old.changes,
+				old.previous_path,
+				old.patch,
+				old.raw_json,
+				old.fetched_at
+			from pull_request_files_old old`,
+		`drop table pull_request_files_old`,
+		`create index if not exists idx_pull_request_files_path on pull_request_files(path)`,
+		`create index if not exists idx_pull_request_files_thread_path on pull_request_files(thread_id, path)`,
+	} {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("migrate pull request files key: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit pull request files key migration: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) pullRequestFilesHavePositionKey(ctx context.Context) bool {
+	rows, err := s.db.QueryContext(ctx, `pragma table_info(pull_request_files)`)
+	if err != nil {
+		return false
+	}
+	defer rows.Close()
+	pk := map[string]int{}
+	for rows.Next() {
+		var cid int
+		var name, columnType string
+		var notNull, primaryKey int
+		var defaultValue any
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			return false
+		}
+		if primaryKey > 0 {
+			pk[name] = primaryKey
+		}
+	}
+	return pk["thread_id"] == 1 && pk["position"] == 2
 }
 
 func (s *Store) threadVectorsHaveCompositeKey(ctx context.Context) bool {

--- a/internal/store/storedb/models.go
+++ b/internal/store/storedb/models.go
@@ -171,6 +171,7 @@ type PullRequestDetail struct {
 
 type PullRequestFile struct {
 	ThreadID     int64          `json:"thread_id"`
+	Position     int64          `json:"position"`
 	Path         string         `json:"path"`
 	Status       sql.NullString `json:"status"`
 	Additions    int64          `json:"additions"`

--- a/internal/store/storedb/queries.sql.go
+++ b/internal/store/storedb/queries.sql.go
@@ -183,12 +183,13 @@ func (q *Queries) InsertPullRequestCommit(ctx context.Context, arg InsertPullReq
 }
 
 const insertPullRequestFile = `-- name: InsertPullRequestFile :exec
-insert into pull_request_files(thread_id, path, status, additions, deletions, changes, previous_path, patch, raw_json, fetched_at)
-values(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+insert into pull_request_files(thread_id, position, path, status, additions, deletions, changes, previous_path, patch, raw_json, fetched_at)
+values(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
 `
 
 type InsertPullRequestFileParams struct {
 	ThreadID     int64          `json:"thread_id"`
+	Position     int64          `json:"position"`
 	Path         string         `json:"path"`
 	Status       sql.NullString `json:"status"`
 	Additions    int64          `json:"additions"`
@@ -203,6 +204,7 @@ type InsertPullRequestFileParams struct {
 func (q *Queries) InsertPullRequestFile(ctx context.Context, arg InsertPullRequestFileParams) error {
 	_, err := q.db.ExecContext(ctx, insertPullRequestFile,
 		arg.ThreadID,
+		arg.Position,
 		arg.Path,
 		arg.Status,
 		arg.Additions,
@@ -983,10 +985,10 @@ func (q *Queries) PullRequestDetail(ctx context.Context, arg PullRequestDetailPa
 }
 
 const pullRequestFiles = `-- name: PullRequestFiles :many
-select thread_id, path, status, additions, deletions, changes, previous_path, patch, raw_json, fetched_at
+select thread_id, position, path, status, additions, deletions, changes, previous_path, patch, raw_json, fetched_at
 from pull_request_files
 where thread_id = ?1
-order by path
+order by path, position
 `
 
 func (q *Queries) PullRequestFiles(ctx context.Context, threadID int64) ([]PullRequestFile, error) {
@@ -1000,6 +1002,7 @@ func (q *Queries) PullRequestFiles(ctx context.Context, threadID int64) ([]PullR
 		var i PullRequestFile
 		if err := rows.Scan(
 			&i.ThreadID,
+			&i.Position,
 			&i.Path,
 			&i.Status,
 			&i.Additions,


### PR DESCRIPTION
## Summary

- Use platform-native config/data/cache/log defaults for new installs while preserving existing `~/.config/gitcrawl` installs through crawlkit's legacy path fallback.
- Update docs, changelog, and the local gitcrawl agent skill to describe macOS `~/Library` paths, Linux XDG paths, and portable-store checkout defaults.
- Fix #77 by storing PR files as a replaceable position-keyed snapshot instead of keying rows by `(thread_id, path)`, since GitHub can return separate `removed` and `added` file entries with the same filename.

## Compatibility notes

- Existing installs with `~/.config/gitcrawl/config.toml` continue to load from that path until a platform-native config exists.
- `--config` still only chooses the config path; it does not move DB/cache/vector/log paths by itself.
- PR file storage migrates the local SQLite schema from version 3 to 4 by rebuilding `pull_request_files` with `(thread_id, position)` as the primary key.
- Read-only legacy DB inspection still handles `pull_request_files` tables without `position`.
- A separate follow-up for fully isolated temp runtime configs is tracked in #78.

## Testing

- `go test ./...`
- `go test ./internal/config ./internal/store ./internal/store/storedb ./internal/syncer ./internal/documents`
- `git diff 6cf67808f72bad2c1d08a64d71469a266fcd4cc7 --check`
- Verified the #77 repros against isolated temp configs/DBs:
  - `jj-vcs/jj#9355` synced successfully with 125 PR files.
  - `jj-vcs/jj#2986` synced successfully with 8 PR files.
  - Confirmed duplicate rows such as `docs/cli-reference.md` `removed` and `added` are preserved with separate positions.
