### PR TITLE
Add archive coverage reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.6.5 - Unreleased
 
+- Add read-only per-repository archive coverage reporting with JSON/table output, repository and missing-PR-detail filters, hydration counts, and explicit failure-ledger availability. Thanks @TurboTheTurtle.
 - Report the active executable/build identity and read-only database schema compatibility in `gitcrawl doctor --json`, including actionable drift diagnostics without applying migrations. Thanks @TurboTheTurtle.
 - Document the first-run local maintainer archive workflow, including targeted PR hydration, bounded-staleness search, run inspection, and the Octopool boundary. Thanks @TurboTheTurtle.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ gitcrawl sync owner/repo
 gitcrawl sync owner/repo --state open
 gitcrawl sync owner/repo --numbers 123,456 --include-comments
 gitcrawl sync owner/repo --numbers https://github.com/owner/repo/issues/123 --with pr-details
-gitcrawl coverage owner/repo --min-missing-pr-details 1 --json
+gitcrawl coverage --repos owner/repo,owner/other --min-missing-pr-details 1 --json
 gitcrawl refresh owner/repo
 gitcrawl cluster owner/repo --threshold 0.80
 gitcrawl clusters owner/repo

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ gitcrawl sync owner/repo
 gitcrawl sync owner/repo --state open
 gitcrawl sync owner/repo --numbers 123,456 --include-comments
 gitcrawl sync owner/repo --numbers https://github.com/owner/repo/issues/123 --with pr-details
+gitcrawl coverage owner/repo --min-missing-pr-details 1 --json
 gitcrawl refresh owner/repo
 gitcrawl cluster owner/repo --threshold 0.80
 gitcrawl clusters owner/repo

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -42,6 +42,7 @@ These work on every command.
 | Command | Purpose | Docs |
 | --- | --- | --- |
 | `gitcrawl sync owner/repo [--state --since --numbers <refs> --limit --include-comments --include-pr-details --with pr-details --json]` | Sync issues and PRs from GitHub into local SQLite | [Sync](/sync/) |
