### PR TITLE
feat: add isolated runtime initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Use CrawlKit's shared safe tokenized FTS5 query and SQL LIKE builders, treating `%`, `_`, and backslashes literally in fallback searches, and refresh dependencies.
 - Preserve duplicate PR file entries returned by GitHub, including removed and added files sharing one path, as position-keyed snapshots. Thanks @joshka.
+- Add `gitcrawl init --runtime-dir` for fully isolated temporary database, cache, vector, and log paths. Thanks @joshka.
 
 ## 0.6.1 - 2026-06-19
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -30,7 +30,7 @@ These work on every command.
 
 | Command | Purpose | Detailed docs |
 | --- | --- | --- |
-| `gitcrawl init [--db --portable-store --portable-db --store-dir --json]` | Create config, database, runtime directories; optionally clone a portable store | [Installation](/installation/), [Portable stores](/portable-stores/) |
+| `gitcrawl init [--db --runtime-dir --portable-store --portable-db --store-dir --json]` | Create config and runtime directories; isolate all local paths under one root or clone a portable store | [Configuration](/configuration/#path-selection-edge-cases), [Portable stores](/portable-stores/) |
 | `gitcrawl doctor [--json]` | Health check for config, database, credentials, model selection, repo/thread counts | [Configuration](/configuration/#gitcrawl-doctor) |
 | `gitcrawl metadata [--json]` | Print the crawlkit command/control manifest for launchers and automation | — |
 | `gitcrawl status [--json]` | Print read-only archive status, database inventory, and control state | — |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,6 +51,10 @@ to any command.
 - `--config` and `GITCRAWL_CONFIG` are exact config-path overrides. They do not
   move an existing database, cache, vector, log, or portable-store checkout by
   themselves; those paths come from the loaded config or defaults.
+- `gitcrawl init --runtime-dir <path>` creates a fully isolated local runtime
+  under that directory: `gitcrawl.db`, `cache/`, `vectors/`, and `logs/`.
+  This is useful for temporary archives and reproducible tests. Existing
+  `init --db` behavior remains database-only.
 - Absolute XDG environment variables are honored even on macOS. Relative XDG
   values are ignored and gitcrawl falls back to the platform default for that
   path.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -69,9 +69,11 @@ type App struct {
 
 type initResult struct {
 	ConfigPath       string `json:"config_path"`
+	RuntimeDir       string `json:"runtime_dir,omitempty"`
 	DBPath           string `json:"db_path"`
 	CacheDir         string `json:"cache_dir"`
 	VectorDir        string `json:"vector_dir"`
+	LogDir           string `json:"log_dir"`
 	PortableStoreURL string `json:"portable_store_url,omitempty"`
 	PortableStoreDir string `json:"portable_store_dir,omitempty"`
 	PortableStore    string `json:"portable_store,omitempty"`
@@ -2750,21 +2752,23 @@ func (a *App) runInit(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("init", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	dbPath := fs.String("db", "", "database path")
+	runtimeDir := fs.String("runtime-dir", "", "root for an isolated database, cache, vectors, and logs")
 	portableStore := fs.String("portable-store", "", "HTTPS git URL for a portable gitcrawl store")
 	portableDB := fs.String("portable-db", "data/openclaw__openclaw.sync.db", "database path inside portable store")
 	storeDir := fs.String("store-dir", "", "local portable store checkout directory")
 	remoteEndpoint := fs.String("remote", "", "remote archive endpoint")
 	remoteArchive := fs.String("archive", "", "remote archive id")
 	jsonOut := fs.Bool("json", false, "write JSON output")
-	if err := fs.Parse(normalizeCommandArgs(args, map[string]bool{"db": true, "portable-store": true, "portable-db": true, "store-dir": true, "remote": true, "archive": true})); err != nil {
+	if err := fs.Parse(normalizeCommandArgs(args, map[string]bool{"db": true, "runtime-dir": true, "portable-store": true, "portable-db": true, "store-dir": true, "remote": true, "archive": true})); err != nil {
 		return usageErr(err)
 	}
 	a.applyCommandJSON(*jsonOut)
 	localDBPath := strings.TrimSpace(*dbPath)
+	isolatedRuntimeDir := strings.TrimSpace(*runtimeDir)
 	portableStoreURL := strings.TrimSpace(*portableStore)
 	remoteEndpointValue := strings.TrimSpace(*remoteEndpoint)
-	if nonEmptyCount(localDBPath, portableStoreURL, remoteEndpointValue) > 1 {
-		return usageErr(fmt.Errorf("use only one of --db, --portable-store, or --remote"))
+	if nonEmptyCount(localDBPath, isolatedRuntimeDir, portableStoreURL, remoteEndpointValue) > 1 {
+		return usageErr(fmt.Errorf("use only one of --db, --runtime-dir, --portable-store, or --remote"))
 	}
 
 	cfg := config.Default()
@@ -2803,6 +2807,12 @@ func (a *App) runInit(ctx context.Context, args []string) error {
 	if localDBPath != "" {
 		cfg.DBPath = localDBPath
 	}
+	if isolatedRuntimeDir != "" {
+		cfg.DBPath = filepath.Join(isolatedRuntimeDir, "gitcrawl.db")
+		cfg.CacheDir = filepath.Join(isolatedRuntimeDir, "cache")
+		cfg.VectorDir = filepath.Join(isolatedRuntimeDir, "vectors")
+		cfg.LogDir = filepath.Join(isolatedRuntimeDir, "logs")
+	}
 	if err := cfg.Normalize(); err != nil {
 		return err
 	}
@@ -2816,9 +2826,11 @@ func (a *App) runInit(ctx context.Context, args []string) error {
 	}
 	result := initResult{
 		ConfigPath:       config.ResolvePath(a.configPath),
+		RuntimeDir:       isolatedRuntimeDir,
 		DBPath:           cfg.DBPath,
 		CacheDir:         cfg.CacheDir,
 		VectorDir:        cfg.VectorDir,
+		LogDir:           cfg.LogDir,
 		PortableStoreURL: portableStoreURL,
 		PortableStoreDir: portableStoreDir,
 		PortableStore:    portableStoreAction,
@@ -4230,7 +4242,7 @@ func (a *App) writeInitOutput(result initResult) error {
 	case FormatJSON:
 		return a.writeOutput("init", result, true)
 	case FormatLog:
-		_, err := fmt.Fprintf(a.Stdout, "init config_path=%s db_path=%s portable_store=%s remote=%s archive=%s\n", result.ConfigPath, result.DBPath, result.PortableStore, result.RemoteEndpoint, result.RemoteArchive)
+		_, err := fmt.Fprintf(a.Stdout, "init config_path=%s runtime_dir=%s db_path=%s portable_store=%s remote=%s archive=%s\n", result.ConfigPath, result.RuntimeDir, result.DBPath, result.PortableStore, result.RemoteEndpoint, result.RemoteArchive)
 		return err
 	default:
 		lines := []string{
@@ -4239,6 +4251,7 @@ func (a *App) writeInitOutput(result initResult) error {
 			"db path: " + result.DBPath,
 			"cache dir: " + result.CacheDir,
 			"vector dir: " + result.VectorDir,
+			"log dir: " + result.LogDir,
 		}
 		if result.PortableStoreURL != "" {
 			lines = append(lines,
@@ -4378,7 +4391,7 @@ Usage:
 	"init": `gitcrawl init creates a local, portable, or cloud archive config.
 
 Usage:
-  gitcrawl init [--db path] [--portable-store URL] [--remote URL --archive id] [--json]
+  gitcrawl init [--db path | --runtime-dir path | --portable-store URL | --remote URL --archive id] [--json]
 `,
 	"configure": `gitcrawl configure updates model fields in the config.
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -56,6 +56,64 @@ func TestInitWritesConfig(t *testing.T) {
 	}
 }
 
+func TestInitRuntimeDirIsolatesRuntimePaths(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	runtimeDir := filepath.Join(dir, "runtime")
+	app := New()
+	var stdout bytes.Buffer
+	app.Stdout = &stdout
+
+	if err := app.Run(context.Background(), []string{"--config", configPath, "--json", "init", "--runtime-dir", runtimeDir}); err != nil {
+		t.Fatalf("run isolated init: %v", err)
+	}
+	var result initResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode init output: %v\n%s", err, stdout.String())
+	}
+	if result.RuntimeDir != runtimeDir {
+		t.Fatalf("runtime dir = %q, want %q", result.RuntimeDir, runtimeDir)
+	}
+	wantPaths := map[string]string{
+		"db":      filepath.Join(runtimeDir, "gitcrawl.db"),
+		"cache":   filepath.Join(runtimeDir, "cache"),
+		"vectors": filepath.Join(runtimeDir, "vectors"),
+		"logs":    filepath.Join(runtimeDir, "logs"),
+	}
+	gotPaths := map[string]string{
+		"db":      result.DBPath,
+		"cache":   result.CacheDir,
+		"vectors": result.VectorDir,
+		"logs":    result.LogDir,
+	}
+	for name, want := range wantPaths {
+		if gotPaths[name] != want {
+			t.Errorf("%s path = %q, want %q", name, gotPaths[name], want)
+		}
+	}
+	for _, path := range []string{filepath.Dir(wantPaths["db"]), wantPaths["cache"], wantPaths["vectors"], wantPaths["logs"]} {
+		if info, err := os.Stat(path); err != nil || !info.IsDir() {
+			t.Errorf("runtime directory %q: info=%v err=%v", path, info, err)
+		}
+	}
+	loaded, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("load isolated config: %v", err)
+	}
+	if loaded.DBPath != wantPaths["db"] || loaded.CacheDir != wantPaths["cache"] || loaded.VectorDir != wantPaths["vectors"] || loaded.LogDir != wantPaths["logs"] {
+		t.Fatalf("isolated config paths = %+v", loaded)
+	}
+}
+
+func TestInitRuntimeDirRejectsOtherArchiveModes(t *testing.T) {
+	dir := t.TempDir()
+	app := New()
+	err := app.Run(context.Background(), []string{"--config", filepath.Join(dir, "config.toml"), "init", "--runtime-dir", filepath.Join(dir, "runtime"), "--db", filepath.Join(dir, "other.db")})
+	if err == nil || !strings.Contains(err.Error(), "use only one of") {
+		t.Fatalf("runtime/db conflict error = %v", err)
+	}
+}
+
 func TestGitcrawlThreadBodyExpr(t *testing.T) {
 	ctx := context.Background()
 	cases := []struct {


### PR DESCRIPTION
## Summary

- add `gitcrawl init --runtime-dir <path>` for isolated temporary runtimes
- place the database, cache, vectors, and logs beneath the selected root
- preserve the existing database-only meaning of `init --db`
- document the new mode and include all resolved paths in init output

Fixes #78.

## Verification

- `GOWORK=off go test ./internal/cli ./internal/config`
- `GOWORK=off go test ./...`
- live temporary-directory CLI smoke with JSON output and filesystem inspection
- autoreview clean; no actionable findings
