### PR TITLE
fix(cluster): unrelated threads cluster when a body links another repository's issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.2 - Unreleased
 
+- Ignore cross-repository issue and pull request URLs when building deterministic cluster edges for the current repository, so an upstream link such as `https://github.com/other/repo/pull/169` no longer clusters the unrelated local thread numbered 169.
 - Remove byte-identical legacy key-summary copies from portable exports after canonicalization, keeping archive snapshots below GitHub's blob limit without dropping distinct legacy evidence.
 - Reuse legacy `llm_key_3line` summaries as canonical key-summary evidence during schema migration so existing archives can embed, cluster, and publish without regenerating every summary first.
 - Require every Gitcrawl cloud publisher manifest to opt into snapshot staging so `--stage-only` and normal publish-then-cutover runs cannot activate serving state through the legacy compatibility path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.7.2 - Unreleased
 
-- Ignore cross-repository issue and pull request URLs when building deterministic cluster edges for the current repository, so an upstream link such as `https://github.com/other/repo/pull/169` no longer clusters the unrelated local thread numbered 169.
+- Ignore cross-repository issue and pull request links when building deterministic cluster edges for the current repository, so an upstream link such as `https://github.com/other/repo/pull/169` no longer clusters the unrelated local thread numbered 169, while unqualified `issues/123` and `pull/123` references still resolve locally.
 - Remove byte-identical legacy key-summary copies from portable exports after canonicalization, keeping archive snapshots below GitHub's blob limit without dropping distinct legacy evidence.
 - Reuse legacy `llm_key_3line` summaries as canonical key-summary evidence during schema migration so existing archives can embed, cluster, and publish without regenerating every summary first.
 - Require every Gitcrawl cloud publisher manifest to opt into snapshot staging so `--stage-only` and normal publish-then-cutover runs cannot activate serving state through the legacy compatibility path.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -50,7 +50,7 @@ const (
 
 var errNoSemanticVectors = errors.New("no semantic vectors")
 
-var threadReferencePattern = regexp.MustCompile(`(?i)(?:\b([\w.-]+/[\w.-]+)#(\d+)|\b([\w.-]+/[\w.-]+)/(?:issues|pull)/(\d+)|#(\d{2,}))`)
+var threadReferencePattern = regexp.MustCompile(`(?i)(?:\b([\w.-]+/[\w.-]+)#(\d+)|(?:\b([\w.-]+/[\w.-]+)/)?(?:issues|pull)/(\d+)|#(\d{2,}))`)
 var githubThreadURLPattern = regexp.MustCompile(`(?i)^https?://github\.com/([\w.-]+)/([\w.-]+)/(?:issues|pull)/(\d+)(?:[/?#].*)?$`)
 var ownerRepoThreadPattern = regexp.MustCompile(`(?i)^([\w.-]+)/([\w.-]+)#(\d+)$`)
 var pathThreadPattern = regexp.MustCompile(`(?i)(?:^|/)(?:issues|pull)/(\d+)(?:[/?#].*)?$`)
@@ -4282,10 +4282,12 @@ func collectReferencedThreadNumbers(refs map[int]referenceEvidence, threadNumber
 				continue
 			}
 			numberText = value[match[4]:match[5]]
-		} else if match[6] >= 0 {
-			refRepo := value[match[6]:match[7]]
-			if !strings.EqualFold(refRepo, repoFullName) {
-				continue
+		} else if match[8] >= 0 {
+			if match[6] >= 0 {
+				refRepo := value[match[6]:match[7]]
+				if !strings.EqualFold(refRepo, repoFullName) {
+					continue
+				}
 			}
 			numberText = value[match[8]:match[9]]
 		} else if match[10] >= 0 {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -50,7 +50,7 @@ const (
 
 var errNoSemanticVectors = errors.New("no semantic vectors")
 
-var threadReferencePattern = regexp.MustCompile(`(?i)(?:\b([\w.-]+/[\w.-]+)#(\d+)|(?:issues|pull)/(\d+)|#(\d{2,}))`)
+var threadReferencePattern = regexp.MustCompile(`(?i)(?:\b([\w.-]+/[\w.-]+)#(\d+)|\b([\w.-]+/[\w.-]+)/(?:issues|pull)/(\d+)|#(\d{2,}))`)
 var githubThreadURLPattern = regexp.MustCompile(`(?i)^https?://github\.com/([\w.-]+)/([\w.-]+)/(?:issues|pull)/(\d+)(?:[/?#].*)?$`)
 var ownerRepoThreadPattern = regexp.MustCompile(`(?i)^([\w.-]+)/([\w.-]+)#(\d+)$`)
 var pathThreadPattern = regexp.MustCompile(`(?i)(?:^|/)(?:issues|pull)/(\d+)(?:[/?#].*)?$`)
@@ -4283,9 +4283,13 @@ func collectReferencedThreadNumbers(refs map[int]referenceEvidence, threadNumber
 			}
 			numberText = value[match[4]:match[5]]
 		} else if match[6] >= 0 {
-			numberText = value[match[6]:match[7]]
-		} else if match[8] >= 0 {
+			refRepo := value[match[6]:match[7]]
+			if !strings.EqualFold(refRepo, repoFullName) {
+				continue
+			}
 			numberText = value[match[8]:match[9]]
+		} else if match[10] >= 0 {
+			numberText = value[match[10]:match[11]]
 		}
 		number, err := strconv.Atoi(numberText)
 		if err != nil || number <= 0 || number == threadNumber {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -7136,6 +7136,9 @@ func TestBuildDurableClusterInputsScopesURLReferencesToRepository(t *testing.T) 
 		{name: "same-repo pull URL", body: "Supersedes https://github.com/openclaw/openclaw/pull/901 by preserving the device-token scope during upgrade.", wantEdges: 1},
 		{name: "same-repo qualified ref", body: "Fixes openclaw/openclaw#901 by preserving the device-token scope during upgrade.", wantEdges: 1},
 		{name: "same-repo bare ref", body: "Fixes #901 by preserving the device-token scope during upgrade.", wantEdges: 1},
+		{name: "unqualified issues path", body: "Fixes issues/901 by preserving the device-token scope during upgrade.", wantEdges: 1},
+		{name: "unqualified pull path", body: "Supersedes pull/901 by preserving the device-token scope during upgrade.", wantEdges: 1},
+		{name: "unqualified rooted issues path", body: "Fixes /issues/901 by preserving the device-token scope during upgrade.", wantEdges: 1},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -7124,6 +7124,92 @@ func TestBuildDurableClusterInputsIgnoresCrossRepoQualifiedReferences(t *testing
 	}
 }
 
+func TestBuildDurableClusterInputsScopesURLReferencesToRepository(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		body      string
+		wantEdges int
+	}{
+		{name: "cross-repo pull URL", body: "Bumps fast-uri from 3.0.5 to 3.0.6, see https://redirect.github.com/fastify/fast-uri/pull/901 for the upstream change.", wantEdges: 0},
+		{name: "cross-repo issues URL", body: "Upstream breakage is tracked in https://github.com/fastify/fast-uri/issues/901 before this bump.", wantEdges: 0},
+		{name: "same-repo issues URL", body: "Fixes https://github.com/openclaw/openclaw/issues/901 by preserving the device-token scope during upgrade.", wantEdges: 1},
+		{name: "same-repo pull URL", body: "Supersedes https://github.com/openclaw/openclaw/pull/901 by preserving the device-token scope during upgrade.", wantEdges: 1},
+		{name: "same-repo qualified ref", body: "Fixes openclaw/openclaw#901 by preserving the device-token scope during upgrade.", wantEdges: 1},
+		{name: "same-repo bare ref", body: "Fixes #901 by preserving the device-token scope during upgrade.", wantEdges: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			st, err := store.Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+			if err != nil {
+				t.Fatalf("open store: %v", err)
+			}
+			defer st.Close()
+			repoID, err := st.UpsertRepository(ctx, store.Repository{
+				Owner:     "openclaw",
+				Name:      "openclaw",
+				FullName:  "openclaw/openclaw",
+				RawJSON:   "{}",
+				UpdatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+			})
+			if err != nil {
+				t.Fatalf("seed repository: %v", err)
+			}
+			issueID, err := st.UpsertThread(ctx, store.Thread{
+				RepoID:        repoID,
+				GitHubID:      "901",
+				Number:        901,
+				Kind:          "issue",
+				State:         "open",
+				Title:         "Gateway token regression",
+				Body:          "Users cannot authorize device tokens.",
+				HTMLURL:       "https://github.com/openclaw/openclaw/issues/901",
+				LabelsJSON:    "[]",
+				AssigneesJSON: "[]",
+				RawJSON:       "{}",
+				ContentHash:   "hash-901",
+				UpdatedAt:     time.Now().UTC().Format(time.RFC3339Nano),
+			})
+			if err != nil {
+				t.Fatalf("seed issue: %v", err)
+			}
+			prID, err := st.UpsertThread(ctx, store.Thread{
+				RepoID:        repoID,
+				GitHubID:      "902",
+				Number:        902,
+				Kind:          "pull_request",
+				State:         "open",
+				Title:         "Repair auth scope migration",
+				Body:          tc.body,
+				HTMLURL:       "https://github.com/openclaw/openclaw/pull/902",
+				LabelsJSON:    "[]",
+				AssigneesJSON: "[]",
+				RawJSON:       "{}",
+				ContentHash:   "hash-902",
+				UpdatedAt:     time.Now().UTC().Format(time.RFC3339Nano),
+			})
+			if err != nil {
+				t.Fatalf("seed pull request: %v", err)
+			}
+			inputs, edgeCount, err := buildDurableClusterInputs(ctx, st, repoID, []store.ThreadVector{
+				{ThreadID: issueID, Vector: []float64{1, 0}},
+				{ThreadID: prID, Vector: []float64{0, 1}},
+			}, clusterBuildOptions{
+				Threshold:          0.99,
+				MinSize:            2,
+				MaxClusterSize:     defaultClusterMaxSize,
+				Fanout:             16,
+				CrossKindThreshold: 0.99,
+			})
+			if err != nil {
+				t.Fatalf("build inputs: %v", err)
+			}
+			if edgeCount != tc.wantEdges || len(inputs) != tc.wantEdges {
+				t.Fatalf("edges=%d inputs=%#v, want %d evidence edges", edgeCount, inputs, tc.wantEdges)
+			}
+		})
+	}
+}
+
 func TestBuildDurableClusterInputsIgnoresBareOneDigitProseRefs(t *testing.T) {
 	ctx := context.Background()
 	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `gitcrawl cluster` see unrelated threads grouped as duplicate candidates when a thread body links to an issue or pull request in another repository. A dependency-update thread that quotes an upstream changelog — full of links like `https://redirect.github.com/fastify/fast-uri/pull/169` — gets clustered with whatever local thread happens to be numbered 169. The false pairs then show up in `clusters`, `clusters-report`, `cluster-detail`, and `neighbors`.

## Why This Change Was Made

Reference scoping was already the intended behavior for the `owner/repo#number` form — 0.4.0: "Ignore cross-repository `owner/repo#number` references when building deterministic cluster edges for the current repository." The URL form, however, was matched by number alone with no repository check, so a link to any repository resolved as a local reference. The URL form now carries the same `owner/repo` scoping, and the same `EqualFold` guard, as the qualified form.

Non-goals, so the boundary is visible:

- Reference *kind* is still not validated — `issues/N` and `pull/N` resolve the same thread, matching GitHub's own redirect behavior.
- A bare `#N` that is the *anchor text* of a cross-repository link still resolves locally. Dependabot's Commits section renders upstream commits that way, so this change reduces but does not eliminate false references from such bodies. Handling that needs link-context awareness, which felt like a separate call to make.

## User Impact

Clusters no longer contain duplicate-candidate links created by upstream changelog or release-note URLs. Same-repository references — URLs, `owner/repo#number`, and bare `#number` — resolve exactly as before.

One behavior change beyond the fix, flagged for a reviewer's eye: a repository-less path such as `See /issues/123` previously resolved to local #123 and no longer does. It is precisely the unscoped form that causes this bug, and a path with no repository context carries no evidence that it means *this* repository — but it is a real delta, not a pure bugfix. If you would rather keep it, the alternative is making the repo prefix optional and enforcing the check only when present.

## Evidence

New `TestBuildDurableClusterInputsScopesURLReferencesToRepository` covers six cases through the existing `buildDurableClusterInputs` seam, alongside its sibling `TestBuildDurableClusterInputsIgnoresCrossRepoQualifiedReferences`.

**Fails on `main` (b38e315)** — both cross-repo cases produce a bogus `duplicate_candidate` cluster:

```
--- FAIL: TestBuildDurableClusterInputsScopesURLReferencesToRepository/cross-repo_pull_URL
    app_test.go:7207: edges=1 inputs=[...ClusterType:"duplicate_candidate",
    Members:[{ThreadID:1, Role:"canonical"}, {ThreadID:2, Role:"related"}]...],
    want 0 evidence edges
--- FAIL: TestBuildDurableClusterInputsScopesURLReferencesToRepository/cross-repo_issues_URL
    app_test.go:7207: edges=1 ... want 0 evidence edges
```

**Passes with the fix**, and the four same-repo cases pass both ways (no regression):

```
--- PASS: TestBuildDurableClusterInputsScopesURLReferencesToRepository (0.07s)
    --- PASS: .../cross-repo_pull_URL
    --- PASS: .../cross-repo_issues_URL
    --- PASS: .../same-repo_issues_URL
    --- PASS: .../same-repo_pull_URL
    --- PASS: .../same-repo_qualified_ref
    --- PASS: .../same-repo_bare_ref
ok  github.com/openclaw/gitcrawl/internal/cli
```

**Observed on a real archive** (442 threads, 82 dependabot-authored), running the extractor before the fix:

- One dependabot body ("Bump fast-uri from 3.1.0 to 3.1.2") yields **17** references — `[148 149 150 151 152 153 154 156 159 161 162 164 165 166 167 169 171]` — every one an upstream `fastify/fast-uri` number, none referring to the local repository. With the fix: **4**.
- Repo-wide: **1049** references extracted from 75 dependabot bodies, **115** colliding with a real local thread number, **9** surviving into deterministic edges.
- A concrete pair: PR #124 ("Bump fast-uri from 3.1.0 to 3.1.2") gains an edge to issue #169 ("Automate workflow anti-stall promotion, downgrade, and hook/validator retirement candidates from mainstream-first policy"). Their actual cosine similarity in that archive is **0.5224**, well under the 0.80 threshold — the edge is entirely reference-driven.

Two details that made these hard to filter, in case they are useful context:

- The weak-evidence path falls through to the title-overlap gate, and the only shared token between those two titles is `from` — `1/min(4,15) = 0.25 ≥ 0.18`, so it passes.
- Deterministic reference edges are applied after the cosine and cross-kind checks, so a false edge lands at 0.94 without a similarity check, including for issue↔PR pairs.

**Checks:** `gofmt -l .` clean, `go vet ./...` clean, `go build ./...` OK, `deadcode -test ./...` clean, coverage 85.0% (unchanged from baseline), full `go test ./...` green across all 13 packages.
