### PR TITLE
fix(store): keep portable exports under GitHub's blob limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.2 - Unreleased
 
+- Remove byte-identical legacy key-summary copies from portable exports after canonicalization, keeping archive snapshots below GitHub's blob limit without dropping distinct legacy evidence.
 - Reuse legacy `llm_key_3line` summaries as canonical key-summary evidence during schema migration so existing archives can embed, cluster, and publish without regenerating every summary first.
 - Require every Gitcrawl cloud publisher manifest to opt into snapshot staging so `--stage-only` and normal publish-then-cutover runs cannot activate serving state through the legacy compatibility path.
 - Update CrawlKit to v0.14.2 and bind publisher resume plus post-cutover verification to the exact snapshot ID, so a newer concurrently staged candidate cannot be mistaken for the snapshot this publisher owns.

--- a/internal/store/coverage_test.go
+++ b/internal/store/coverage_test.go
@@ -267,6 +267,64 @@ func TestPortablePruneCanonicalizesSchemaAndMetadata(t *testing.T) {
 	}
 }
 
+func TestPortablePruneDeletesOnlyEquivalentLegacyKeySummaries(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	_, threadIDs := seedVectorThreads(t, ctx, st)
+	if _, err := st.DB().ExecContext(ctx, `
+		insert into thread_revisions(
+			thread_id, source_updated_at, observation_sequence,
+			content_hash, title_hash, body_hash, labels_hash, created_at
+		)
+		select id, '2026-07-15T00:00:00Z', observation_sequence,
+			'content', 'title', 'body', 'labels', '2026-07-15T00:00:00Z'
+		from threads
+		where id = ?
+	`, threadIDs[0]); err != nil {
+		t.Fatalf("seed revision: %v", err)
+	}
+	var revisionID int64
+	if err := st.DB().QueryRowContext(ctx, `select id from thread_revisions where thread_id = ?`, threadIDs[0]).Scan(&revisionID); err != nil {
+		t.Fatalf("revision id: %v", err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `
+		insert into thread_key_summaries(
+			thread_revision_id, summary_kind, prompt_version, provider, model,
+			input_hash, output_hash, key_text, created_at
+		)
+		values
+			(?, 'llm_key_summary', 'equivalent', 'test', 'test', 'input-1', 'output-1', 'same text', '2026-07-15T00:01:00Z'),
+			(?, 'llm_key_3line', 'equivalent', 'test', 'test', 'input-1', 'output-1', 'same text', '2026-07-15T00:01:00Z'),
+			(?, 'llm_key_3line', 'legacy-only', 'test', 'test', 'input-2', 'output-2', 'legacy only', '2026-07-15T00:02:00Z'),
+			(?, 'llm_key_summary', 'different', 'test', 'test', 'input-3', 'output-3', 'canonical text', '2026-07-15T00:03:00Z'),
+			(?, 'llm_key_3line', 'different', 'test', 'test', 'input-3', 'output-3', 'different legacy text', '2026-07-15T00:03:00Z')
+	`, revisionID, revisionID, revisionID, revisionID, revisionID); err != nil {
+		t.Fatalf("seed key summaries: %v", err)
+	}
+
+	stats, err := st.PrunePortablePayloads(ctx, PortablePruneOptions{BodyChars: 5})
+	if err != nil {
+		t.Fatalf("prune portable: %v", err)
+	}
+	if stats.LegacySummariesDeleted != 1 {
+		t.Fatalf("legacy summaries deleted = %d, want 1", stats.LegacySummariesDeleted)
+	}
+	var legacyCount, canonicalCount int
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from thread_key_summaries where summary_kind = 'llm_key_3line'`).Scan(&legacyCount); err != nil {
+		t.Fatalf("count legacy summaries: %v", err)
+	}
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from thread_key_summaries where summary_kind = 'llm_key_summary'`).Scan(&canonicalCount); err != nil {
+		t.Fatalf("count canonical summaries: %v", err)
+	}
+	if legacyCount != 2 || canonicalCount != 2 {
+		t.Fatalf("summary counts legacy=%d canonical=%d, want 2/2", legacyCount, canonicalCount)
+	}
+}
+
 func TestPortablePruneClearsPRRawJSONBlobPointersAndFingerprints(t *testing.T) {
 	ctx := context.Background()
 	st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))

