### PR TITLE
fix(init): anchor local filesystem paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.6.5 - Unreleased
 
+- Resolve relative `gitcrawl init` database, runtime, and portable-store filesystem paths before saving them so later SQLite commands open the intended files instead of failing on an invalid URI, and reject unsupported SQLite URI or in-memory `--db` values.
 - Add `gitcrawl doctor --locks --json` for read-only SQLite health, sidecar state, and best-effort writer-process diagnostics, keeping archive health distinct from detected activity. Thanks @TurboTheTurtle.
 - Add read-only per-repository archive coverage reporting with JSON/table output, repository and missing-PR-detail filters, hydration counts, and explicit failure-ledger availability. Thanks @TurboTheTurtle.
 - Report the active executable/build identity and read-only database schema compatibility in `gitcrawl doctor --json`, including actionable drift diagnostics without applying migrations. Thanks @TurboTheTurtle.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,7 +54,10 @@ to any command.
 - `gitcrawl init --runtime-dir <path>` creates a fully isolated local runtime
   under that directory: `gitcrawl.db`, `cache/`, `vectors/`, and `logs/`.
   This is useful for temporary archives and reproducible tests. Existing
-  `init --db` behavior remains database-only.
+  `init --db` behavior remains database-only. Relative `--db`, `--runtime-dir`,
+  and `--store-dir` filesystem paths are anchored to the current working
+  directory before they are saved, so later commands keep using the same files.
+  `--db` accepts durable filesystem paths, not SQLite `file:` URIs or `:memory:`.
 - Absolute XDG environment variables are honored even on macOS. Relative XDG
   values are ignored and gitcrawl falls back to the platform default for that
   path.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/alecthomas/kong"
+	crawlconfig "github.com/openclaw/crawlkit/config"
 	"github.com/openclaw/crawlkit/control"
 	"github.com/openclaw/crawlkit/mirror"
 	crawlremote "github.com/openclaw/crawlkit/remote"