+| `gitcrawl coverage [owner/repo] [--min-missing-pr-details N --json]` | Report per-repository PR-detail completeness from the local archive | — |
 | `gitcrawl refresh owner/repo [--no-sync --no-embed --no-cluster ...]` | Wrapper that runs sync → embed → cluster | [Refresh and embed](/refresh-and-embed/) |
 | `gitcrawl embed owner/repo [--number <ref> --limit --force --include-closed --json]` | Generate OpenAI embeddings for thread documents | [Refresh and embed](/refresh-and-embed/#embed) |
 | `gitcrawl runs owner/repo [--kind sync\|embedding\|cluster --limit --json]` | List recorded run history | [Refresh and embed](/refresh-and-embed/#runs) |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -42,7 +42,7 @@ These work on every command.
 | Command | Purpose | Docs |
 | --- | --- | --- |
 | `gitcrawl sync owner/repo [--state --since --numbers <refs> --limit --include-comments --include-pr-details --with pr-details --json]` | Sync issues and PRs from GitHub into local SQLite | [Sync](/sync/) |
-| `gitcrawl coverage [owner/repo] [--min-missing-pr-details N --json]` | Report per-repository PR-detail completeness from the local archive | — |
+| `gitcrawl coverage [owner/repo \| --repos owner/a,owner/b] [--min-missing-pr-details N --json]` | Report per-repository archive and PR-detail completeness | — |
 | `gitcrawl refresh owner/repo [--no-sync --no-embed --no-cluster ...]` | Wrapper that runs sync → embed → cluster | [Refresh and embed](/refresh-and-embed/) |
 | `gitcrawl embed owner/repo [--number <ref> --limit --force --include-closed --json]` | Generate OpenAI embeddings for thread documents | [Refresh and embed](/refresh-and-embed/#embed) |
 | `gitcrawl runs owner/repo [--kind sync\|embedding\|cluster --limit --json]` | List recorded run history | [Refresh and embed](/refresh-and-embed/#runs) |

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -73,7 +73,7 @@ issue or pull request URLs.
 
 PR details land in `pr_files`, `pr_commits`, `pr_checks`, and `pr_runs` tables for local review, search, clustering, and TUI workflows.
 
-Use `gitcrawl coverage [owner/repo] --json` to inspect PR-detail completeness after a sync. It reports total PRs, PRs with hydrated detail rows, missing PR details, and detail-table row counts per repository. Add `--min-missing-pr-details N` to focus backfill work on repositories with gaps. Known failed or skipped hydration attempts are reported as unavailable until the separate failure ledger is present.
+Use `gitcrawl coverage [owner/repo] --json` to inspect archive completeness after a sync. It reports issue, PR, comment, and review counts alongside hydrated PR detail rows, missing PR details, and detail-table row counts per repository. Use `--repos owner/a,owner/b` to compare selected repositories and `--min-missing-pr-details N` to focus backfill work on repositories with gaps. Known failed or skipped hydration attempts are reported as unavailable until the separate failure ledger is present.
 
 `--include-code` is accepted for compatibility but is currently a no-op.
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -73,6 +73,8 @@ issue or pull request URLs.
 
 PR details land in `pr_files`, `pr_commits`, `pr_checks`, and `pr_runs` tables for local review, search, clustering, and TUI workflows.
 
+Use `gitcrawl coverage [owner/repo] --json` to inspect PR-detail completeness after a sync. It reports total PRs, PRs with hydrated detail rows, missing PR details, and detail-table row counts per repository. Add `--min-missing-pr-details N` to focus backfill work on repositories with gaps. Known failed or skipped hydration attempts are reported as unavailable until the separate failure ledger is present.
+
 `--include-code` is accepted for compatibility but is currently a no-op.
 
 ## Limit and pagination

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/alecthomas/kong"
@@ -175,6 +176,8 @@ func (a *App) Run(ctx context.Context, args []string) error {
 		return a.runSetClusterCanonical(ctx, rest[1:])
 	case "runs":
 		return a.runRuns(ctx, rest[1:])
+	case "coverage":
+		return a.runCoverage(ctx, rest[1:])
 	case "search":
 		return a.runSearch(ctx, rest[1:])
 	case "code":
@@ -2256,6 +2259,103 @@ func (a *App) runRuns(ctx context.Context, args []string) error {
 	}, true)
 }
 
+func (a *App) runCoverage(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("coverage", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	minMissingRaw := fs.String("min-missing-pr-details", "", "only show repositories with at least this many PRs missing detail rows")
+	jsonOut := fs.Bool("json", false, "write JSON output")
+	if err := fs.Parse(normalizeCommandArgs(args, map[string]bool{"min-missing-pr-details": true})); err != nil {
+		return usageErr(err)
+	}
+	a.applyCommandJSON(*jsonOut)
+	if fs.NArg() > 1 {
+		return usageErr(fmt.Errorf("coverage accepts at most one owner/repo filter"))
+	}
+	minMissing, err := parseOptionalNonNegativeInt(*minMissingRaw)
+	if err != nil {
+		return usageErr(fmt.Errorf("min-missing-pr-details: %w", err))
+	}
+
+	rt, err := a.openLocalRuntimeReadOnly(ctx)
+	if err != nil {
+		return err
+	}
+	defer rt.Store.Close()
+
+	opts := store.ArchiveCoverageOptions{MinMissingPRDetails: minMissing}
+	repository := ""
+	if fs.NArg() == 1 {
+		owner, repoName, err := parseOwnerRepo(fs.Arg(0))
+		if err != nil {
+			return usageErr(err)
+		}
+		repo, err := rt.repository(ctx, owner, repoName)
+		if err != nil {
+			return err
+		}
+		opts.RepoID = repo.ID
+		repository = repo.FullName
+	}
+	coverage, err := rt.Store.ArchiveCoverage(ctx, opts)
+	if err != nil {
+		return err
+	}
+	payload := map[string]any{
+		"repository":                   repository,
+		"min_missing_pr_details":       minMissing,
+		"hydration_failures_available": false,
+		"repositories":                 coverage.Rows,
+		"totals":                       coverage.Totals,
+	}
+	if a.format == FormatJSON {
+		return a.writeOutput("coverage", payload, true)
+	}
+	return a.writeCoverageTable(coverage)
+}
+
+func (a *App) writeCoverageTable(coverage store.ArchiveCoverage) error {
+	tw := tabwriter.NewWriter(a.Stdout, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "REPOSITORY\tISSUES\tPRS\tPRS_WITH_DETAILS\tMISSING_PR_DETAILS\tFILES\tCOMMITS\tCHECKS\tREVIEW_THREADS\tWORKFLOW_RUNS\tLAST_SYNC"); err != nil {
+		return err
+	}
+	for _, row := range coverage.Rows {
+		if _, err := fmt.Fprintf(tw, "%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\n",
+			row.Repository,
+			row.Issues,
+			row.PullRequests,
+			row.PullRequestsWithDetails,
+			row.MissingPRDetails,
+			row.PRFiles,
+			row.PRCommits,
+			row.PRChecks,
+			row.PRReviewThreads,
+			row.WorkflowRuns,
+			row.LastSyncAt,
+		); err != nil {
+			return err
+		}
+	}
+	if len(coverage.Rows) > 1 {
+		row := coverage.Totals
+		if _, err := fmt.Fprintf(tw, "%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\n",
+			row.Repository,
+			row.Issues,
+			row.PullRequests,
+			row.PullRequestsWithDetails,
+			row.MissingPRDetails,
+			row.PRFiles,
+			row.PRCommits,
+			row.PRChecks,
+			row.PRReviewThreads,
+			row.WorkflowRuns,
+			row.LastSyncAt,
+		); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
 func (a *App) runThreads(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("threads", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
@@ -3551,7 +3651,7 @@ func (a *App) runMetadata(args []string) error {
 		DefaultCache:    cfg.CacheDir,
 		DefaultLogs:     cfg.LogDir,
 	}
-	manifest.Capabilities = []string{"metadata", "status", "doctor", "sync", "search", "code-index", "tui", "portable", "remote", "cloud-publish", "clusters", "embeddings"}
+	manifest.Capabilities = []string{"metadata", "status", "doctor", "sync", "coverage", "search", "code-index", "tui", "portable", "remote", "cloud-publish", "clusters", "embeddings"}
 	manifest.Privacy = control.Privacy{ContainsPrivateMessages: false, ExportsSecrets: false, LocalOnlyScopes: []string{"github", "git", "sqlite", "portable"}}
 	manifest.Commands = map[string]control.Command{
 		"status":          {Title: "Status", Argv: []string{"gitcrawl", "status", "--json"}, JSON: true},
@@ -3562,6 +3662,7 @@ func (a *App) runMetadata(args []string) error {
 		"whoami":          {Title: "Remote identity", Argv: []string{"gitcrawl", "whoami", "--json"}, JSON: true},
 		"check-update":    {Title: "Check for updates", Argv: []string{"gitcrawl", "check-update", "--json"}, JSON: true},
 		"doctor":          {Title: "Doctor", Argv: []string{"gitcrawl", "doctor", "--json"}, JSON: true},
+		"coverage":        {Title: "Archive coverage", Argv: []string{"gitcrawl", "coverage", "--json"}, JSON: true},
 		"sync":            {Title: "Sync repository", Argv: []string{"gitcrawl", "sync", "--json"}, JSON: true, Mutates: true},
 		"search":          {Title: "Search", Argv: []string{"gitcrawl", "search", "--json"}, JSON: true},
 		"code-index":      {Title: "Code index", Argv: []string{"gitcrawl", "code", "index", "--json"}, JSON: true, Mutates: true},
@@ -3790,6 +3891,17 @@ func parseOptionalPositiveInt(value string) (int, error) {
 	parsed, err := strconv.Atoi(value)
 	if err != nil || parsed <= 0 {
 		return 0, fmt.Errorf("expected positive integer, got %q", value)
+	}
+	return parsed, nil
+}
+
+func parseOptionalNonNegativeInt(value string) (int, error) {
+	if strings.TrimSpace(value) == "" {
+		return 0, nil
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed < 0 {
+		return 0, fmt.Errorf("expected non-negative integer, got %q", value)
 	}
 	return parsed, nil
 }
@@ -4372,6 +4484,7 @@ Core commands:
   init                 create config, optionally from a portable store
   doctor               check config, token, and database readiness
   sync                 sync GitHub issue and pull request metadata
+  coverage             report local archive PR-detail completeness
   refresh              run sync, enrichment, embedding, and clustering pipeline
   embed                generate OpenAI embeddings for local thread documents
   threads              list local issue and pull request rows
@@ -4455,6 +4568,11 @@ Usage:
 
 Usage:
   gitcrawl sync owner/repo [--state open|closed|all] [--numbers refs] [--with pr-details] [--include-pr-details] [--json]
+`,
+	"coverage": `gitcrawl coverage reports local archive PR-detail completeness.
+
+Usage:
+  gitcrawl coverage [owner/repo] [--min-missing-pr-details N] [--json]
 `,
 	"refresh": `gitcrawl refresh runs sync, enrichment, embedding, and clustering.
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -2262,14 +2262,18 @@ func (a *App) runRuns(ctx context.Context, args []string) error {
 func (a *App) runCoverage(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("coverage", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
+	reposRaw := fs.String("repos", "", "comma-separated owner/repo filters")
 	minMissingRaw := fs.String("min-missing-pr-details", "", "only show repositories with at least this many PRs missing detail rows")
 	jsonOut := fs.Bool("json", false, "write JSON output")
-	if err := fs.Parse(normalizeCommandArgs(args, map[string]bool{"min-missing-pr-details": true})); err != nil {
+	if err := fs.Parse(normalizeCommandArgs(args, map[string]bool{"repos": true, "min-missing-pr-details": true})); err != nil {
 		return usageErr(err)
 	}
 	a.applyCommandJSON(*jsonOut)
 	if fs.NArg() > 1 {
 		return usageErr(fmt.Errorf("coverage accepts at most one owner/repo filter"))
+	}
+	if fs.NArg() == 1 && strings.TrimSpace(*reposRaw) != "" {
+		return usageErr(fmt.Errorf("coverage accepts either a positional owner/repo or --repos, not both"))
 	}
 	minMissing, err := parseOptionalNonNegativeInt(*minMissingRaw)
 	if err != nil {
@@ -2282,10 +2286,23 @@ func (a *App) runCoverage(ctx context.Context, args []string) error {
 	}
 	defer rt.Store.Close()
 
-	opts := store.ArchiveCoverageOptions{MinMissingPRDetails: minMissing}
-	repository := ""
+	repositoryFilters := make([]string, 0)
 	if fs.NArg() == 1 {
-		owner, repoName, err := parseOwnerRepo(fs.Arg(0))
+		repositoryFilters = append(repositoryFilters, fs.Arg(0))
+	} else if strings.TrimSpace(*reposRaw) != "" {
+		for _, value := range strings.Split(*reposRaw, ",") {
+			value = strings.TrimSpace(value)
+			if value == "" {
+				return usageErr(fmt.Errorf("repos: expected comma-separated owner/repo values"))
+			}
+			repositoryFilters = append(repositoryFilters, value)
+		}
+	}
+	opts := store.ArchiveCoverageOptions{MinMissingPRDetails: minMissing}
+	resolvedFilters := make([]string, 0, len(repositoryFilters))
+	seenRepoIDs := make(map[int64]struct{}, len(repositoryFilters))
+	for _, value := range repositoryFilters {
+		owner, repoName, err := parseOwnerRepo(value)
 		if err != nil {
 			return usageErr(err)
 		}
@@ -2293,15 +2310,19 @@ func (a *App) runCoverage(ctx context.Context, args []string) error {
 		if err != nil {
 			return err
 		}
-		opts.RepoID = repo.ID
-		repository = repo.FullName
+		if _, seen := seenRepoIDs[repo.ID]; seen {
+			continue
+		}
+		seenRepoIDs[repo.ID] = struct{}{}
+		opts.RepoIDs = append(opts.RepoIDs, repo.ID)
+		resolvedFilters = append(resolvedFilters, repo.FullName)
 	}
 	coverage, err := rt.Store.ArchiveCoverage(ctx, opts)
 	if err != nil {
 		return err
 	}
 	payload := map[string]any{
-		"repository":                   repository,
+		"repository_filters":           resolvedFilters,
 		"min_missing_pr_details":       minMissing,
 		"hydration_failures_available": false,
 		"repositories":                 coverage.Rows,
@@ -2315,14 +2336,16 @@ func (a *App) runCoverage(ctx context.Context, args []string) error {
 
 func (a *App) writeCoverageTable(coverage store.ArchiveCoverage) error {
 	tw := tabwriter.NewWriter(a.Stdout, 0, 0, 2, ' ', 0)
-	if _, err := fmt.Fprintln(tw, "REPOSITORY\tISSUES\tPRS\tPRS_WITH_DETAILS\tMISSING_PR_DETAILS\tFILES\tCOMMITS\tCHECKS\tREVIEW_THREADS\tWORKFLOW_RUNS\tLAST_SYNC"); err != nil {
+	if _, err := fmt.Fprintln(tw, "REPOSITORY\tISSUES\tPRS\tCOMMENTS\tPR_REVIEWS\tPRS_WITH_DETAILS\tMISSING_PR_DETAILS\tFILES\tCOMMITS\tCHECKS\tREVIEW_THREADS\tWORKFLOW_RUNS\tLAST_SYNC"); err != nil {
 		return err
 	}
 	for _, row := range coverage.Rows {
-		if _, err := fmt.Fprintf(tw, "%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\n",
+		if _, err := fmt.Fprintf(tw, "%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\n",
 			row.Repository,
 			row.Issues,
 			row.PullRequests,
+			row.Comments,
+			row.PRReviews,
 			row.PullRequestsWithDetails,
 			row.MissingPRDetails,
 			row.PRFiles,
@@ -2337,10 +2360,12 @@ func (a *App) writeCoverageTable(coverage store.ArchiveCoverage) error {
 	}
 	if len(coverage.Rows) > 1 {
 		row := coverage.Totals
-		if _, err := fmt.Fprintf(tw, "%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\n",
+		if _, err := fmt.Fprintf(tw, "%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\n",
 			row.Repository,
 			row.Issues,
 			row.PullRequests,
+			row.Comments,
+			row.PRReviews,
 			row.PullRequestsWithDetails,
 			row.MissingPRDetails,
 			row.PRFiles,
@@ -4569,10 +4594,10 @@ Usage:
 Usage:
   gitcrawl sync owner/repo [--state open|closed|all] [--numbers refs] [--with pr-details] [--include-pr-details] [--json]
 `,
-	"coverage": `gitcrawl coverage reports local archive PR-detail completeness.
+	"coverage": `gitcrawl coverage reports local archive completeness by repository.
 
 Usage:
-  gitcrawl coverage [owner/repo] [--min-missing-pr-details N] [--json]
+  gitcrawl coverage [owner/repo | --repos owner/a,owner/b] [--min-missing-pr-details N] [--json]
 `,
 	"refresh": `gitcrawl refresh runs sync, enrichment, embedding, and clustering.
 

--- a/internal/cli/archive_coverage_test.go
+++ b/internal/cli/archive_coverage_test.go
@@ -152,6 +152,62 @@ func TestCoverageCommandSupportsCanonicalPortableArchive(t *testing.T) {
 	}
 }
 
+func TestCoverageCommandSupportsArchiveWithoutOptionalCoverageTables(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	dbPath := filepath.Join(dir, "gitcrawl.db")
+	if err := New().Run(ctx, []string{"--config", configPath, "init", "--db", dbPath}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	seedCoverageStore(t, ctx, dbPath)
+
+	st, err := store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	for _, table := range []string{
+		"comments",
+		"pull_request_files",
+		"pull_request_commits",
+		"pull_request_checks",
+		"pull_request_review_threads",
+		"pull_request_details",
+		"github_workflow_runs",
+		"sync_runs",
+		"repo_sync_state",
+	} {
+		if _, err := st.DB().ExecContext(ctx, `drop table `+table); err != nil {
+			st.Close()
+			t.Fatalf("drop %s: %v", table, err)
+		}
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close compatibility archive: %v", err)
+	}
+
+	run := New()
+	var out bytes.Buffer
+	run.Stdout = &out
+	if err := run.Run(ctx, []string{"--config", configPath, "coverage", "--json"}); err != nil {
+		t.Fatalf("coverage compatibility archive: %v", err)
+	}
+	var payload struct {
+		Repositories []store.ArchiveCoverageRow `json:"repositories"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("decode compatibility coverage json: %v\n%s", err, out.String())
+	}
+	if len(payload.Repositories) != 2 {
+		t.Fatalf("compatibility coverage rows = %+v", payload.Repositories)
+	}
+	for _, row := range payload.Repositories {
+		if row.PullRequestsWithDetails != 0 || row.MissingPRDetails != row.PullRequests || row.Comments != 0 || row.PRFiles != 0 || row.WorkflowRuns != 0 {
+			t.Fatalf("compatibility coverage row = %+v", row)
+		}
+	}
+}
+
 func seedCoverageStore(t *testing.T, ctx context.Context, dbPath string) {
 	t.Helper()
 	st, err := store.Open(ctx, dbPath)

--- a/internal/cli/archive_coverage_test.go
+++ b/internal/cli/archive_coverage_test.go
@@ -1,0 +1,148 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/gitcrawl/internal/store"
+)
+
+func TestCoverageCommandJSONAndTable(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	dbPath := filepath.Join(dir, "gitcrawl.db")
+	if err := New().Run(ctx, []string{"--config", configPath, "init", "--db", dbPath}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	seedCoverageStore(t, ctx, dbPath)
+
+	jsonRun := New()
+	var jsonOut bytes.Buffer
+	jsonRun.Stdout = &jsonOut
+	if err := jsonRun.Run(ctx, []string{"--config", configPath, "coverage", "openclaw/gitcrawl", "--min-missing-pr-details", "2", "--json"}); err != nil {
+		t.Fatalf("coverage json: %v", err)
+	}
+	var payload struct {
+		Repositories []store.ArchiveCoverageRow `json:"repositories"`
+		Totals       store.ArchiveCoverageRow   `json:"totals"`
+	}
+	if err := json.Unmarshal(jsonOut.Bytes(), &payload); err != nil {
+		t.Fatalf("decode coverage json: %v\n%s", err, jsonOut.String())
+	}
+	if len(payload.Repositories) != 1 {
+		t.Fatalf("repositories = %+v", payload.Repositories)
+	}
+	row := payload.Repositories[0]
+	if row.Repository != "openclaw/gitcrawl" || row.PullRequests != 3 || row.PullRequestsWithDetails != 1 || row.MissingPRDetails != 2 {
+		t.Fatalf("coverage row = %+v", row)
+	}
+	if row.HydrationFailuresSupported || row.KnownFailedHydrations != nil {
+		t.Fatalf("failure ledger fields = %+v", row)
+	}
+
+	tableRun := New()
+	var tableOut bytes.Buffer
+	tableRun.Stdout = &tableOut
+	if err := tableRun.Run(ctx, []string{"--config", configPath, "coverage"}); err != nil {
+		t.Fatalf("coverage table: %v", err)
+	}
+	if !strings.Contains(tableOut.String(), "MISSING_PR_DETAILS") || !strings.Contains(tableOut.String(), "openclaw/gitcrawl") || !strings.Contains(tableOut.String(), "openclaw/other") {
+		t.Fatalf("coverage table output = %q", tableOut.String())
+	}
+}
+
+func seedCoverageStore(t *testing.T, ctx context.Context, dbPath string) {
+	t.Helper()
+	st, err := store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	gitcrawlID, err := st.UpsertRepository(ctx, store.Repository{Owner: "openclaw", Name: "gitcrawl", FullName: "openclaw/gitcrawl", RawJSON: "{}", UpdatedAt: "2026-07-03T00:00:00Z"})
+	if err != nil {
+		t.Fatalf("gitcrawl repo: %v", err)
+	}
+	otherID, err := st.UpsertRepository(ctx, store.Repository{Owner: "openclaw", Name: "other", FullName: "openclaw/other", RawJSON: "{}", UpdatedAt: "2026-07-03T00:00:00Z"})
+	if err != nil {
+		t.Fatalf("other repo: %v", err)
+	}
+	_, err = st.UpsertThread(ctx, coverageThread(gitcrawlID, 1, "issue"))
+	if err != nil {
+		t.Fatalf("issue thread: %v", err)
+	}
+	var detailedPRID int64
+	for _, number := range []int{2, 3, 4} {
+		id, err := st.UpsertThread(ctx, coverageThread(gitcrawlID, number, "pull_request"))
+		if err != nil {
+			t.Fatalf("gitcrawl pr %d: %v", number, err)
+		}
+		if number == 3 {
+			detailedPRID = id
+		}
+	}
+	if _, err := st.UpsertThread(ctx, coverageThread(otherID, 9, "pull_request")); err != nil {
+		t.Fatalf("other pr: %v", err)
+	}
+	if err := st.UpsertPullRequestCache(ctx, store.PullRequestDetail{
+		ThreadID:  detailedPRID,
+		RepoID:    gitcrawlID,
+		Number:    3,
+		RawJSON:   "{}",
+		FetchedAt: "2026-07-03T00:00:00Z",
+		UpdatedAt: "2026-07-03T00:00:00Z",
+	}, []store.PullRequestFile{{
+		ThreadID:  detailedPRID,
+		Path:      "README.md",
+		RawJSON:   "{}",
+		FetchedAt: "2026-07-03T00:00:00Z",
+	}}, []store.PullRequestCommit{{
+		ThreadID:  detailedPRID,
+		SHA:       "abc",
+		RawJSON:   "{}",
+		FetchedAt: "2026-07-03T00:00:00Z",
+	}}, []store.PullRequestCheck{{
+		ThreadID:  detailedPRID,
+		Name:      "test",
+		RawJSON:   "{}",
+		FetchedAt: "2026-07-03T00:00:00Z",
+	}}, []store.WorkflowRun{{
+		RepoID:    gitcrawlID,
+		RunID:     "99",
+		RawJSON:   "{}",
+		FetchedAt: "2026-07-03T00:00:00Z",
+	}}); err != nil {
+		t.Fatalf("pr details: %v", err)
+	}
+	if err := st.UpsertPullRequestReviewThreads(ctx, detailedPRID, "2026-07-03T00:00:00Z", []store.PullRequestReviewThread{{
+		ThreadID:       detailedPRID,
+		ReviewThreadID: "thread-1",
+		RawJSON:        "{}",
+		CommentsJSON:   "[]",
+		FetchedAt:      "2026-07-03T00:00:00Z",
+	}}); err != nil {
+		t.Fatalf("review thread: %v", err)
+	}
+}
+
+func coverageThread(repoID int64, number int, kind string) store.Thread {
+	return store.Thread{
+		RepoID:        repoID,
+		GitHubID:      fmt.Sprintf("gid-%d", number),
+		Number:        number,
+		Kind:          kind,
+		State:         "open",
+		Title:         "thread",
+		HTMLURL:       "https://github.com/openclaw/gitcrawl/issues/1",
+		LabelsJSON:    "[]",
+		AssigneesJSON: "[]",
+		RawJSON:       "{}",
+		ContentHash:   "hash",
+		UpdatedAt:     "2026-07-03T00:00:00Z",
+	}
+}

--- a/internal/cli/archive_coverage_test.go
+++ b/internal/cli/archive_coverage_test.go
@@ -29,8 +29,9 @@ func TestCoverageCommandJSONAndTable(t *testing.T) {
 		t.Fatalf("coverage json: %v", err)
 	}
 	var payload struct {
-		Repositories []store.ArchiveCoverageRow `json:"repositories"`
-		Totals       store.ArchiveCoverageRow   `json:"totals"`
+		RepositoryFilters []string                   `json:"repository_filters"`
+		Repositories      []store.ArchiveCoverageRow `json:"repositories"`
+		Totals            store.ArchiveCoverageRow   `json:"totals"`
 	}
 	if err := json.Unmarshal(jsonOut.Bytes(), &payload); err != nil {
 		t.Fatalf("decode coverage json: %v\n%s", err, jsonOut.String())
@@ -41,6 +42,9 @@ func TestCoverageCommandJSONAndTable(t *testing.T) {
 	row := payload.Repositories[0]
 	if row.Repository != "openclaw/gitcrawl" || row.PullRequests != 3 || row.PullRequestsWithDetails != 1 || row.MissingPRDetails != 2 {
 		t.Fatalf("coverage row = %+v", row)
+	}
+	if row.Comments != 2 || row.PRReviews != 1 {
+		t.Fatalf("comment coverage = %+v", row)
 	}
 	if row.HydrationFailuresSupported || row.KnownFailedHydrations != nil {
 		t.Fatalf("failure ledger fields = %+v", row)
@@ -54,6 +58,45 @@ func TestCoverageCommandJSONAndTable(t *testing.T) {
 	}
 	if !strings.Contains(tableOut.String(), "MISSING_PR_DETAILS") || !strings.Contains(tableOut.String(), "openclaw/gitcrawl") || !strings.Contains(tableOut.String(), "openclaw/other") {
 		t.Fatalf("coverage table output = %q", tableOut.String())
+	}
+
+	multiRun := New()
+	var multiOut bytes.Buffer
+	multiRun.Stdout = &multiOut
+	if err := multiRun.Run(ctx, []string{"--config", configPath, "coverage", "--repos", "openclaw/gitcrawl,openclaw/other,openclaw/gitcrawl", "--json"}); err != nil {
+		t.Fatalf("coverage multi-repo json: %v", err)
+	}
+	if err := json.Unmarshal(multiOut.Bytes(), &payload); err != nil {
+		t.Fatalf("decode multi-repo coverage json: %v\n%s", err, multiOut.String())
+	}
+	if got := payload.RepositoryFilters; len(got) != 2 || got[0] != "openclaw/gitcrawl" || got[1] != "openclaw/other" {
+		t.Fatalf("repository filters = %v", got)
+	}
+	if len(payload.Repositories) != 2 {
+		t.Fatalf("filtered repositories = %+v", payload.Repositories)
+	}
+
+	filteredRun := New()
+	var filteredOut bytes.Buffer
+	filteredRun.Stdout = &filteredOut
+	if err := filteredRun.Run(ctx, []string{"--config", configPath, "coverage", "--repos", "openclaw/gitcrawl,openclaw/other", "--min-missing-pr-details", "4", "--json"}); err != nil {
+		t.Fatalf("coverage filtered json: %v", err)
+	}
+	payload.Repositories = nil
+	if err := json.Unmarshal(filteredOut.Bytes(), &payload); err != nil {
+		t.Fatalf("decode filtered coverage json: %v\n%s", err, filteredOut.String())
+	}
+	if payload.Repositories == nil || len(payload.Repositories) != 0 {
+		t.Fatalf("empty repositories should encode as an array: %+v", payload.Repositories)
+	}
+
+	for _, args := range [][]string{
+		{"--config", configPath, "coverage", "openclaw/gitcrawl", "--repos", "openclaw/other", "--json"},
+		{"--config", configPath, "coverage", "--repos", "openclaw/gitcrawl,,openclaw/other", "--json"},
+	} {
+		if err := New().Run(ctx, args); err == nil {
+			t.Fatalf("coverage args should fail: %v", args)
+		}
 	}
 }
 
@@ -72,7 +115,7 @@ func seedCoverageStore(t *testing.T, ctx context.Context, dbPath string) {
 	if err != nil {
 		t.Fatalf("other repo: %v", err)
 	}
-	_, err = st.UpsertThread(ctx, coverageThread(gitcrawlID, 1, "issue"))
+	issueID, err := st.UpsertThread(ctx, coverageThread(gitcrawlID, 1, "issue"))
 	if err != nil {
 		t.Fatalf("issue thread: %v", err)
 	}
@@ -127,6 +170,14 @@ func seedCoverageStore(t *testing.T, ctx context.Context, dbPath string) {
 		FetchedAt:      "2026-07-03T00:00:00Z",
 	}}); err != nil {
 		t.Fatalf("review thread: %v", err)
+	}
+	for _, comment := range []store.Comment{
+		{ThreadID: issueID, GitHubID: "issue-comment", CommentType: "issue_comment", Body: "comment", RawJSON: "{}"},
+		{ThreadID: detailedPRID, GitHubID: "review", CommentType: "pull_review", Body: "review", RawJSON: "{}"},
+	} {
+		if _, err := st.UpsertComment(ctx, comment); err != nil {
+			t.Fatalf("comment: %v", err)
+		}
 	}
 }
 

--- a/internal/cli/archive_coverage_test.go
+++ b/internal/cli/archive_coverage_test.go
@@ -100,6 +100,58 @@ func TestCoverageCommandJSONAndTable(t *testing.T) {
 	}
 }
 
+func TestCoverageCommandSupportsCanonicalPortableArchive(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	dbPath := filepath.Join(dir, "gitcrawl.db")
+	if err := New().Run(ctx, []string{"--config", configPath, "init", "--db", dbPath}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	seedCoverageStore(t, ctx, dbPath)
+
+	st, err := store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if _, err := st.PrunePortablePayloads(ctx, store.PortablePruneOptions{BodyChars: 2000, Vacuum: false}); err != nil {
+		st.Close()
+		t.Fatalf("prune portable archive: %v", err)
+	}
+	var syncRuns int
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from sqlite_master where type = 'table' and name = 'sync_runs'`).Scan(&syncRuns); err != nil {
+		st.Close()
+		t.Fatalf("inspect portable archive: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close portable archive: %v", err)
+	}
+	if syncRuns != 0 {
+		t.Fatalf("portable archive retained sync_runs")
+	}
+
+	run := New()
+	var out bytes.Buffer
+	run.Stdout = &out
+	if err := run.Run(ctx, []string{"--config", configPath, "coverage", "--json"}); err != nil {
+		t.Fatalf("coverage portable archive: %v", err)
+	}
+	var payload struct {
+		Repositories []store.ArchiveCoverageRow `json:"repositories"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("decode portable coverage json: %v\n%s", err, out.String())
+	}
+	if len(payload.Repositories) != 2 {
+		t.Fatalf("portable coverage rows = %+v", payload.Repositories)
+	}
+	for _, row := range payload.Repositories {
+		if row.LastSyncAt == "" {
+			t.Fatalf("portable coverage missing last sync: %+v", row)
+		}
+	}
+}
+
 func seedCoverageStore(t *testing.T, ctx context.Context, dbPath string) {
 	t.Helper()
 	st, err := store.Open(ctx, dbPath)

--- a/internal/store/archive_coverage.go
+++ b/internal/store/archive_coverage.go
@@ -41,6 +41,46 @@ func (s *Store) ArchiveCoverage(ctx context.Context, opts ArchiveCoverageOptions
 	if !s.hasTable(ctx, "repositories") {
 		return ArchiveCoverage{Rows: []ArchiveCoverageRow{}}, nil
 	}
+	if !s.archiveCoverageHasColumns(ctx, "repositories", "id", "full_name") ||
+		!s.archiveCoverageHasColumns(ctx, "threads", "id", "repo_id", "kind", "state") {
+		return ArchiveCoverage{}, fmt.Errorf("archive coverage requires compatible repositories and threads tables; run gitcrawl doctor --json")
+	}
+	commentsExpression := "0"
+	prReviewsExpression := "0"
+	if s.archiveCoverageHasColumns(ctx, "comments", "thread_id", "comment_type") {
+		commentsExpression = `(
+			select count(*)
+			from comments c
+			join threads ct on ct.id = c.thread_id
+			where ct.repo_id = r.id
+		)`
+		prReviewsExpression = `(
+			select count(*)
+			from comments c
+			join threads ct on ct.id = c.thread_id
+			where ct.repo_id = r.id and c.comment_type = 'pull_review'
+		)`
+	}
+	pullRequestsWithDetailsExpression := "0"
+	missingPRDetailsExpression := "coalesce(sum(case when t.kind = 'pull_request' then 1 else 0 end), 0)"
+	pullRequestDetailsJoin := ""
+	if s.archiveCoverageHasColumns(ctx, "pull_request_details", "thread_id") {
+		pullRequestsWithDetailsExpression = "count(distinct prd.thread_id)"
+		missingPRDetailsExpression += " - count(distinct prd.thread_id)"
+		pullRequestDetailsJoin = "left join pull_request_details prd on prd.thread_id = t.id\n"
+	}
+	prFilesExpression := s.archiveCoverageThreadChildCountExpression(ctx, "pull_request_files")
+	prCommitsExpression := s.archiveCoverageThreadChildCountExpression(ctx, "pull_request_commits")
+	prChecksExpression := s.archiveCoverageThreadChildCountExpression(ctx, "pull_request_checks")
+	prReviewThreadsExpression := s.archiveCoverageThreadChildCountExpression(ctx, "pull_request_review_threads")
+	workflowRunsExpression := "0"
+	if s.archiveCoverageHasColumns(ctx, "github_workflow_runs", "repo_id") {
+		workflowRunsExpression = `(
+			select count(*)
+			from github_workflow_runs gwr
+			where gwr.repo_id = r.id
+		)`
+	}
 	lastSyncExpression := s.archiveCoverageLastSyncExpression(ctx)
 	query := `
 		select
@@ -49,54 +89,19 @@ func (s *Store) ArchiveCoverage(ctx context.Context, opts ArchiveCoverageOptions
 		  coalesce(sum(case when t.kind = 'issue' then 1 else 0 end), 0) as issues,
 		  coalesce(sum(case when t.kind = 'pull_request' then 1 else 0 end), 0) as pull_requests,
 		  coalesce(sum(case when t.kind = 'pull_request' and t.state = 'open' then 1 else 0 end), 0) as open_pull_requests,
-		  (
-		    select count(*)
-		    from comments c
-		    join threads ct on ct.id = c.thread_id
-		    where ct.repo_id = r.id
-		  ) as comments,
-		  (
-		    select count(*)
-		    from comments c
-		    join threads ct on ct.id = c.thread_id
-		    where ct.repo_id = r.id and c.comment_type = 'pull_review'
-		  ) as pr_reviews,
-		  count(distinct prd.thread_id) as pull_requests_with_details,
-		  coalesce(sum(case when t.kind = 'pull_request' then 1 else 0 end), 0) - count(distinct prd.thread_id) as missing_pr_details,
-		  (
-		    select count(*)
-		    from pull_request_files pf
-		    join threads pt on pt.id = pf.thread_id
-		    where pt.repo_id = r.id
-		  ) as pr_files,
-		  (
-		    select count(*)
-		    from pull_request_commits pc
-		    join threads pt on pt.id = pc.thread_id
-		    where pt.repo_id = r.id
-		  ) as pr_commits,
-		  (
-		    select count(*)
-		    from pull_request_checks pc
-		    join threads pt on pt.id = pc.thread_id
-		    where pt.repo_id = r.id
-		  ) as pr_checks,
-		  (
-		    select count(*)
-		    from pull_request_review_threads prt
-		    join threads pt on pt.id = prt.thread_id
-		    where pt.repo_id = r.id
-		  ) as pr_review_threads,
-		  (
-		    select count(*)
-		    from github_workflow_runs gwr
-		    where gwr.repo_id = r.id
-		  ) as workflow_runs,
+		  ` + commentsExpression + ` as comments,
+		  ` + prReviewsExpression + ` as pr_reviews,
+		  ` + pullRequestsWithDetailsExpression + ` as pull_requests_with_details,
+		  ` + missingPRDetailsExpression + ` as missing_pr_details,
+		  ` + prFilesExpression + ` as pr_files,
+		  ` + prCommitsExpression + ` as pr_commits,
+		  ` + prChecksExpression + ` as pr_checks,
+		  ` + prReviewThreadsExpression + ` as pr_review_threads,
+		  ` + workflowRunsExpression + ` as workflow_runs,
 		  ` + lastSyncExpression + ` as last_sync_at
 		from repositories r
 		left join threads t on t.repo_id = r.id
-		left join pull_request_details prd on prd.thread_id = t.id
-	`
+	` + pullRequestDetailsJoin
 	args := make([]any, 0, len(opts.RepoIDs)+1)
 	if len(opts.RepoIDs) > 0 {
 		query += "where r.id in (" + strings.TrimSuffix(strings.Repeat("?,", len(opts.RepoIDs)), ",") + ")\n"
@@ -152,16 +157,40 @@ func (s *Store) ArchiveCoverage(ctx context.Context, opts ArchiveCoverageOptions
 	return coverage, nil
 }
 
+func (s *Store) archiveCoverageHasColumns(ctx context.Context, table string, columns ...string) bool {
+	if !s.hasTable(ctx, table) {
+		return false
+	}
+	for _, column := range columns {
+		if !s.hasColumn(ctx, table, column) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *Store) archiveCoverageThreadChildCountExpression(ctx context.Context, table string) string {
+	if !s.archiveCoverageHasColumns(ctx, table, "thread_id") {
+		return "0"
+	}
+	return `(
+		select count(*)
+		from ` + sqliteIdentifier(table) + ` child
+		join threads pt on pt.id = child.thread_id
+		where pt.repo_id = r.id
+	)`
+}
+
 func (s *Store) archiveCoverageLastSyncExpression(ctx context.Context) string {
 	candidates := make([]string, 0, 4)
-	if s.hasTable(ctx, "sync_runs") {
+	if s.archiveCoverageHasColumns(ctx, "sync_runs", "repo_id", "status", "finished_at") {
 		candidates = append(candidates, `(
 			select max(sr.finished_at)
 			from sync_runs sr
 			where sr.repo_id = r.id and sr.status in ('success', 'completed')
 		)`)
 	}
-	if s.hasTable(ctx, "repo_sync_state") {
+	if s.archiveCoverageHasColumns(ctx, "repo_sync_state", "repo_id", "last_open_close_reconciled_at", "last_overlapping_open_scan_completed_at", "last_non_overlapping_scan_completed_at", "last_full_open_scan_started_at", "updated_at") {
 		candidates = append(candidates, `(
 			select coalesce(
 				max(rss.last_open_close_reconciled_at),
@@ -174,7 +203,7 @@ func (s *Store) archiveCoverageLastSyncExpression(ctx context.Context) string {
 			where rss.repo_id = r.id
 		)`)
 	}
-	if s.hasTable(ctx, "portable_metadata") {
+	if s.archiveCoverageHasColumns(ctx, "portable_metadata", "key", "value") {
 		candidates = append(candidates, `(
 			select pm.value
 			from portable_metadata pm
@@ -182,6 +211,9 @@ func (s *Store) archiveCoverageLastSyncExpression(ctx context.Context) string {
 		)`)
 	}
 	candidates = append(candidates, `''`)
+	if len(candidates) == 1 {
+		return candidates[0]
+	}
 	return "coalesce(" + strings.Join(candidates, ",\n") + ")"
 }
 

--- a/internal/store/archive_coverage.go
+++ b/internal/store/archive_coverage.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 )
 
 type ArchiveCoverageOptions struct {
-	RepoID              int64
+	RepoIDs             []int64
 	MinMissingPRDetails int
 }
 
@@ -17,6 +18,8 @@ type ArchiveCoverageRow struct {
 	Issues                     int    `json:"issues"`
 	PullRequests               int    `json:"pull_requests"`
 	OpenPullRequests           int    `json:"open_pull_requests"`
+	Comments                   int    `json:"comments"`
+	PRReviews                  int    `json:"pr_reviews"`
 	PullRequestsWithDetails    int    `json:"pull_requests_with_details"`
 	MissingPRDetails           int    `json:"missing_pr_details"`
 	PRFiles                    int    `json:"pr_files"`
@@ -36,15 +39,27 @@ type ArchiveCoverage struct {
 
 func (s *Store) ArchiveCoverage(ctx context.Context, opts ArchiveCoverageOptions) (ArchiveCoverage, error) {
 	if !s.hasTable(ctx, "repositories") {
-		return ArchiveCoverage{}, nil
+		return ArchiveCoverage{Rows: []ArchiveCoverageRow{}}, nil
 	}
-	rows, err := s.q().QueryContext(ctx, `
+	query := `
 		select
 		  r.id,
 		  r.full_name,
 		  coalesce(sum(case when t.kind = 'issue' then 1 else 0 end), 0) as issues,
 		  coalesce(sum(case when t.kind = 'pull_request' then 1 else 0 end), 0) as pull_requests,
 		  coalesce(sum(case when t.kind = 'pull_request' and t.state = 'open' then 1 else 0 end), 0) as open_pull_requests,
+		  (
+		    select count(*)
+		    from comments c
+		    join threads ct on ct.id = c.thread_id
+		    where ct.repo_id = r.id
+		  ) as comments,
+		  (
+		    select count(*)
+		    from comments c
+		    join threads ct on ct.id = c.thread_id
+		    where ct.repo_id = r.id and c.comment_type = 'pull_review'
+		  ) as pr_reviews,
 		  count(distinct prd.thread_id) as pull_requests_with_details,
 		  coalesce(sum(case when t.kind = 'pull_request' then 1 else 0 end), 0) - count(distinct prd.thread_id) as missing_pr_details,
 		  (
@@ -84,17 +99,27 @@ func (s *Store) ArchiveCoverage(ctx context.Context, opts ArchiveCoverageOptions
 		from repositories r
 		left join threads t on t.repo_id = r.id
 		left join pull_request_details prd on prd.thread_id = t.id
-		where (? = 0 or r.id = ?)
+	`
+	args := make([]any, 0, len(opts.RepoIDs)+1)
+	if len(opts.RepoIDs) > 0 {
+		query += "where r.id in (" + strings.TrimSuffix(strings.Repeat("?,", len(opts.RepoIDs)), ",") + ")\n"
+		for _, repoID := range opts.RepoIDs {
+			args = append(args, repoID)
+		}
+	}
+	query += `
 		group by r.id, r.full_name
 		having missing_pr_details >= ?
 		order by r.full_name
-	`, opts.RepoID, opts.RepoID, opts.MinMissingPRDetails)
+	`
+	args = append(args, opts.MinMissingPRDetails)
+	rows, err := s.q().QueryContext(ctx, query, args...)
 	if err != nil {
 		return ArchiveCoverage{}, fmt.Errorf("archive coverage: %w", err)
 	}
 	defer rows.Close()
 
-	var coverage ArchiveCoverage
+	coverage := ArchiveCoverage{Rows: []ArchiveCoverageRow{}}
 	for rows.Next() {
 		var row ArchiveCoverageRow
 		var lastSync sql.NullString
@@ -104,6 +129,8 @@ func (s *Store) ArchiveCoverage(ctx context.Context, opts ArchiveCoverageOptions
 			&row.Issues,
 			&row.PullRequests,
 			&row.OpenPullRequests,
+			&row.Comments,
+			&row.PRReviews,
 			&row.PullRequestsWithDetails,
 			&row.MissingPRDetails,
 			&row.PRFiles,
@@ -132,6 +159,8 @@ func addArchiveCoverageTotals(total *ArchiveCoverageRow, row ArchiveCoverageRow)
 	total.Issues += row.Issues
 	total.PullRequests += row.PullRequests
 	total.OpenPullRequests += row.OpenPullRequests
+	total.Comments += row.Comments
+	total.PRReviews += row.PRReviews
 	total.PullRequestsWithDetails += row.PullRequestsWithDetails
 	total.MissingPRDetails += row.MissingPRDetails
 	total.PRFiles += row.PRFiles

--- a/internal/store/archive_coverage.go
+++ b/internal/store/archive_coverage.go
@@ -1,0 +1,142 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+type ArchiveCoverageOptions struct {
+	RepoID              int64
+	MinMissingPRDetails int
+}
+
+type ArchiveCoverageRow struct {
+	RepoID                     int64  `json:"repo_id"`
+	Repository                 string `json:"repository"`
+	Issues                     int    `json:"issues"`
+	PullRequests               int    `json:"pull_requests"`
+	OpenPullRequests           int    `json:"open_pull_requests"`
+	PullRequestsWithDetails    int    `json:"pull_requests_with_details"`
+	MissingPRDetails           int    `json:"missing_pr_details"`
+	PRFiles                    int    `json:"pr_files"`
+	PRCommits                  int    `json:"pr_commits"`
+	PRChecks                   int    `json:"pr_checks"`
+	PRReviewThreads            int    `json:"pr_review_threads"`
+	WorkflowRuns               int    `json:"workflow_runs"`
+	LastSyncAt                 string `json:"last_sync_at,omitempty"`
+	HydrationFailuresSupported bool   `json:"hydration_failures_supported"`
+	KnownFailedHydrations      *int   `json:"known_failed_hydrations"`
+}
+
+type ArchiveCoverage struct {
+	Rows   []ArchiveCoverageRow `json:"repositories"`
+	Totals ArchiveCoverageRow   `json:"totals"`
+}
+
+func (s *Store) ArchiveCoverage(ctx context.Context, opts ArchiveCoverageOptions) (ArchiveCoverage, error) {
+	if !s.hasTable(ctx, "repositories") {
+		return ArchiveCoverage{}, nil
+	}
+	rows, err := s.q().QueryContext(ctx, `
+		select
+		  r.id,
+		  r.full_name,
+		  coalesce(sum(case when t.kind = 'issue' then 1 else 0 end), 0) as issues,
+		  coalesce(sum(case when t.kind = 'pull_request' then 1 else 0 end), 0) as pull_requests,
+		  coalesce(sum(case when t.kind = 'pull_request' and t.state = 'open' then 1 else 0 end), 0) as open_pull_requests,
+		  count(distinct prd.thread_id) as pull_requests_with_details,
+		  coalesce(sum(case when t.kind = 'pull_request' then 1 else 0 end), 0) - count(distinct prd.thread_id) as missing_pr_details,
+		  (
+		    select count(*)
+		    from pull_request_files pf
+		    join threads pt on pt.id = pf.thread_id
+		    where pt.repo_id = r.id
+		  ) as pr_files,
+		  (
+		    select count(*)
+		    from pull_request_commits pc
+		    join threads pt on pt.id = pc.thread_id
+		    where pt.repo_id = r.id
+		  ) as pr_commits,
+		  (
+		    select count(*)
+		    from pull_request_checks pc
+		    join threads pt on pt.id = pc.thread_id
+		    where pt.repo_id = r.id
+		  ) as pr_checks,
+		  (
+		    select count(*)
+		    from pull_request_review_threads prt
+		    join threads pt on pt.id = prt.thread_id
+		    where pt.repo_id = r.id
+		  ) as pr_review_threads,
+		  (
+		    select count(*)
+		    from github_workflow_runs gwr
+		    where gwr.repo_id = r.id
+		  ) as workflow_runs,
+		  (
+		    select coalesce(max(finished_at), '')
+		    from sync_runs sr
+		    where sr.repo_id = r.id and sr.status in ('success', 'completed')
+		  ) as last_sync_at
+		from repositories r
+		left join threads t on t.repo_id = r.id
+		left join pull_request_details prd on prd.thread_id = t.id
+		where (? = 0 or r.id = ?)
+		group by r.id, r.full_name
+		having missing_pr_details >= ?
+		order by r.full_name
+	`, opts.RepoID, opts.RepoID, opts.MinMissingPRDetails)
+	if err != nil {
+		return ArchiveCoverage{}, fmt.Errorf("archive coverage: %w", err)
+	}
+	defer rows.Close()
+
+	var coverage ArchiveCoverage
+	for rows.Next() {
+		var row ArchiveCoverageRow
+		var lastSync sql.NullString
+		if err := rows.Scan(
+			&row.RepoID,
+			&row.Repository,
+			&row.Issues,
+			&row.PullRequests,
+			&row.OpenPullRequests,
+			&row.PullRequestsWithDetails,
+			&row.MissingPRDetails,
+			&row.PRFiles,
+			&row.PRCommits,
+			&row.PRChecks,
+			&row.PRReviewThreads,
+			&row.WorkflowRuns,
+			&lastSync,
+		); err != nil {
+			return ArchiveCoverage{}, fmt.Errorf("scan archive coverage: %w", err)
+		}
+		row.LastSyncAt = lastSync.String
+		row.HydrationFailuresSupported = false
+		coverage.Rows = append(coverage.Rows, row)
+		addArchiveCoverageTotals(&coverage.Totals, row)
+	}
+	if err := rows.Err(); err != nil {
+		return ArchiveCoverage{}, fmt.Errorf("iterate archive coverage: %w", err)
+	}
+	coverage.Totals.Repository = "total"
+	coverage.Totals.HydrationFailuresSupported = false
+	return coverage, nil
+}
+
+func addArchiveCoverageTotals(total *ArchiveCoverageRow, row ArchiveCoverageRow) {
+	total.Issues += row.Issues
+	total.PullRequests += row.PullRequests
+	total.OpenPullRequests += row.OpenPullRequests
+	total.PullRequestsWithDetails += row.PullRequestsWithDetails
+	total.MissingPRDetails += row.MissingPRDetails
+	total.PRFiles += row.PRFiles
+	total.PRCommits += row.PRCommits
+	total.PRChecks += row.PRChecks
+	total.PRReviewThreads += row.PRReviewThreads
+	total.WorkflowRuns += row.WorkflowRuns
+}

--- a/internal/store/archive_coverage.go
+++ b/internal/store/archive_coverage.go
@@ -41,6 +41,7 @@ func (s *Store) ArchiveCoverage(ctx context.Context, opts ArchiveCoverageOptions
 	if !s.hasTable(ctx, "repositories") {
 		return ArchiveCoverage{Rows: []ArchiveCoverageRow{}}, nil
 	}
+	lastSyncExpression := s.archiveCoverageLastSyncExpression(ctx)
 	query := `
 		select
 		  r.id,
@@ -91,11 +92,7 @@ func (s *Store) ArchiveCoverage(ctx context.Context, opts ArchiveCoverageOptions
 		    from github_workflow_runs gwr
 		    where gwr.repo_id = r.id
 		  ) as workflow_runs,
-		  (
-		    select coalesce(max(finished_at), '')
-		    from sync_runs sr
-		    where sr.repo_id = r.id and sr.status in ('success', 'completed')
-		  ) as last_sync_at
+		  ` + lastSyncExpression + ` as last_sync_at
 		from repositories r
 		left join threads t on t.repo_id = r.id
 		left join pull_request_details prd on prd.thread_id = t.id
@@ -153,6 +150,39 @@ func (s *Store) ArchiveCoverage(ctx context.Context, opts ArchiveCoverageOptions
 	coverage.Totals.Repository = "total"
 	coverage.Totals.HydrationFailuresSupported = false
 	return coverage, nil
+}
+
+func (s *Store) archiveCoverageLastSyncExpression(ctx context.Context) string {
+	candidates := make([]string, 0, 4)
+	if s.hasTable(ctx, "sync_runs") {
+		candidates = append(candidates, `(
+			select max(sr.finished_at)
+			from sync_runs sr
+			where sr.repo_id = r.id and sr.status in ('success', 'completed')
+		)`)
+	}
+	if s.hasTable(ctx, "repo_sync_state") {
+		candidates = append(candidates, `(
+			select coalesce(
+				max(rss.last_open_close_reconciled_at),
+				max(rss.last_overlapping_open_scan_completed_at),
+				max(rss.last_non_overlapping_scan_completed_at),
+				max(rss.last_full_open_scan_started_at),
+				max(rss.updated_at)
+			)
+			from repo_sync_state rss
+			where rss.repo_id = r.id
+		)`)
+	}
+	if s.hasTable(ctx, "portable_metadata") {
+		candidates = append(candidates, `(
+			select pm.value
+			from portable_metadata pm
+			where pm.key = 'exported_at'
+		)`)
+	}
+	candidates = append(candidates, `''`)
+	return "coalesce(" + strings.Join(candidates, ",\n") + ")"
 }
 
 func addArchiveCoverageTotals(total *ArchiveCoverageRow, row ArchiveCoverageRow) {

--- a/internal/store/archive_coverage_test.go
+++ b/internal/store/archive_coverage_test.go
@@ -1,0 +1,177 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestArchiveCoverageReportsAndFiltersCurrentStore(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	primaryID, secondaryID := seedArchiveCoverageRows(t, ctx, st)
+
+	coverage, err := st.ArchiveCoverage(ctx, ArchiveCoverageOptions{})
+	if err != nil {
+		t.Fatalf("archive coverage: %v", err)
+	}
+	if len(coverage.Rows) != 2 || coverage.Totals.PullRequests != 4 || coverage.Totals.MissingPRDetails != 3 {
+		t.Fatalf("coverage = %+v", coverage)
+	}
+	primary := coverage.Rows[0]
+	if primary.Repository != "openclaw/gitcrawl" || primary.Comments != 2 || primary.PRReviews != 1 || primary.PullRequestsWithDetails != 1 || primary.PRFiles != 1 || primary.PRCommits != 1 || primary.PRChecks != 1 || primary.PRReviewThreads != 1 || primary.WorkflowRuns != 1 || primary.LastSyncAt == "" {
+		t.Fatalf("primary coverage = %+v", primary)
+	}
+
+	filtered, err := st.ArchiveCoverage(ctx, ArchiveCoverageOptions{RepoIDs: []int64{primaryID, secondaryID}, MinMissingPRDetails: 2})
+	if err != nil {
+		t.Fatalf("filtered archive coverage: %v", err)
+	}
+	if len(filtered.Rows) != 1 || filtered.Rows[0].Repository != "openclaw/gitcrawl" {
+		t.Fatalf("filtered coverage = %+v", filtered)
+	}
+}
+
+func TestArchiveCoverageSupportsPortableAndOptionalTableDrift(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("portable", func(t *testing.T) {
+		st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+		if err != nil {
+			t.Fatalf("open store: %v", err)
+		}
+		defer st.Close()
+		seedArchiveCoverageRows(t, ctx, st)
+		if _, err := st.PrunePortablePayloads(ctx, PortablePruneOptions{BodyChars: 2000, Vacuum: false}); err != nil {
+			t.Fatalf("prune portable store: %v", err)
+		}
+		coverage, err := st.ArchiveCoverage(ctx, ArchiveCoverageOptions{})
+		if err != nil {
+			t.Fatalf("portable archive coverage: %v", err)
+		}
+		if len(coverage.Rows) != 2 || coverage.Rows[0].LastSyncAt == "" {
+			t.Fatalf("portable coverage = %+v", coverage)
+		}
+	})
+
+	t.Run("optional tables absent", func(t *testing.T) {
+		st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+		if err != nil {
+			t.Fatalf("open store: %v", err)
+		}
+		defer st.Close()
+		seedArchiveCoverageRows(t, ctx, st)
+		for _, table := range []string{
+			"comments",
+			"pull_request_files",
+			"pull_request_commits",
+			"pull_request_checks",
+			"pull_request_review_threads",
+			"pull_request_details",
+			"github_workflow_runs",
+			"sync_runs",
+			"repo_sync_state",
+		} {
+			if _, err := st.DB().ExecContext(ctx, `drop table `+table); err != nil {
+				t.Fatalf("drop %s: %v", table, err)
+			}
+		}
+		coverage, err := st.ArchiveCoverage(ctx, ArchiveCoverageOptions{})
+		if err != nil {
+			t.Fatalf("compatibility archive coverage: %v", err)
+		}
+		if len(coverage.Rows) != 2 || coverage.Rows[0].PullRequestsWithDetails != 0 || coverage.Rows[0].MissingPRDetails != coverage.Rows[0].PullRequests || coverage.Rows[0].Comments != 0 || coverage.Rows[0].LastSyncAt != "" {
+			t.Fatalf("compatibility coverage = %+v", coverage)
+		}
+	})
+}
+
+func TestArchiveCoverageRejectsIncompatibleCoreTables(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	if _, err := st.DB().ExecContext(ctx, `alter table threads rename to legacy_threads`); err != nil {
+		t.Fatalf("rename threads: %v", err)
+	}
+	if _, err := st.ArchiveCoverage(ctx, ArchiveCoverageOptions{}); err == nil || !strings.Contains(err.Error(), "gitcrawl doctor --json") {
+		t.Fatalf("incompatible core error = %v", err)
+	}
+}
+
+func seedArchiveCoverageRows(t *testing.T, ctx context.Context, st *Store) (int64, int64) {
+	t.Helper()
+	primaryID, err := st.UpsertRepository(ctx, Repository{Owner: "openclaw", Name: "gitcrawl", FullName: "openclaw/gitcrawl", RawJSON: "{}", UpdatedAt: "2026-07-06T00:00:00Z"})
+	if err != nil {
+		t.Fatalf("primary repository: %v", err)
+	}
+	secondaryID, err := st.UpsertRepository(ctx, Repository{Owner: "openclaw", Name: "other", FullName: "openclaw/other", RawJSON: "{}", UpdatedAt: "2026-07-06T00:00:00Z"})
+	if err != nil {
+		t.Fatalf("secondary repository: %v", err)
+	}
+	issueID, err := st.UpsertThread(ctx, archiveCoverageThread(primaryID, 1, "issue"))
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	var detailedPRID int64
+	for _, number := range []int{2, 3, 4} {
+		threadID, err := st.UpsertThread(ctx, archiveCoverageThread(primaryID, number, "pull_request"))
+		if err != nil {
+			t.Fatalf("primary PR %d: %v", number, err)
+		}
+		if number == 2 {
+			detailedPRID = threadID
+		}
+	}
+	if _, err := st.UpsertThread(ctx, archiveCoverageThread(secondaryID, 5, "pull_request")); err != nil {
+		t.Fatalf("secondary PR: %v", err)
+	}
+	for _, comment := range []Comment{
+		{ThreadID: issueID, GitHubID: "comment", CommentType: "issue_comment", Body: "comment", RawJSON: "{}"},
+		{ThreadID: detailedPRID, GitHubID: "review", CommentType: "pull_review", Body: "review", RawJSON: "{}"},
+	} {
+		if _, err := st.UpsertComment(ctx, comment); err != nil {
+			t.Fatalf("comment: %v", err)
+		}
+	}
+	if err := st.UpsertPullRequestCache(ctx, PullRequestDetail{ThreadID: detailedPRID, RepoID: primaryID, Number: 2, RawJSON: "{}", FetchedAt: "2026-07-06T00:01:00Z", UpdatedAt: "2026-07-06T00:01:00Z"},
+		[]PullRequestFile{{ThreadID: detailedPRID, Path: "README.md", RawJSON: "{}", FetchedAt: "2026-07-06T00:01:00Z"}},
+		[]PullRequestCommit{{ThreadID: detailedPRID, SHA: "abc", RawJSON: "{}", FetchedAt: "2026-07-06T00:01:00Z"}},
+		[]PullRequestCheck{{ThreadID: detailedPRID, Name: "test", RawJSON: "{}", FetchedAt: "2026-07-06T00:01:00Z"}},
+		[]WorkflowRun{{RepoID: primaryID, RunID: "1", RawJSON: "{}", FetchedAt: "2026-07-06T00:01:00Z"}},
+	); err != nil {
+		t.Fatalf("PR cache: %v", err)
+	}
+	if err := st.UpsertPullRequestReviewThreads(ctx, detailedPRID, "2026-07-06T00:01:00Z", []PullRequestReviewThread{{ThreadID: detailedPRID, ReviewThreadID: "thread", CommentsJSON: "[]", RawJSON: "{}", FetchedAt: "2026-07-06T00:01:00Z"}}); err != nil {
+		t.Fatalf("review threads: %v", err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `insert into sync_runs(repo_id, scope, status, started_at, finished_at) values(?, 'open', 'success', '2026-07-06T00:00:00Z', '2026-07-06T00:02:00Z')`, primaryID); err != nil {
+		t.Fatalf("sync run: %v", err)
+	}
+	return primaryID, secondaryID
+}
+
+func archiveCoverageThread(repoID int64, number int, kind string) Thread {
+	return Thread{
+		RepoID:        repoID,
+		GitHubID:      fmt.Sprintf("gid-%d", number),
+		Number:        number,
+		Kind:          kind,
+		State:         "open",
+		Title:         "thread",
+		HTMLURL:       fmt.Sprintf("https://github.com/openclaw/gitcrawl/issues/%d", number),
+		LabelsJSON:    "[]",
+		AssigneesJSON: "[]",
+		RawJSON:       "{}",
+		ContentHash:   fmt.Sprintf("hash-%d", number),
+		UpdatedAt:     "2026-07-06T00:00:00Z",
+	}
+}


### PR DESCRIPTION
Closes #82.

Adds a read-only `gitcrawl coverage` command that reports per-repository PR-detail completeness from the local SQLite archive, including JSON and table output plus filtering by `--min-missing-pr-details`.

Known failed/skipped hydration counts are reported as unavailable until the separate failure-ledger work exists, so the new command does not imply zero failures.

Behavior proof:
On a throwaway archive seeded with two metadata-only open PRs for `openclaw/gitcrawl`, JSON coverage reported `pull_requests: 2`, `pull_requests_with_details: 0`, and `missing_pr_details: 2`.