--- a/internal/store/portable.go
+++ b/internal/store/portable.go
@@ -32,6 +32,7 @@ type PortablePruneStats struct {
 	RepositoriesPruned       int64    `json:"repositories_pruned"`
 	RawJSONPruned            int64    `json:"raw_json_pruned"`
 	FingerprintsPruned       int64    `json:"fingerprints_pruned"`
+	LegacySummariesDeleted   int64    `json:"legacy_summaries_deleted"`
 	DocumentsDeleted         int64    `json:"documents_deleted"`
 	DocumentsFTSRebuilt      bool     `json:"documents_fts_rebuilt"`
 	DroppedTables            []string `json:"dropped_tables,omitempty"`
@@ -125,6 +126,11 @@ func (s *Store) PrunePortablePayloads(ctx context.Context, options PortablePrune
 		}
 		stats.FingerprintsPruned = rowsAffected(result)
 	}
+	if deleted, err := s.pruneEquivalentLegacyKeySummaries(ctx); err != nil {
+		return stats, err
+	} else {
+		stats.LegacySummariesDeleted = deleted
+	}
 	if s.tableExists(ctx, "documents") {
 		result, err := s.db.ExecContext(ctx, `delete from documents`)
 		if err != nil {
@@ -153,6 +159,35 @@ func (s *Store) PrunePortablePayloads(ctx context.Context, options PortablePrune
 		stats.BytesAfter = info.Size()
 	}
 	return stats, nil
+}
+
+func (s *Store) pruneEquivalentLegacyKeySummaries(ctx context.Context) (int64, error) {
+	if !s.hasColumn(ctx, "thread_key_summaries", "summary_kind") {
+		return 0, nil
+	}
+	// Full stores retain the legacy kind for compatibility. Portable snapshots
+	// only drop byte-identical copies after the canonical row is present.
+	result, err := s.db.ExecContext(ctx, `
+		delete from thread_key_summaries
+		where summary_kind = ?
+			and exists (
+				select 1
+				from thread_key_summaries as canonical
+				where canonical.thread_revision_id = thread_key_summaries.thread_revision_id
+					and canonical.summary_kind = ?
+					and canonical.prompt_version = thread_key_summaries.prompt_version
+					and canonical.provider = thread_key_summaries.provider
+					and canonical.model = thread_key_summaries.model
+					and canonical.input_hash = thread_key_summaries.input_hash
+					and canonical.output_hash = thread_key_summaries.output_hash
+					and canonical.key_text = thread_key_summaries.key_text
+					and canonical.created_at = thread_key_summaries.created_at
+			)
+	`, summaryKindLegacyLLMKey3Line, SummaryKindLLMKey)
+	if err != nil {
+		return 0, fmt.Errorf("prune equivalent legacy key summaries: %w", err)
+	}
+	return rowsAffected(result), nil
 }
 
 func (s *Store) canonicalizePortableSchema(ctx context.Context, bodyChars int, stats *PortablePruneStats) error {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators publishing a portable Gitcrawl store could generate a database larger than GitHub's 100 MB blob limit after the legacy key-summary migration duplicated canonical summary evidence.

## Why This Change Was Made

Portable pruning now removes a legacy key-summary row only when a canonical row matches every identity, hash, text, and timestamp field. Full archives continue retaining compatibility rows, and distinct legacy evidence remains in portable exports.

## User Impact

Portable stores no longer pay twice for byte-identical migrated summaries, making Git-backed store refreshes substantially less likely to fail at the blob-size boundary.

## Evidence

- `go test ./internal/store -run 'TestPortablePrune(DeletesOnlyEquivalentLegacyKeySummaries|CanonicalizesSchemaAndMetadata)' -count=1`
- `go test ./...`
- Fresh autoreview: clean, confidence 0.93
- Regression coverage proves equivalent legacy copies are deleted while unmatched and content-different legacy rows remain.