@@ -64,8 +65,9 @@ type App struct {
 	Stdout io.Writer
 	Stderr io.Writer
 
-	configPath string
-	format     OutputFormat
+	configPath          string
+	format              OutputFormat
+	getWorkingDirectory func() (string, error)
 }
 
 type initResult struct {
@@ -95,9 +97,10 @@ var version = "dev"
 
 func New() *App {
 	return &App{
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
-		format: FormatText,
+		Stdout:              os.Stdout,
+		Stderr:              os.Stderr,
+		format:              FormatText,
+		getWorkingDirectory: os.Getwd,
 	}
 }
 
@@ -2895,6 +2898,21 @@ func (a *App) runInit(ctx context.Context, args []string) error {
 	if nonEmptyCount(localDBPath, isolatedRuntimeDir, portableStoreURL, remoteEndpointValue) > 1 {
 		return usageErr(fmt.Errorf("use only one of --db, --runtime-dir, --portable-store, or --remote"))
 	}
+	if localDBPath == ":memory:" || strings.HasPrefix(localDBPath, "file:") {
+		return usageErr(fmt.Errorf("--db requires a filesystem path; SQLite URIs and :memory: are unsupported"))
+	}
+	if localDBPath != "" {
+		var err error
+		localDBPath, err = a.absoluteInitPath(localDBPath)
+		if err != nil {
+			return fmt.Errorf("resolve --db path: %w", err)
+		}
+	}
+	var err error
+	isolatedRuntimeDir, err = a.absoluteInitPath(isolatedRuntimeDir)
+	if err != nil {
+		return fmt.Errorf("resolve --runtime-dir path: %w", err)
+	}
 
 	cfg := config.Default()
 	portableStoreDir := ""
@@ -2914,6 +2932,10 @@ func (a *App) runInit(ctx context.Context, args []string) error {
 		portableStoreDir = strings.TrimSpace(*storeDir)
 		if portableStoreDir == "" {
 			portableStoreDir = defaultPortableStoreDir(config.ResolvePath(a.configPath), portableStoreURL)
+		}
+		portableStoreDir, err = a.absoluteInitPath(portableStoreDir)
+		if err != nil {
+			return fmt.Errorf("resolve --store-dir path: %w", err)
 		}
 		action, err := syncPortableStore(ctx, portableStoreURL, portableStoreDir)
 		if err != nil {
@@ -2966,6 +2988,22 @@ func (a *App) runInit(ctx context.Context, args []string) error {
 		result.RemoteArchive = cfg.Remote.Archive
 	}
 	return a.writeInitOutput(result)
+}
+
+func (a *App) absoluteInitPath(path string) (string, error) {
+	originalPath := strings.TrimSpace(path)
+	path = crawlconfig.ExpandHome(path)
+	if (originalPath == "~" || strings.HasPrefix(originalPath, "~/")) && path == originalPath {
+		return "", fmt.Errorf("expand home-relative path %q: home directory unavailable", originalPath)
+	}
+	if path == "" || filepath.IsAbs(path) {
+		return path, nil
+	}
+	workingDir, err := a.getWorkingDirectory()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(workingDir, path), nil
 }
 
 func (a *App) runPortable(ctx context.Context, args []string) error {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -56,6 +56,152 @@ func TestInitWritesConfig(t *testing.T) {
 	}
 }
 
+func TestInitRelativeDBPathIsAbsoluteAndWritable(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	workDir := filepath.Join(dir, "work")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatalf("mkdir work dir: %v", err)
+	}
+	t.Chdir(workDir)
+	configPath := filepath.Join(dir, "config.toml")
+
+	if err := New().Run(ctx, []string{"--config", configPath, "init", "--db", "archive.db"}); err != nil {
+		t.Fatalf("init relative db: %v", err)
+	}
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	wantDBPath := filepath.Join(workDir, "archive.db")
+	if cfg.DBPath != wantDBPath {
+		t.Fatalf("db path = %q, want %q", cfg.DBPath, wantDBPath)
+	}
+	if cfg.VectorDir != filepath.Join(workDir, "vectors") {
+		t.Fatalf("vector dir = %q, want sibling of resolved db", cfg.VectorDir)
+	}
+	st, err := store.Open(ctx, cfg.DBPath)
+	if err != nil {
+		t.Fatalf("open resolved db: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close resolved db: %v", err)
+	}
+	if info, err := os.Stat(wantDBPath); err != nil || info.Size() == 0 {
+		t.Fatalf("resolved db was not initialized: info=%v err=%v", info, err)
+	}
+}
+
+func TestInitRelativeRuntimeDirIsAbsolute(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	configPath := filepath.Join(dir, "config.toml")
+
+	if err := New().Run(context.Background(), []string{"--config", configPath, "init", "--runtime-dir", "runtime"}); err != nil {
+		t.Fatalf("init relative runtime: %v", err)
+	}
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	wantRoot := filepath.Join(dir, "runtime")
+	if cfg.DBPath != filepath.Join(wantRoot, "gitcrawl.db") || cfg.CacheDir != filepath.Join(wantRoot, "cache") || cfg.VectorDir != filepath.Join(wantRoot, "vectors") || cfg.LogDir != filepath.Join(wantRoot, "logs") {
+		t.Fatalf("relative runtime paths not anchored under %q: %+v", wantRoot, cfg)
+	}
+}
+
+func TestInitHomeRelativePathsExpandBeforeAnchoring(t *testing.T) {
+	homeDir := t.TempDir()
+	workDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Chdir(workDir)
+
+	dbConfigPath := filepath.Join(workDir, "db.toml")
+	if err := New().Run(context.Background(), []string{"--config", dbConfigPath, "init", "--db", "~/archive.db"}); err != nil {
+		t.Fatalf("init home-relative db: %v", err)
+	}
+	dbConfig, err := config.Load(dbConfigPath)
+	if err != nil {
+		t.Fatalf("load db config: %v", err)
+	}
+	if want := filepath.Join(homeDir, "archive.db"); dbConfig.DBPath != want {
+		t.Fatalf("home-relative db path = %q, want %q", dbConfig.DBPath, want)
+	}
+
+	runtimeConfigPath := filepath.Join(workDir, "runtime.toml")
+	if err := New().Run(context.Background(), []string{"--config", runtimeConfigPath, "init", "--runtime-dir", "~/runtime"}); err != nil {
+		t.Fatalf("init home-relative runtime: %v", err)
+	}
+	runtimeConfig, err := config.Load(runtimeConfigPath)
+	if err != nil {
+		t.Fatalf("load runtime config: %v", err)
+	}
+	wantRuntimeRoot := filepath.Join(homeDir, "runtime")
+	if runtimeConfig.DBPath != filepath.Join(wantRuntimeRoot, "gitcrawl.db") || runtimeConfig.CacheDir != filepath.Join(wantRuntimeRoot, "cache") || runtimeConfig.VectorDir != filepath.Join(wantRuntimeRoot, "vectors") || runtimeConfig.LogDir != filepath.Join(wantRuntimeRoot, "logs") {
+		t.Fatalf("home-relative runtime paths not anchored under %q: %+v", wantRuntimeRoot, runtimeConfig)
+	}
+}
+
+func TestInitResolvesWorkingDirectoryOnlyForRelativePaths(t *testing.T) {
+	app := New()
+	app.getWorkingDirectory = func() (string, error) {
+		return "", errors.New("working directory unavailable")
+	}
+
+	relativeCases := []struct {
+		name string
+		args []string
+		flag string
+	}{
+		{name: "database", args: []string{"init", "--db", "archive.db"}, flag: "--db"},
+		{name: "runtime", args: []string{"init", "--runtime-dir", "runtime"}, flag: "--runtime-dir"},
+		{name: "portable store", args: []string{"init", "--portable-store", "https://example.com/store.git", "--store-dir", "store"}, flag: "--store-dir"},
+	}
+	for _, tc := range relativeCases {
+		err := app.Run(context.Background(), tc.args)
+		if err == nil || !strings.Contains(err.Error(), "resolve "+tc.flag+" path") {
+			t.Errorf("%s error = %v, want %s resolution failure", tc.name, err, tc.flag)
+		}
+	}
+
+	dir := t.TempDir()
+	absoluteConfig := filepath.Join(dir, "absolute.toml")
+	if err := app.Run(context.Background(), []string{"--config", absoluteConfig, "init", "--db", filepath.Join(dir, "archive.db")}); err != nil {
+		t.Fatalf("absolute db init consulted working directory: %v", err)
+	}
+	remoteConfig := filepath.Join(dir, "remote.toml")
+	if err := app.Run(context.Background(), []string{"--config", remoteConfig, "init", "--remote", "https://archive.example.com", "--archive", "example"}); err != nil {
+		t.Fatalf("remote init consulted working directory: %v", err)
+	}
+}
+
+func TestInitRejectsNonFilesystemDBValues(t *testing.T) {
+	for _, dbPath := range []string{":memory:", "file:archive.db", "file:/tmp/archive.db?mode=rwc"} {
+		err := New().Run(context.Background(), []string{"init", "--db", dbPath})
+		if err == nil || !strings.Contains(err.Error(), "--db requires a filesystem path") {
+			t.Errorf("init --db %q error = %v", dbPath, err)
+		}
+	}
+}
+
+func TestInitRejectsHomeRelativePathsWithoutHomeDirectory(t *testing.T) {
+	t.Setenv("HOME", "")
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "database", args: []string{"init", "--db", "~/archive.db"}},
+		{name: "runtime", args: []string{"init", "--runtime-dir", "~/runtime"}},
+		{name: "portable store", args: []string{"init", "--portable-store", "https://example.com/store.git", "--store-dir", "~/store"}},
+	}
+	for _, tc := range tests {
+		err := New().Run(context.Background(), tc.args)
+		if err == nil || !strings.Contains(err.Error(), "home directory unavailable") {
+			t.Errorf("%s error = %v, want unavailable-home failure", tc.name, err)
+		}
+	}
+}
+
 func TestInitRuntimeDirIsolatesRuntimePaths(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.toml")
@@ -1361,8 +1507,10 @@ func TestGitRemoteForMessageRedactsURLCredentials(t *testing.T) {
 func TestInitWithPortableStoreCloneAndPull(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
+	t.Chdir(dir)
 	remoteDir := filepath.Join(dir, "remote")
-	checkoutDir := filepath.Join(dir, "checkout")
+	checkoutDir := "checkout"
+	wantCheckoutDir := filepath.Join(dir, checkoutDir)
 	dbRel := filepath.Join("data", "openclaw__openclaw.sync.db")
 	if err := os.MkdirAll(filepath.Join(remoteDir, "data"), 0o755); err != nil {
 		t.Fatalf("mkdir remote data: %v", err)
@@ -1387,6 +1535,13 @@ func TestInitWithPortableStoreCloneAndPull(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "Portable store") || !strings.Contains(stdout.String(), "cloned") {
 		t.Fatalf("portable init output = %q", stdout.String())
+	}
+	loaded, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("load portable config: %v", err)
+	}
+	if loaded.DBPath != filepath.Join(wantCheckoutDir, dbRel) {
+		t.Fatalf("portable db path = %q, want %q", loaded.DBPath, filepath.Join(wantCheckoutDir, dbRel))
 	}
 	action, err := syncPortableStore(ctx, remoteDir, checkoutDir)
 	if err != nil {


### PR DESCRIPTION
## Summary

- anchor relative database, isolated-runtime, and portable-store filesystem paths before saving config
- preserve `~/...` expansion and fail clearly when home or working-directory resolution is unavailable
- reject unsupported SQLite URI and in-memory `--db` values instead of persisting configs other Gitcrawl file operations cannot use
- document path semantics and add regression coverage

## Validation

- `go vet ./...`
- deadcode across tests and packages
- full tests with exactly 85.0% aggregate coverage
- docs site build
- six-target GoReleaser snapshot
- Docker build and smoke tests
- live init in one directory, targeted public GitHub sync from another, then doctor health/schema verification; no database created in the second directory
- structured autoreview clean
