### PR TITLE
fix(store): reuse existing key summaries during upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.2 - Unreleased
 
+- Reuse legacy `llm_key_3line` summaries as canonical key-summary evidence during schema migration so existing archives can embed, cluster, and publish without regenerating every summary first.
 - Require every Gitcrawl cloud publisher manifest to opt into snapshot staging so `--stage-only` and normal publish-then-cutover runs cannot activate serving state through the legacy compatibility path.
 - Update CrawlKit to v0.14.2 and bind publisher resume plus post-cutover verification to the exact snapshot ID, so a newer concurrently staged candidate cannot be mistaken for the snapshot this publisher owns.
 - Fail cloud publication before any remote mutation when local enrichment coverage is incomplete unless operators explicitly pass `--allow-incomplete`.

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -3635,10 +3635,10 @@ func TestDoctorJSONReportsCurrentSchemaDiagnosticsWithoutMutation(t *testing.T) 
 	if got := schema["state"]; got != "current" {
 		t.Fatalf("db_schema.state = %#v, payload=%#v", got, schema)
 	}
-	if got := schema["current_version"]; got != float64(10) {
+	if got := schema["current_version"]; got != float64(11) {
 		t.Fatalf("db_schema.current_version = %#v, payload=%#v", got, schema)
 	}
-	if got := schema["supported_version"]; got != float64(10) {
+	if got := schema["supported_version"]; got != float64(11) {
 		t.Fatalf("db_schema.supported_version = %#v, payload=%#v", got, schema)
 	}
 	if got := schema["child_observation_reservations"]; got != true {
@@ -3900,7 +3900,7 @@ func TestDoctorJSONReportsLegacyPendingSchemaWithoutMutation(t *testing.T) {
 		t.Fatalf("pr_details.duplicate_path_files_supported = %#v, payload=%#v", got, prDetails)
 	}
 	pending := doctorStringList(t, schema, "pending_migrations")
-	if !doctorListContains(pending, "schema_version_3_to_10") ||
+	if !doctorListContains(pending, "schema_version_3_to_11") ||
 		!doctorListContains(pending, "pull_request_files_position_key") ||
 		!doctorListContains(pending, "thread_child_observation_reservations_table") {
 		t.Fatalf("pending_migrations = %#v", pending)

--- a/internal/store/migration_observation_test.go
+++ b/internal/store/migration_observation_test.go
@@ -748,7 +748,7 @@ func TestInspectSchemaClassifiesBoundaryStates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open newer-schema fixture: %v", err)
 	}
-	if _, err := st.DB().ExecContext(ctx, `pragma user_version = 11`); err != nil {
+	if _, err := st.DB().ExecContext(ctx, `pragma user_version = 12`); err != nil {
 		_ = st.Close()
 		t.Fatalf("mark newer-schema fixture: %v", err)
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	schemaVersion = 10
+	schemaVersion = 11
 	timeLayout    = time.RFC3339Nano
 )
 
@@ -308,6 +308,9 @@ func (s *Store) migrate(ctx context.Context) error {
 	if err := s.ensurePullRequestFilesPositionKey(ctx); err != nil {
 		return err
 	}
+	if err := s.ensureLegacyThreadKeySummaryKinds(ctx); err != nil {
+		return err
+	}
 	if err := s.ensureObservationSchemaConvergence(ctx); err != nil {
 		return err
 	}
@@ -327,6 +330,25 @@ func (s *Store) migrate(ctx context.Context) error {
 		return fmt.Errorf("schema migration left pending convergence: %s", strings.Join(pending, ", "))
 	}
 	return s.markObservationSchemaConverged(ctx)
+}
+
+func (s *Store) ensureLegacyThreadKeySummaryKinds(ctx context.Context) error {
+	if _, err := s.db.ExecContext(ctx, `
+		insert into thread_key_summaries(
+			thread_revision_id, summary_kind, prompt_version, provider, model,
+			input_hash, output_hash, key_text, created_at
+		)
+		select
+			thread_revision_id, ?, prompt_version, provider, model,
+			input_hash, output_hash, key_text, created_at
+		from thread_key_summaries
+		where summary_kind = ?
+		on conflict(thread_revision_id, summary_kind, prompt_version, provider, model)
+			do nothing
+	`, SummaryKindLLMKey, summaryKindLegacyLLMKey3Line); err != nil {
+		return fmt.Errorf("migrate legacy thread key summaries: %w", err)
+	}
+	return nil
 }
 
 func (s *Store) ensureLegacyPortableColumns(ctx context.Context) error {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -89,6 +89,152 @@ func TestOpenMigratesSchema(t *testing.T) {
 	}
 }
 
+func TestOpenMigratesLegacyThreadKeySummaryKinds(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "gitcrawl.db")
+	st, err := Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	repoID, err := st.UpsertRepository(ctx, Repository{
+		Owner:     "openclaw",
+		Name:      "gitcrawl",
+		FullName:  "openclaw/gitcrawl",
+		RawJSON:   "{}",
+		UpdatedAt: "2026-07-12T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("repository: %v", err)
+	}
+	thread := Thread{
+		RepoID:          repoID,
+		GitHubID:        "101",
+		Number:          101,
+		Kind:            "issue",
+		State:           "open",
+		Title:           "reuse legacy summary",
+		HTMLURL:         "https://github.com/openclaw/gitcrawl/issues/101",
+		LabelsJSON:      "[]",
+		AssigneesJSON:   "[]",
+		RawJSON:         "{}",
+		ContentHash:     "thread",
+		UpdatedAtGitHub: "2026-07-12T00:00:00Z",
+		UpdatedAt:       "2026-07-12T00:00:00Z",
+	}
+	thread.ID, err = st.UpsertThread(ctx, thread)
+	if err != nil {
+		t.Fatalf("thread: %v", err)
+	}
+	enrichment, err := st.UpsertThreadRevisionAndFingerprint(
+		ctx,
+		ThreadEvidence{Thread: thread},
+		"2026-07-12T00:00:00Z",
+	)
+	if err != nil {
+		t.Fatalf("enrichment: %v", err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `
+		insert into thread_key_summaries(
+			thread_revision_id, summary_kind, prompt_version, provider, model,
+			input_hash, output_hash, key_text, created_at
+		)
+		values
+			(?, 'llm_key_3line', 'llm-key-summary-v1', 'openai', 'gpt-5-mini',
+				'legacy-input-v1', 'legacy-output-v1', 'legacy summary v1', '2026-07-12T00:01:00Z'),
+			(?, 'llm_key_3line', 'llm-key-summary-v2', 'openai', 'gpt-5-mini',
+				'legacy-input-v2', 'legacy-output-v2', 'legacy summary v2', '2026-07-12T00:02:00Z'),
+			(?, 'llm_key_summary', 'llm-key-summary-v2', 'openai', 'gpt-5-mini',
+				'canonical-input-v2', 'canonical-output-v2', 'canonical summary v2', '2026-07-12T00:03:00Z');
+		pragma user_version = 10;
+	`, enrichment.RevisionID, enrichment.RevisionID, enrichment.RevisionID); err != nil {
+		_ = st.Close()
+		t.Fatalf("seed legacy summaries: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close legacy store: %v", err)
+	}
+
+	st, err = Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("reopen migrated store: %v", err)
+	}
+	defer st.Close()
+
+	var version int
+	if err := st.DB().QueryRowContext(ctx, `pragma user_version`).Scan(&version); err != nil {
+		t.Fatalf("read schema version: %v", err)
+	}
+	if version != schemaVersion {
+		t.Fatalf("schema version = %d, want %d", version, schemaVersion)
+	}
+	for _, test := range []struct {
+		promptVersion string
+		inputHash     string
+		outputHash    string
+		keyText       string
+		createdAt     string
+	}{
+		{
+			promptVersion: "llm-key-summary-v1",
+			inputHash:     "legacy-input-v1",
+			outputHash:    "legacy-output-v1",
+			keyText:       "legacy summary v1",
+			createdAt:     "2026-07-12T00:01:00Z",
+		},
+		{
+			promptVersion: "llm-key-summary-v2",
+			inputHash:     "canonical-input-v2",
+			outputHash:    "canonical-output-v2",
+			keyText:       "canonical summary v2",
+			createdAt:     "2026-07-12T00:03:00Z",
+		},
+	} {
+		var inputHash, outputHash, keyText, createdAt string
+		if err := st.DB().QueryRowContext(ctx, `
+			select input_hash, output_hash, key_text, created_at
+			from thread_key_summaries
+			where thread_revision_id = ?
+				and summary_kind = ?
+				and prompt_version = ?
+				and provider = 'openai'
+				and model = 'gpt-5-mini'
+		`, enrichment.RevisionID, SummaryKindLLMKey, test.promptVersion).Scan(
+			&inputHash,
+			&outputHash,
+			&keyText,
+			&createdAt,
+		); err != nil {
+			t.Fatalf("read canonical %s summary: %v", test.promptVersion, err)
+		}
+		if inputHash != test.inputHash || outputHash != test.outputHash ||
+			keyText != test.keyText || createdAt != test.createdAt {
+			t.Fatalf(
+				"canonical %s summary = %q/%q/%q/%q, want %q/%q/%q/%q",
+				test.promptVersion,
+				inputHash,
+				outputHash,
+				keyText,
+				createdAt,
+				test.inputHash,
+				test.outputHash,
+				test.keyText,
+				test.createdAt,
+			)
+		}
+	}
+	var legacyCount int
+	if err := st.DB().QueryRowContext(ctx, `
+		select count(*)
+		from thread_key_summaries
+		where thread_revision_id = ? and summary_kind = 'llm_key_3line'
+	`, enrichment.RevisionID).Scan(&legacyCount); err != nil {
+		t.Fatalf("count preserved legacy summaries: %v", err)
+	}
+	if legacyCount != 2 {
+		t.Fatalf("legacy summaries = %d, want 2", legacyCount)
+	}
+}
+
 func TestOpenMigratesAuthorAssociationFromVersionFour(t *testing.T) {
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "gitcrawl.db")
@@ -1246,7 +1392,7 @@ func TestInspectSchemaReportsEmptyDatabaseMigration(t *testing.T) {
 	}
 
 	diag := InspectSchema(ctx, dbPath)
-	if diag.State != "pending_migration" || diag.CurrentVersion != 0 || !containsString(diag.PendingMigrations, "schema_version_0_to_10") {
+	if diag.State != "pending_migration" || diag.CurrentVersion != 0 || !containsString(diag.PendingMigrations, "schema_version_0_to_11") {
 		t.Fatalf("schema diag = %#v, want empty database migration", diag)
 	}
 }
@@ -1279,7 +1425,7 @@ func TestInspectSchemaReportsCurrentVersionCompatibilityDriftWithoutMutation(t *
 			model text
 		);
 		create table pull_request_details (thread_id integer primary key);
-		pragma user_version = 10;
+		pragma user_version = 11;
 	`)
 	if err != nil {
 		_ = db.Close()
@@ -1389,7 +1535,7 @@ func TestInspectSchemaReportsLegacyPendingMigrationWithoutMutation(t *testing.T)
 	if diag.PRDetails.State != "legacy" || diag.PRDetails.FilesPositionKey || diag.PRDetails.DuplicatePathFilesSupported {
 		t.Fatalf("pr detail diag = %#v, want legacy", diag.PRDetails)
 	}
-	if !containsString(diag.PendingMigrations, "schema_version_3_to_10") ||
+	if !containsString(diag.PendingMigrations, "schema_version_3_to_11") ||
 		!containsString(diag.PendingMigrations, "pull_request_files_position_key") ||
 		!containsString(diag.PendingMigrations, "thread_child_observation_reservations_table") ||
 		!containsString(diag.PendingMigrations, "workflow_run_observation_reservations_table") {

--- a/internal/store/summary_tasks.go
+++ b/internal/store/summary_tasks.go
@@ -10,11 +10,12 @@ import (
 )
 
 const (
-	SummaryKindLLMKey       = "llm_key_summary"
-	SummaryPromptVersionV1  = "key-summary-v1"
-	MaxSummaryTextRunes     = 12_000
-	MaxSummaryTextBytes     = 24_000
-	summaryInputHashVersion = "summary-input:v2"
+	SummaryKindLLMKey            = "llm_key_summary"
+	SummaryPromptVersionV1       = "key-summary-v1"
+	MaxSummaryTextRunes          = 12_000
+	MaxSummaryTextBytes          = 24_000
+	summaryInputHashVersion      = "summary-input:v2"
+	summaryKindLegacyLLMKey3Line = "llm_key_3line"
 )
 
 type SummaryTask struct {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where upgrading an existing Gitcrawl archive would regenerate every legacy key summary before summary-backed embeddings and cloud publication could converge.

## Why This Change Was Made

The schema upgrade now copies valid `llm_key_3line` rows into the canonical `llm_key_summary` basis once, while preserving current canonical rows and retaining the legacy source rows for compatibility.

## User Impact

Existing archives can immediately reuse their stored summaries after upgrade instead of spending model quota and refresh time recreating equivalent data.

## Evidence

- `go test ./... -count=1`
- 96 MB production-shaped archive copy: schema `4 -> 11`, canonical summaries `0 -> 35,175`, legacy summaries preserved at `35,175`, `PRAGMA integrity_check = ok`
- migration completed in 1.431 seconds on the disposable archive copy
- local and branch autoreview: no actionable findings
