### PR TITLE
Document initial maintainer archive workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.6.5 - Unreleased
 
 - Report the active executable/build identity and read-only database schema compatibility in `gitcrawl doctor --json`, including actionable drift diagnostics without applying migrations. Thanks @TurboTheTurtle.
+- Document the first-run local maintainer archive workflow, including targeted PR hydration, bounded-staleness search, run inspection, and the Octopool boundary. Thanks @TurboTheTurtle.
 
 ## 0.6.4 - 2026-06-23
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Full documentation: [gitcrawl.sh](https://gitcrawl.sh)
 
+Maintainer first-run workflow: [docs/maintainer-archive.md](docs/maintainer-archive.md)
+
 ## Status
 
 Early bootstrap. The implementation is being built in small commits.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -47,6 +47,8 @@ These work on every command.
 | `gitcrawl runs owner/repo [--kind sync\|embedding\|cluster --limit --json]` | List recorded run history | [Refresh and embed](/refresh-and-embed/#runs) |
 | `gitcrawl code index owner/repo [--path --max-file-bytes --max-total-bytes --max-files --json]` | Index tracked text files from a local Git checkout | [Code indexing](/code-index/) |
 
+For an end-to-end first-run sequence that combines `status --json`, `doctor --json`, `sync --numbers`, bounded `--sync-if-stale` search, `gitcrawl runs`, and Octopool live reads, see the [maintainer archive workflow](/maintainer-archive/).
+
 ## Inspect
 
 | Command | Purpose | Docs |

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ A local-first GitHub triage tool for maintainers and agents. Sync issues and PRs
 Use [`gitcrawl search`](/search/) for local discovery and [Octopool migration](/gh-shim/) for pooled `gh` reads.
 
 ### I want to triage a busy repo
-Read [Sync](/sync/) to bring data local, then [Clustering](/clustering/) and the [TUI](/tui/) for the maintainer workflow.
+Read the [maintainer archive workflow](/maintainer-archive/) for the first-run checklist, then [Sync](/sync/) to bring data local, [Clustering](/clustering/), and the [TUI](/tui/) for the triage loop.
 
 ### I want the full reference
 [Commands](/commands/) lists every flag and JSON field. [Configuration](/configuration/) covers env vars and paths.

--- a/docs/maintainer-archive.md
+++ b/docs/maintainer-archive.md
@@ -23,7 +23,7 @@ gitcrawl status --json
 gitcrawl doctor --json
 ```
 
-`status --json` is the quick inventory check: it reports the configured archive database, repository count, thread count, open-thread count, cluster count, and last successful sync time. Use it to confirm that your local archive is present and to decide whether a refresh is needed.
+`status --json` is the quick inventory check: it reports the configured archive database, its repository/thread/open-thread/cluster inventory under `databases[].counts`, and the last successful sync time. Use it to confirm that your local archive is present and to decide whether a refresh is needed.
 
 `doctor --json` is the setup check: it reports config path, database health, credential discovery, model settings, portable-store status, and the same core counts. Use it when a run fails, when a machine has multiple config paths, or when an agent needs a machine-readable readiness gate.
 
@@ -33,7 +33,7 @@ Run an initial metadata sync, then decide whether comments and PR details are wo
 
 ```bash
 gitcrawl sync openclaw/gitcrawl --state open --json
-gitcrawl sync openclaw/gitcrawl --numbers 82,86,87 --include-comments --with pr-details --json
+gitcrawl sync openclaw/gitcrawl --numbers 94,95,96 --include-comments --with pr-details --json
 ```
 
 The first command mirrors open issues and pull requests into SQLite. The targeted `sync --numbers` command refreshes exact issues or pull requests after local discovery, so you can hydrate only the rows you intend to inspect.
@@ -77,7 +77,9 @@ NUMS=$(gitcrawl search prs "needs proof" -R openclaw/gitcrawl \
   --json number \
   | jq -r '[.[].number] | join(",")')
 
-gitcrawl sync openclaw/gitcrawl --numbers "$NUMS" --include-comments --with pr-details --json
+if [ -n "$NUMS" ]; then
+  gitcrawl sync openclaw/gitcrawl --numbers "$NUMS" --include-comments --with pr-details --json
+fi
 ```
 
 For broad backlog sweeps, keep the first pass metadata-only. Hydrate comments and PR details after you have narrowed the candidate list. This keeps local triage responsive and avoids consuming review-thread, check-run, and workflow-run quota for rows you will not inspect.

--- a/docs/maintainer-archive.md
+++ b/docs/maintainer-archive.md
@@ -1,0 +1,104 @@
+---
+title: Maintainer archive workflow
+nav_order: 13
+permalink: /maintainer-archive/
+---
+
+# Maintainer archive workflow
+{: .no_toc }
+
+A first-run checklist for maintainers who want a local SQLite mirror for issue and pull request triage, with Octopool handling pooled live GitHub reads.
+{: .fs-6 .fw-300 }
+
+1. TOC
+{:toc}
+
+## Start with local health
+
+Initialize or verify the runtime before spending GitHub quota:
+
+```bash
+gitcrawl init
+gitcrawl status --json
+gitcrawl doctor --json
+```
+
+`status --json` is the quick inventory check: it reports the configured archive database, repository count, thread count, open-thread count, cluster count, and last successful sync time. Use it to confirm that your local archive is present and to decide whether a refresh is needed.
+
+`doctor --json` is the setup check: it reports config path, database health, credential discovery, model settings, portable-store status, and the same core counts. Use it when a run fails, when a machine has multiple config paths, or when an agent needs a machine-readable readiness gate.
+
+## Bring one repository local
+
+Run an initial metadata sync, then decide whether comments and PR details are worth hydrating immediately:
+
+```bash
+gitcrawl sync openclaw/gitcrawl --state open --json
+gitcrawl sync openclaw/gitcrawl --numbers 82,86,87 --include-comments --with pr-details --json
+```
+
+The first command mirrors open issues and pull requests into SQLite. The targeted `sync --numbers` command refreshes exact issues or pull requests after local discovery, so you can hydrate only the rows you intend to inspect.
+
+Use `--include-comments` when issue discussion matters. Use `--with pr-details` for pull requests that need files, commits, checks, workflow runs, and review-thread state. Those detail rows are useful for review work, but they cost more GitHub API calls than metadata-only sync.
+
+## Search with bounded staleness
+
+Use local search for discovery and add a staleness bound when an agent or script should refresh before answering:
+
+```bash
+gitcrawl search issues "archive coverage" \
+  -R openclaw/gitcrawl \
+  --state open \
+  --sync-if-stale 5m \
+  --json number,title,url,updatedAt,labels
+```
+
+`--sync-if-stale` runs one metadata sync only when the local mirror is older than the duration you provide. The search result still comes from SQLite, so repeated searches stay local once the freshness window is satisfied.
+
+## Inspect recent work
+
+Use run history to understand what populated the archive:
+
+```bash
+gitcrawl runs openclaw/gitcrawl --kind sync --limit 5 --json
+gitcrawl runs openclaw/gitcrawl --kind embedding --limit 5 --json
+gitcrawl runs openclaw/gitcrawl --kind cluster --limit 5 --json
+```
+
+`gitcrawl runs` shows recent pipeline records by kind. Pair it with `status --json` when deciding whether an archive is fresh enough for triage, or with `doctor --json` when a sync succeeded but downstream search, embedding, or clustering output looks stale.
+
+## Decide when to hydrate
+
+For a small candidate set, hydrate exact rows:
+
+```bash
+NUMS=$(gitcrawl search prs "needs proof" -R openclaw/gitcrawl \
+  --state open \
+  --sync-if-stale 5m \
+  --json number \
+  | jq -r '[.[].number] | join(",")')
+
+gitcrawl sync openclaw/gitcrawl --numbers "$NUMS" --include-comments --with pr-details --json
+```
+
+For broad backlog sweeps, keep the first pass metadata-only. Hydrate comments and PR details after you have narrowed the candidate list. This keeps local triage responsive and avoids consuming review-thread, check-run, and workflow-run quota for rows you will not inspect.
+
+## Know the Octopool boundary
+
+Gitcrawl owns the local SQLite mirror, search, clustering, TUI, and read-only JSON control surfaces. Octopool owns pooled live `gh` reads:
+
+```bash
+octopool login
+octopool gh api repos/openclaw/gitcrawl/issues/82
+```
+
+Use `gitcrawl search` and `gitcrawl cluster-detail` for local discovery. Use Octopool, or the real `gh` CLI when you need to write, for final live verification, comments, labels, PR creation, and other GitHub mutations.
+
+## First-run checklist
+
+1. Run `gitcrawl init`, then `gitcrawl doctor --json`.
+2. Run `gitcrawl status --json` and confirm the database path is the one you expect.
+3. Sync the target repository metadata with `gitcrawl sync owner/repo --state open --json`.
+4. Search locally with `--sync-if-stale` when freshness matters.
+5. Use `sync --numbers` to hydrate only the candidate issues or pull requests you are actively triaging.
+6. Check `gitcrawl runs owner/repo --kind sync --json` if freshness or last-run status is unclear.
+7. Use Octopool or real `gh` for final live GitHub reads and all write actions.

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -16,7 +16,7 @@ const sections = [
   ["Start", ["index.md", "installation.md", "quickstart.md", "concepts.md"]],
   ["Configure", ["configuration.md", "sync.md", "refresh-and-embed.md"]],
   ["Use", ["search.md", "clustering.md", "governance.md", "tui.md", "gh-shim.md"]],
-  ["Operate", ["portable-stores.md", "automation.md"]],
+  ["Operate", ["portable-stores.md", "maintainer-archive.md", "automation.md"]],
   ["Reference", ["commands.md", "reference.md"]],
 ];
 


### PR DESCRIPTION
Closes #87.

Adds a maintainer archive workflow guide that connects the existing local health checks, targeted hydration, bounded-staleness search, run inspection, hydration cost choices, and Octopool boundary.

Links the guide from the docs index, command reference, and README so first-run maintainer triage has one entry point.

Behavior proof:
The generated docs site includes the new maintainer archive guide, and the repository docs now link it from README, the docs index, and the command reference.


Generated-site proof:

```text
built docs site: dist/docs-site
dist/docs-site/maintainer-archive/index.html: Operate ... Maintainer archive workflow ... active
dist/docs-site/portable-stores/index.html: page-nav-next ... Maintainer archive workflow
dist/docs-site/automation/index.html: page-nav-prev ... Maintainer archive workflow
```
