### PR TITLE
fix(sync): allow local databases under stray Git metadata

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -2063,7 +2063,7 @@ func emptyClusterBrowserPayload(ctx context.Context, cfg config.Config, sourceDB
 }
 
 func databaseSourceKind(ctx context.Context, dbPath string) string {
-	if _, ok := portableStoreRoot(ctx, dbPath); ok {
+	if _, ok, _ := portableStoreRoot(ctx, dbPath); ok {
 		return "remote"
 	}
 	return "local"
@@ -2085,7 +2085,7 @@ func remoteRuntimePath(rt localRuntime) string {
 
 func databaseSourceLocation(ctx context.Context, dbPath string) string {
 	filename := filepath.Base(dbPath)
-	root, ok := portableStoreRoot(ctx, dbPath)
+	root, ok, _ := portableStoreRoot(ctx, dbPath)
 	if !ok {
 		return filename
 	}
@@ -3716,16 +3716,17 @@ func sqliteDBHealth(ctx context.Context, dbPath, manifestDBPath string) map[stri
 
 func portableStoreGitStatus(ctx context.Context, dbPath string) map[string]any {
 	result := map[string]any{}
-	root, ok := portableStoreRoot(ctx, dbPath)
+	root, ok, err := portableStoreRoot(ctx, dbPath)
+	if err != nil {
+		result["state"] = "error"
+		result["error"] = err.Error()
+		return result
+	}
 	if !ok {
 		result["state"] = "not_portable"
 		return result
 	}
 	result["root"] = root
-	if !portableStoreIsGitWorktree(ctx, root) {
-		result["state"] = "not_git"
-		return result
-	}
 	if gitWorktreeClean(ctx, root) {
 		result["state"] = "clean"
 	} else {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1993,7 +1993,7 @@ func (a *App) runTUI(ctx context.Context, args []string) error {
 		Repository:         repo.FullName,
 		InferredRepository: inferred,
 		Mode:               "cluster-browser",
-		DBSource:           databaseSourceKind(rt.SourceDBPath),
+		DBSource:           databaseSourceKind(ctx, rt.SourceDBPath),
 		DBLocation:         databaseSourceLocation(ctx, rt.SourceDBPath),
 		DBRefreshSource:    remoteRefreshSource(rt),
 		DBRuntimePath:      remoteRuntimePath(rt),
@@ -2048,7 +2048,7 @@ func emptyClusterBrowserPayload(ctx context.Context, cfg config.Config, sourceDB
 	}
 	return clusterBrowserPayload{
 		Mode:           "cluster-browser",
-		DBSource:       databaseSourceKind(sourceDBPath),
+		DBSource:       databaseSourceKind(ctx, sourceDBPath),
 		DBLocation:     databaseSourceLocation(ctx, sourceDBPath),
 		Sort:           sort,
 		Layout:         layout,
@@ -2062,8 +2062,8 @@ func emptyClusterBrowserPayload(ctx context.Context, cfg config.Config, sourceDB
 	}
 }
 
-func databaseSourceKind(dbPath string) string {
-	if _, ok := portableStoreRoot(dbPath); ok {
+func databaseSourceKind(ctx context.Context, dbPath string) string {
+	if _, ok := portableStoreRoot(ctx, dbPath); ok {
 		return "remote"
 	}
 	return "local"
@@ -2085,7 +2085,7 @@ func remoteRuntimePath(rt localRuntime) string {
 
 func databaseSourceLocation(ctx context.Context, dbPath string) string {
 	filename := filepath.Base(dbPath)
-	root, ok := portableStoreRoot(dbPath)
+	root, ok := portableStoreRoot(ctx, dbPath)
 	if !ok {
 		return filename
 	}
@@ -3716,7 +3716,7 @@ func sqliteDBHealth(ctx context.Context, dbPath, manifestDBPath string) map[stri
 
 func portableStoreGitStatus(ctx context.Context, dbPath string) map[string]any {
 	result := map[string]any{}
-	root, ok := portableStoreRoot(dbPath)
+	root, ok := portableStoreRoot(ctx, dbPath)
 	if !ok {
 		result["state"] = "not_portable"
 		return result

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -2688,7 +2688,7 @@ func TestDefaultPortableStoreDir(t *testing.T) {
 
 func TestDatabaseSourceLocationLocal(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "gitcrawl.db")
-	if got := databaseSourceKind(dbPath); got != "local" {
+	if got := databaseSourceKind(context.Background(), dbPath); got != "local" {
 		t.Fatalf("source kind = %q, want local", got)
 	}
 	if got := databaseSourceLocation(context.Background(), dbPath); got != "gitcrawl.db" {
@@ -2711,7 +2711,7 @@ func TestDatabaseSourceLocationRemoteGitHubStore(t *testing.T) {
 		t.Fatalf("git remote add: %v", err)
 	}
 
-	if got := databaseSourceKind(dbPath); got != "remote" {
+	if got := databaseSourceKind(ctx, dbPath); got != "remote" {
 		t.Fatalf("source kind = %q, want remote", got)
 	}
 	want := "openclaw/gitcrawl-store:openclaw__openclaw.sync.db"
@@ -3094,7 +3094,7 @@ func TestReadCommandRefreshesPortableStore(t *testing.T) {
 	if !gitWorktreeClean(ctx, checkoutDir) {
 		t.Fatal("portable checkout should stay clean after read-only command")
 	}
-	mirrorPath, err := run.portableRuntimeDBPath(filepath.Join(checkoutDir, dbRel))
+	mirrorPath, err := run.portableRuntimeDBPath(ctx, filepath.Join(checkoutDir, dbRel))
 	if err != nil {
 		t.Fatalf("runtime db path: %v", err)
 	}
@@ -3205,7 +3205,7 @@ func TestReadCommandRepairsMalformedDirtyPortableStore(t *testing.T) {
 	}
 	run := New()
 	run.configPath = configPath
-	mirrorPath, err := run.portableRuntimeDBPath(checkoutDB)
+	mirrorPath, err := run.portableRuntimeDBPath(ctx, checkoutDB)
 	if err != nil {
 		t.Fatalf("runtime db path: %v", err)
 	}
@@ -3331,7 +3331,7 @@ func TestPortableRuntimePropagatesNonCorruptionSourceErrors(t *testing.T) {
 	checkoutDB := filepath.Join(checkoutDir, dbRel)
 	run := New()
 	run.configPath = filepath.Join(dir, "config.toml")
-	mirrorPath, err := run.portableRuntimeDBPath(checkoutDB)
+	mirrorPath, err := run.portableRuntimeDBPath(ctx, checkoutDB)
 	if err != nil {
 		t.Fatalf("runtime db path: %v", err)
 	}
@@ -3473,6 +3473,53 @@ func TestPortableRuntimeRejectsManifestMismatchBeforeReplacingMirror(t *testing.
 	err = validatePortableSQLiteFile(ctx, checkoutDB, checkoutDB)
 	if err == nil || !isPortableSourceRepairableHealthError(err) {
 		t.Fatalf("malformed manifest should be a repairable health error, got %v", err)
+	}
+}
+
+func TestSyncCreatesLocalDatabaseBelowUnrelatedGitMetadata(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dataRoot := filepath.Join(dir, "data-root")
+	if err := os.MkdirAll(filepath.Join(dataRoot, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir unrelated git metadata: %v", err)
+	}
+
+	dbPath := filepath.Join(dataRoot, "gitcrawl", "gitcrawl.db")
+	configPath := filepath.Join(dir, "config.toml")
+	app := New()
+	if err := app.Run(ctx, []string{"--config", configPath, "init", "--db", dbPath}); err != nil {
+		t.Fatalf("init config: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/openclaw/openclaw":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 12345, "full_name": "openclaw/openclaw"})
+		case "/repos/openclaw/openclaw/issues/101":
+			_ = json.NewEncoder(w).Encode(githubIssueJSON(101, "issue", "Git metadata regression"))
+		default:
+			t.Fatalf("unexpected GitHub path: %s", r.URL.String())
+		}
+	}))
+	defer server.Close()
+	t.Setenv("GITHUB_TOKEN", "test-gh-token")
+	t.Setenv("GITCRAWL_GITHUB_BASE_URL", server.URL)
+
+	if err := New().Run(ctx, []string{"--config", configPath, "sync", "openclaw/openclaw", "--numbers", "101", "--json"}); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	st, err := store.OpenReadOnly(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open local database: %v", err)
+	}
+	defer st.Close()
+	status, err := st.Status(ctx)
+	if err != nil {
+		t.Fatalf("local database status: %v", err)
+	}
+	if status.ThreadCount != 1 {
+		t.Fatalf("local database thread count = %d, want 1", status.ThreadCount)
 	}
 }
 

--- a/internal/cli/lock_diagnostics_test.go
+++ b/internal/cli/lock_diagnostics_test.go
@@ -90,7 +90,7 @@ func TestDoctorLocksUsesPortableRuntimeDB(t *testing.T) {
 	}
 	expected := New()
 	expected.configPath = configPath
-	expectedRuntimeDB, err := expected.portableRuntimeDBPath(sourceDB)
+	expectedRuntimeDB, err := expected.portableRuntimeDBPath(ctx, sourceDB)
 	if err != nil {
 		t.Fatalf("runtime db path: %v", err)
 	}

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -44,7 +44,9 @@ func (a *App) openLocalRuntime(ctx context.Context) (localRuntime, error) {
 	}
 	sourceDBPath := cfg.DBPath
 	remoteSource := false
-	if _, ok := portableStoreRoot(ctx, cfg.DBPath); ok {
+	if _, ok, err := portableStoreRoot(ctx, cfg.DBPath); err != nil {
+		return localRuntime{}, err
+	} else if ok {
 		mirrorPath, _, err := a.ensurePortableRuntimeDB(ctx, cfg.DBPath, false)
 		if err != nil {
 			return localRuntime{}, err
@@ -73,7 +75,9 @@ func (a *App) openLocalRuntimeReadOnlyWithConfig(ctx context.Context, cfg config
 	}
 	sourceDBPath := cfg.DBPath
 	remoteSource := false
-	if _, ok := portableStoreRoot(ctx, cfg.DBPath); ok {
+	if _, ok, err := portableStoreRoot(ctx, cfg.DBPath); err != nil {
+		return localRuntime{}, err
+	} else if ok {
 		mirrorPath, _, err := a.ensurePortableRuntimeDB(ctx, cfg.DBPath, true)
 		if err != nil {
 			return localRuntime{}, err
@@ -104,11 +108,11 @@ func (rt localRuntime) defaultRepository(ctx context.Context) (store.Repository,
 }
 
 func refreshPortableStoreForDB(ctx context.Context, dbPath string) error {
-	root, ok := portableStoreRoot(ctx, dbPath)
-	if !ok {
-		return nil
+	root, ok, err := portableStoreRoot(ctx, dbPath)
+	if err != nil {
+		return err
 	}
-	if !portableStoreIsGitWorktree(ctx, root) {
+	if !ok {
 		return nil
 	}
 	if !gitWorktreeClean(ctx, root) {
@@ -131,11 +135,11 @@ type portableRepairResult struct {
 
 func repairMalformedPortableStoreForDB(ctx context.Context, dbPath, configPath string) (portableRepairResult, error) {
 	result := portableRepairResult{Action: "reset-pulled"}
-	root, ok := portableStoreRoot(ctx, dbPath)
-	if !ok {
-		return result, nil
+	root, ok, err := portableStoreRoot(ctx, dbPath)
+	if err != nil {
+		return result, err
 	}
-	if !portableStoreIsGitWorktree(ctx, root) {
+	if !ok {
 		return result, nil
 	}
 	if !portableStoreRepairAllowed(root, configPath) {
@@ -165,11 +169,11 @@ func repairMalformedPortableStoreForDB(ctx context.Context, dbPath, configPath s
 
 func recloneMalformedPortableStoreForDB(ctx context.Context, dbPath, configPath string) (portableRepairResult, error) {
 	result := portableRepairResult{Action: "recloned"}
-	root, ok := portableStoreRoot(ctx, dbPath)
-	if !ok {
-		return result, nil
+	root, ok, err := portableStoreRoot(ctx, dbPath)
+	if err != nil {
+		return result, err
 	}
-	if !portableStoreIsGitWorktree(ctx, root) {
+	if !ok {
 		return result, nil
 	}
 	if !portableStoreRepairAllowed(root, configPath) {
@@ -219,7 +223,10 @@ func (a *App) ensurePortableRuntimeDB(ctx context.Context, sourceDBPath string, 
 }
 
 func (a *App) portableRuntimeDBPath(ctx context.Context, sourceDBPath string) (string, error) {
-	root, ok := portableStoreRoot(ctx, sourceDBPath)
+	root, ok, err := portableStoreRoot(ctx, sourceDBPath)
+	if err != nil {
+		return "", err
+	}
 	if !ok {
 		return "", fmt.Errorf("portable store root not found for %s", sourceDBPath)
 	}
@@ -237,8 +244,11 @@ func (a *App) portableRuntimeDBPath(ctx context.Context, sourceDBPath string) (s
 func refreshPortableRuntimeDB(ctx context.Context, sourceDBPath, mirrorPath string, refresh bool, configPath string) (bool, error) {
 	portableRuntimeMu.Lock()
 	defer portableRuntimeMu.Unlock()
-	portableRoot, isPortableSource := portableStoreRoot(ctx, sourceDBPath)
-	isRepairablePortableSource := isPortableSource && portableStoreIsGitWorktree(ctx, portableRoot)
+	_, isPortableSource, err := portableStoreRoot(ctx, sourceDBPath)
+	if err != nil {
+		return false, err
+	}
+	isRepairablePortableSource := isPortableSource
 	if refresh {
 		_ = refreshPortableStoreForDBIfDue(ctx, sourceDBPath, mirrorPath)
 	}
@@ -768,23 +778,49 @@ func copySQLiteFileAtomicVerified(ctx context.Context, sourcePath, targetPath st
 	return nil
 }
 
-func portableStoreRoot(ctx context.Context, dbPath string) (string, bool) {
+func portableStoreRoot(ctx context.Context, dbPath string) (string, bool, error) {
 	dir := filepath.Clean(filepath.Dir(dbPath))
 	for {
-		if info, err := os.Stat(filepath.Join(dir, ".git")); err == nil && info.IsDir() && portableStoreIsGitWorktree(ctx, dir) {
-			return dir, true
+		info, statErr := os.Stat(filepath.Join(dir, ".git"))
+		if statErr == nil && info.IsDir() {
+			isWorktree, err := probePortableStoreGitWorktree(ctx, dir)
+			if err != nil {
+				return "", false, fmt.Errorf("verify portable store candidate %s: %w", dir, err)
+			}
+			if isWorktree {
+				return dir, true, nil
+			}
+		} else if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+			return "", false, fmt.Errorf("inspect portable store candidate %s: %w", dir, statErr)
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return "", false
+			return "", false, nil
 		}
 		dir = parent
 	}
 }
 
-func portableStoreIsGitWorktree(ctx context.Context, dir string) bool {
-	out, err := gitOutput(ctx, "", "-C", dir, "rev-parse", "--is-inside-work-tree")
-	return err == nil && strings.TrimSpace(out) == "true"
+func probePortableStoreGitWorktree(ctx context.Context, dir string) (bool, error) {
+	out, err := runGitCommandOutput(ctx, "", "-C", dir, "rev-parse", "--is-inside-work-tree")
+	if err == nil {
+		switch strings.TrimSpace(out) {
+		case "true":
+			return true, nil
+		case "false":
+			return false, nil
+		default:
+			return false, fmt.Errorf("git rev-parse returned unexpected output %q", strings.TrimSpace(out))
+		}
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return false, ctxErr
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 128 && strings.Contains(out, "not a git repository") {
+		return false, nil
+	}
+	return false, fmt.Errorf("git rev-parse failed: %w\n%s", err, strings.TrimSpace(out))
 }
 
 func portableStoreRemoteURL(ctx context.Context, root string) string {

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -44,7 +44,7 @@ func (a *App) openLocalRuntime(ctx context.Context) (localRuntime, error) {
 	}
 	sourceDBPath := cfg.DBPath
 	remoteSource := false
-	if _, ok := portableStoreRoot(cfg.DBPath); ok {
+	if _, ok := portableStoreRoot(ctx, cfg.DBPath); ok {
 		mirrorPath, _, err := a.ensurePortableRuntimeDB(ctx, cfg.DBPath, false)
 		if err != nil {
 			return localRuntime{}, err
@@ -73,7 +73,7 @@ func (a *App) openLocalRuntimeReadOnlyWithConfig(ctx context.Context, cfg config
 	}
 	sourceDBPath := cfg.DBPath
 	remoteSource := false
-	if _, ok := portableStoreRoot(cfg.DBPath); ok {
+	if _, ok := portableStoreRoot(ctx, cfg.DBPath); ok {
 		mirrorPath, _, err := a.ensurePortableRuntimeDB(ctx, cfg.DBPath, true)
 		if err != nil {
 			return localRuntime{}, err
@@ -104,7 +104,7 @@ func (rt localRuntime) defaultRepository(ctx context.Context) (store.Repository,
 }
 
 func refreshPortableStoreForDB(ctx context.Context, dbPath string) error {
-	root, ok := portableStoreRoot(dbPath)
+	root, ok := portableStoreRoot(ctx, dbPath)
 	if !ok {
 		return nil
 	}
@@ -131,7 +131,7 @@ type portableRepairResult struct {
 
 func repairMalformedPortableStoreForDB(ctx context.Context, dbPath, configPath string) (portableRepairResult, error) {
 	result := portableRepairResult{Action: "reset-pulled"}
-	root, ok := portableStoreRoot(dbPath)
+	root, ok := portableStoreRoot(ctx, dbPath)
 	if !ok {
 		return result, nil
 	}
@@ -165,7 +165,7 @@ func repairMalformedPortableStoreForDB(ctx context.Context, dbPath, configPath s
 
 func recloneMalformedPortableStoreForDB(ctx context.Context, dbPath, configPath string) (portableRepairResult, error) {
 	result := portableRepairResult{Action: "recloned"}
-	root, ok := portableStoreRoot(dbPath)
+	root, ok := portableStoreRoot(ctx, dbPath)
 	if !ok {
 		return result, nil
 	}
@@ -210,7 +210,7 @@ func recloneMalformedPortableStoreForDB(ctx context.Context, dbPath, configPath 
 var portableRuntimeMu sync.Mutex
 
 func (a *App) ensurePortableRuntimeDB(ctx context.Context, sourceDBPath string, refresh bool) (string, bool, error) {
-	mirrorPath, err := a.portableRuntimeDBPath(sourceDBPath)
+	mirrorPath, err := a.portableRuntimeDBPath(ctx, sourceDBPath)
 	if err != nil {
 		return "", false, err
 	}
@@ -218,8 +218,8 @@ func (a *App) ensurePortableRuntimeDB(ctx context.Context, sourceDBPath string, 
 	return mirrorPath, changed, err
 }
 
-func (a *App) portableRuntimeDBPath(sourceDBPath string) (string, error) {
-	root, ok := portableStoreRoot(sourceDBPath)
+func (a *App) portableRuntimeDBPath(ctx context.Context, sourceDBPath string) (string, error) {
+	root, ok := portableStoreRoot(ctx, sourceDBPath)
 	if !ok {
 		return "", fmt.Errorf("portable store root not found for %s", sourceDBPath)
 	}
@@ -237,7 +237,7 @@ func (a *App) portableRuntimeDBPath(sourceDBPath string) (string, error) {
 func refreshPortableRuntimeDB(ctx context.Context, sourceDBPath, mirrorPath string, refresh bool, configPath string) (bool, error) {
 	portableRuntimeMu.Lock()
 	defer portableRuntimeMu.Unlock()
-	portableRoot, isPortableSource := portableStoreRoot(sourceDBPath)
+	portableRoot, isPortableSource := portableStoreRoot(ctx, sourceDBPath)
 	isRepairablePortableSource := isPortableSource && portableStoreIsGitWorktree(ctx, portableRoot)
 	if refresh {
 		_ = refreshPortableStoreForDBIfDue(ctx, sourceDBPath, mirrorPath)
@@ -768,10 +768,10 @@ func copySQLiteFileAtomicVerified(ctx context.Context, sourcePath, targetPath st
 	return nil
 }
 
-func portableStoreRoot(dbPath string) (string, bool) {
+func portableStoreRoot(ctx context.Context, dbPath string) (string, bool) {
 	dir := filepath.Clean(filepath.Dir(dbPath))
 	for {
-		if info, err := os.Stat(filepath.Join(dir, ".git")); err == nil && info.IsDir() {
+		if info, err := os.Stat(filepath.Join(dir, ".git")); err == nil && info.IsDir() && portableStoreIsGitWorktree(ctx, dir) {
 			return dir, true
 		}
 		parent := filepath.Dir(dir)

--- a/internal/cli/runtime_extra_test.go
+++ b/internal/cli/runtime_extra_test.go
@@ -2,11 +2,26 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 )
+
+func TestPortableStoreRootPropagatesGitProbeFailure(t *testing.T) {
+	dir := t.TempDir()
+	if err := runGit(context.Background(), "", "init", dir); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err := portableStoreRoot(ctx, filepath.Join(dir, "gitcrawl.db"))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("portable store root error = %v, want context canceled", err)
+	}
+}
 
 func TestPortableRuntimeUtilityBranches(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `gitcrawl init --db ...` followed by `gitcrawl sync` failed with `stat portable source db: no such file or directory` when an ancestor of the database path contained a stray `.git` directory that was not a Git worktree.

Gitcrawl treated the path as a portable-store checkout and tried to copy the not-yet-created local database into a runtime mirror.

## Why This Change Was Made

Portable-store discovery now verifies candidate `.git` ancestors with Git. A confirmed non-worktree is ignored; cancellation, a missing Git executable, safe-directory failures, and other unexpected probe errors are returned instead of reclassifying a portable checkout as local.

Valid Git worktrees retain their existing behavior so older portable checkouts without Gitcrawl's marker continue to work. Distinguishing an ordinary repository from an unmarked legacy portable checkout is intentionally outside this change because both currently have the same on-disk identity.

## User Impact

Users can initialize and sync a local database below unrelated or incomplete Git metadata. Existing portable-store checkouts continue to use their writable runtime mirrors; an unexpected verification failure now stops the operation instead of bypassing the mirror.

## Evidence

### Live before/after proof

The commands below used freshly built binaries, temporary directories, and public PR #105. Paths are redacted.

Current `main` fails after `init` when an empty unrelated `.git` directory is above the configured database:

```text
$ gitcrawl-main --config <proof-root>/main/config.toml init --db <proof-root>/main/data/nested/gitcrawl.db
$ gitcrawl-main --config <proof-root>/main/config.toml sync openclaw/gitcrawl --numbers 105 --json
stat portable source db: stat <proof-root>/main/data/nested/gitcrawl.db: no such file or directory
exit=1
```

The patched binary creates and syncs the configured local database:

```text
$ gitcrawl-fixed --config <proof-root>/fixed/config.toml sync openclaw/gitcrawl --numbers 105 --json
{
  "repository": "openclaw/gitcrawl",
  "threads_synced": 1,
  "pull_requests_synced": 1,
  "numbers": [105]
}
$ gitcrawl-fixed --config <proof-root>/fixed/config.toml status --json
{
  "state": "current",
  "summary": "1 threads across 1 repositories",
  "database_path": "<proof-root>/fixed/data/nested/gitcrawl.db"
}
exit=0
```

A separate initialized Git checkout containing the same database remains portable. `doctor --json` reports the runtime mirror, and the source checksum is unchanged after opening it:

```text
portable_store_status.state=clean
db_schema.path=<proof-root>/portable/runtime/checkout/archive/gitcrawl.db
runtime_db_health.health=ok
source_db_health.health=ok
source_unchanged=true
exit=0
```

### Automated validation

- `TestSyncCreatesLocalDatabaseBelowUnrelatedGitMetadata` covers the full `init` then `sync` regression.
- `TestPortableStoreRootPropagatesGitProbeFailure` verifies that a canceled Git probe for a valid checkout is returned rather than classified as local.
- Existing portable runtime and diagnostics tests verify that valid checkouts still use their mirrors.
- `make test-coverage` — passes, total coverage 85.0%.
- `go vet ./...` — passes.
- `go mod tidy` — no `go.mod` or `go.sum` changes.
- `go build -ldflags '-X github.com/openclaw/gitcrawl/internal/cli.version=pr105' -o bin/gitcrawl ./cmd/gitcrawl` — passes.
- `./scripts/test-release.sh` — passes.

Suggested review order: `portableStoreRoot` and `probePortableStoreGitWorktree` in `internal/cli/runtime.go`, then their runtime callers, then the two regression tests.
