### PR TITLE
fix(runtime): verify portable store worktrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.7.2 - Unreleased
 
 - Ignore cross-repository issue and pull request links when building deterministic cluster edges for the current repository, so an upstream link such as `https://github.com/other/repo/pull/169` no longer clusters the unrelated local thread numbered 169, while unqualified `issues/123` and `pull/123` references still resolve locally.
+- Ignore stray ancestor `.git` directories when resolving local databases while preserving verified legacy portable-store worktrees and fail-closed probe errors. Thanks @morluto.
 - Remove byte-identical legacy key-summary copies from portable exports after canonicalization, keeping archive snapshots below GitHub's blob limit without dropping distinct legacy evidence.
 - Reuse legacy `llm_key_3line` summaries as canonical key-summary evidence during schema migration so existing archives can embed, cluster, and publish without regenerating every summary first.
 - Require every Gitcrawl cloud publisher manifest to opt into snapshot staging so `--stage-only` and normal publish-then-cutover runs cannot activate serving state through the legacy compatibility path.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1993,7 +1993,7 @@ func (a *App) runTUI(ctx context.Context, args []string) error {
 		Repository:         repo.FullName,
 		InferredRepository: inferred,
 		Mode:               "cluster-browser",
-		DBSource:           databaseSourceKind(rt.SourceDBPath),
+		DBSource:           databaseSourceKind(ctx, rt.SourceDBPath),
 		DBLocation:         databaseSourceLocation(ctx, rt.SourceDBPath),
 		DBRefreshSource:    remoteRefreshSource(rt),
 		DBRuntimePath:      remoteRuntimePath(rt),
@@ -2048,7 +2048,7 @@ func emptyClusterBrowserPayload(ctx context.Context, cfg config.Config, sourceDB
 	}
 	return clusterBrowserPayload{
 		Mode:           "cluster-browser",
-		DBSource:       databaseSourceKind(sourceDBPath),
+		DBSource:       databaseSourceKind(ctx, sourceDBPath),
 		DBLocation:     databaseSourceLocation(ctx, sourceDBPath),
 		Sort:           sort,
 		Layout:         layout,
@@ -2062,8 +2062,8 @@ func emptyClusterBrowserPayload(ctx context.Context, cfg config.Config, sourceDB
 	}
 }
 
-func databaseSourceKind(dbPath string) string {
-	if _, ok := portableStoreRoot(dbPath); ok {
+func databaseSourceKind(ctx context.Context, dbPath string) string {
+	if _, ok, _ := portableStoreRoot(ctx, dbPath); ok {
 		return "remote"
 	}
 	return "local"
@@ -2085,7 +2085,7 @@ func remoteRuntimePath(rt localRuntime) string {
 
 func databaseSourceLocation(ctx context.Context, dbPath string) string {
 	filename := filepath.Base(dbPath)
-	root, ok := portableStoreRoot(dbPath)
+	root, ok, _ := portableStoreRoot(ctx, dbPath)
 	if !ok {
 		return filename
 	}
@@ -3400,28 +3400,38 @@ func runGit(ctx context.Context, workdir string, args ...string) error {
 }
 
 func runGitCommandOutput(ctx context.Context, workdir string, args ...string) (string, error) {
+	return runGitCommandOutputWithEnv(ctx, workdir, os.Environ(), args...)
+}
+
+func runGitCommandOutputWithEnv(ctx context.Context, workdir string, env []string, args ...string) (string, error) {
+	stdout, stderr, err := runGitCommandOutputWithEnvSeparate(ctx, workdir, env, args...)
+	return stdout + stderr, err
+}
+
+func runGitCommandOutputWithEnvSeparate(ctx context.Context, workdir string, env []string, args ...string) (string, string, error) {
 	if err := ctx.Err(); err != nil {
-		return "", err
+		return "", "", err
 	}
 	cmd := exec.Command("git", args...)
 	cmd.Dir = workdir
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(append([]string(nil), env...),
 		"GIT_TERMINAL_PROMPT=0",
 		"GIT_SSH_COMMAND=ssh -o BatchMode=yes -o ConnectTimeout=10",
 	)
 	configureCommandGroup(cmd)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 	if err := cmd.Start(); err != nil {
 		cleanupCommandGroup(cmd)
-		return out.String(), err
+		return stdout.String(), stderr.String(), err
 	}
 	if err := attachCommandGroup(cmd); err != nil {
 		killCommandGroup(cmd)
 		_ = cmd.Wait()
 		cleanupCommandGroup(cmd)
-		return out.String(), err
+		return stdout.String(), stderr.String(), err
 	}
 	done := make(chan error, 1)
 	go func() {
@@ -3430,7 +3440,7 @@ func runGitCommandOutput(ctx context.Context, workdir string, args ...string) (s
 	select {
 	case err := <-done:
 		cleanupCommandGroup(cmd)
-		return out.String(), err
+		return stdout.String(), stderr.String(), err
 	case <-ctx.Done():
 		killCommandGroup(cmd)
 		err := <-done
@@ -3438,7 +3448,7 @@ func runGitCommandOutput(ctx context.Context, workdir string, args ...string) (s
 		if err == nil {
 			err = ctx.Err()
 		}
-		return out.String(), fmt.Errorf("%w: %v", ctx.Err(), err)
+		return stdout.String(), stderr.String(), fmt.Errorf("%w: %v", ctx.Err(), err)
 	}
 }
 
@@ -3716,16 +3726,17 @@ func sqliteDBHealth(ctx context.Context, dbPath, manifestDBPath string) map[stri
 
 func portableStoreGitStatus(ctx context.Context, dbPath string) map[string]any {
 	result := map[string]any{}
-	root, ok := portableStoreRoot(dbPath)
+	root, ok, err := portableStoreRoot(ctx, dbPath)
+	if err != nil {
+		result["state"] = "error"
+		result["error"] = err.Error()
+		return result
+	}
 	if !ok {
 		result["state"] = "not_portable"
 		return result
 	}
 	result["root"] = root
-	if !portableStoreIsGitWorktree(ctx, root) {
-		result["state"] = "not_git"
-		return result
-	}
 	if gitWorktreeClean(ctx, root) {
 		result["state"] = "clean"
 	} else {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -2688,7 +2688,7 @@ func TestDefaultPortableStoreDir(t *testing.T) {
 
 func TestDatabaseSourceLocationLocal(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "gitcrawl.db")
-	if got := databaseSourceKind(dbPath); got != "local" {
+	if got := databaseSourceKind(context.Background(), dbPath); got != "local" {
 		t.Fatalf("source kind = %q, want local", got)
 	}
 	if got := databaseSourceLocation(context.Background(), dbPath); got != "gitcrawl.db" {
@@ -2711,7 +2711,7 @@ func TestDatabaseSourceLocationRemoteGitHubStore(t *testing.T) {
 		t.Fatalf("git remote add: %v", err)
 	}
 
-	if got := databaseSourceKind(dbPath); got != "remote" {
+	if got := databaseSourceKind(ctx, dbPath); got != "remote" {
 		t.Fatalf("source kind = %q, want remote", got)
 	}
 	want := "openclaw/gitcrawl-store:openclaw__openclaw.sync.db"
@@ -3094,7 +3094,7 @@ func TestReadCommandRefreshesPortableStore(t *testing.T) {
 	if !gitWorktreeClean(ctx, checkoutDir) {
 		t.Fatal("portable checkout should stay clean after read-only command")
 	}
-	mirrorPath, err := run.portableRuntimeDBPath(filepath.Join(checkoutDir, dbRel))
+	mirrorPath, err := run.portableRuntimeDBPath(ctx, filepath.Join(checkoutDir, dbRel))
 	if err != nil {
 		t.Fatalf("runtime db path: %v", err)
 	}
@@ -3205,7 +3205,7 @@ func TestReadCommandRepairsMalformedDirtyPortableStore(t *testing.T) {
 	}
 	run := New()
 	run.configPath = configPath
-	mirrorPath, err := run.portableRuntimeDBPath(checkoutDB)
+	mirrorPath, err := run.portableRuntimeDBPath(ctx, checkoutDB)
 	if err != nil {
 		t.Fatalf("runtime db path: %v", err)
 	}
@@ -3331,7 +3331,7 @@ func TestPortableRuntimePropagatesNonCorruptionSourceErrors(t *testing.T) {
 	checkoutDB := filepath.Join(checkoutDir, dbRel)
 	run := New()
 	run.configPath = filepath.Join(dir, "config.toml")
-	mirrorPath, err := run.portableRuntimeDBPath(checkoutDB)
+	mirrorPath, err := run.portableRuntimeDBPath(ctx, checkoutDB)
 	if err != nil {
 		t.Fatalf("runtime db path: %v", err)
 	}
@@ -3473,6 +3473,53 @@ func TestPortableRuntimeRejectsManifestMismatchBeforeReplacingMirror(t *testing.
 	err = validatePortableSQLiteFile(ctx, checkoutDB, checkoutDB)
 	if err == nil || !isPortableSourceRepairableHealthError(err) {
 		t.Fatalf("malformed manifest should be a repairable health error, got %v", err)
+	}
+}
+
+func TestSyncCreatesLocalDatabaseBelowUnrelatedGitMetadata(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dataRoot := filepath.Join(dir, "data-root")
+	if err := os.MkdirAll(filepath.Join(dataRoot, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir unrelated git metadata: %v", err)
+	}
+
+	dbPath := filepath.Join(dataRoot, "gitcrawl", "gitcrawl.db")
+	configPath := filepath.Join(dir, "config.toml")
+	app := New()
+	if err := app.Run(ctx, []string{"--config", configPath, "init", "--db", dbPath}); err != nil {
+		t.Fatalf("init config: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/openclaw/openclaw":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 12345, "full_name": "openclaw/openclaw"})
+		case "/repos/openclaw/openclaw/issues/101":
+			_ = json.NewEncoder(w).Encode(githubIssueJSON(101, "issue", "Git metadata regression"))
+		default:
+			t.Fatalf("unexpected GitHub path: %s", r.URL.String())
+		}
+	}))
+	defer server.Close()
+	t.Setenv("GITHUB_TOKEN", "test-gh-token")
+	t.Setenv("GITCRAWL_GITHUB_BASE_URL", server.URL)
+
+	if err := New().Run(ctx, []string{"--config", configPath, "sync", "openclaw/openclaw", "--numbers", "101", "--json"}); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	st, err := store.OpenReadOnly(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open local database: %v", err)
+	}
+	defer st.Close()
+	status, err := st.Status(ctx)
+	if err != nil {
+		t.Fatalf("local database status: %v", err)
+	}
+	if status.ThreadCount != 1 {
+		t.Fatalf("local database thread count = %d, want 1", status.ThreadCount)
 	}
 }
 

--- a/internal/cli/lock_diagnostics_test.go
+++ b/internal/cli/lock_diagnostics_test.go
@@ -90,7 +90,7 @@ func TestDoctorLocksUsesPortableRuntimeDB(t *testing.T) {
 	}
 	expected := New()
 	expected.configPath = configPath
-	expectedRuntimeDB, err := expected.portableRuntimeDBPath(sourceDB)
+	expectedRuntimeDB, err := expected.portableRuntimeDBPath(ctx, sourceDB)
 	if err != nil {
 		t.Fatalf("runtime db path: %v", err)
 	}

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -44,7 +44,9 @@ func (a *App) openLocalRuntime(ctx context.Context) (localRuntime, error) {
 	}
 	sourceDBPath := cfg.DBPath
 	remoteSource := false
-	if _, ok := portableStoreRoot(cfg.DBPath); ok {
+	if _, ok, err := portableStoreRoot(ctx, cfg.DBPath); err != nil {
+		return localRuntime{}, err
+	} else if ok {
 		mirrorPath, _, err := a.ensurePortableRuntimeDB(ctx, cfg.DBPath, false)
 		if err != nil {
 			return localRuntime{}, err
@@ -73,7 +75,9 @@ func (a *App) openLocalRuntimeReadOnlyWithConfig(ctx context.Context, cfg config
 	}
 	sourceDBPath := cfg.DBPath
 	remoteSource := false
-	if _, ok := portableStoreRoot(cfg.DBPath); ok {
+	if _, ok, err := portableStoreRoot(ctx, cfg.DBPath); err != nil {
+		return localRuntime{}, err
+	} else if ok {
 		mirrorPath, _, err := a.ensurePortableRuntimeDB(ctx, cfg.DBPath, true)
 		if err != nil {
 			return localRuntime{}, err
@@ -104,11 +108,11 @@ func (rt localRuntime) defaultRepository(ctx context.Context) (store.Repository,
 }
 
 func refreshPortableStoreForDB(ctx context.Context, dbPath string) error {
-	root, ok := portableStoreRoot(dbPath)
-	if !ok {
-		return nil
+	root, ok, err := portableStoreRoot(ctx, dbPath)
+	if err != nil {
+		return err
 	}
-	if !portableStoreIsGitWorktree(ctx, root) {
+	if !ok {
 		return nil
 	}
 	if !gitWorktreeClean(ctx, root) {
@@ -131,11 +135,11 @@ type portableRepairResult struct {
 
 func repairMalformedPortableStoreForDB(ctx context.Context, dbPath, configPath string) (portableRepairResult, error) {
 	result := portableRepairResult{Action: "reset-pulled"}
-	root, ok := portableStoreRoot(dbPath)
-	if !ok {
-		return result, nil
+	root, ok, err := portableStoreRoot(ctx, dbPath)
+	if err != nil {
+		return result, err
 	}
-	if !portableStoreIsGitWorktree(ctx, root) {
+	if !ok {
 		return result, nil
 	}
 	if !portableStoreRepairAllowed(root, configPath) {
@@ -165,11 +169,11 @@ func repairMalformedPortableStoreForDB(ctx context.Context, dbPath, configPath s
 
 func recloneMalformedPortableStoreForDB(ctx context.Context, dbPath, configPath string) (portableRepairResult, error) {
 	result := portableRepairResult{Action: "recloned"}
-	root, ok := portableStoreRoot(dbPath)
-	if !ok {
-		return result, nil
+	root, ok, err := portableStoreRoot(ctx, dbPath)
+	if err != nil {
+		return result, err
 	}
-	if !portableStoreIsGitWorktree(ctx, root) {
+	if !ok {
 		return result, nil
 	}
 	if !portableStoreRepairAllowed(root, configPath) {
@@ -210,7 +214,7 @@ func recloneMalformedPortableStoreForDB(ctx context.Context, dbPath, configPath 
 var portableRuntimeMu sync.Mutex
 
 func (a *App) ensurePortableRuntimeDB(ctx context.Context, sourceDBPath string, refresh bool) (string, bool, error) {
-	mirrorPath, err := a.portableRuntimeDBPath(sourceDBPath)
+	mirrorPath, err := a.portableRuntimeDBPath(ctx, sourceDBPath)
 	if err != nil {
 		return "", false, err
 	}
@@ -218,8 +222,11 @@ func (a *App) ensurePortableRuntimeDB(ctx context.Context, sourceDBPath string, 
 	return mirrorPath, changed, err
 }
 
-func (a *App) portableRuntimeDBPath(sourceDBPath string) (string, error) {
-	root, ok := portableStoreRoot(sourceDBPath)
+func (a *App) portableRuntimeDBPath(ctx context.Context, sourceDBPath string) (string, error) {
+	root, ok, err := portableStoreRoot(ctx, sourceDBPath)
+	if err != nil {
+		return "", err
+	}
 	if !ok {
 		return "", fmt.Errorf("portable store root not found for %s", sourceDBPath)
 	}
@@ -237,8 +244,11 @@ func (a *App) portableRuntimeDBPath(sourceDBPath string) (string, error) {
 func refreshPortableRuntimeDB(ctx context.Context, sourceDBPath, mirrorPath string, refresh bool, configPath string) (bool, error) {
 	portableRuntimeMu.Lock()
 	defer portableRuntimeMu.Unlock()
-	portableRoot, isPortableSource := portableStoreRoot(sourceDBPath)
-	isRepairablePortableSource := isPortableSource && portableStoreIsGitWorktree(ctx, portableRoot)
+	_, isPortableSource, err := portableStoreRoot(ctx, sourceDBPath)
+	if err != nil {
+		return false, err
+	}
+	isRepairablePortableSource := isPortableSource
 	if refresh {
 		_ = refreshPortableStoreForDBIfDue(ctx, sourceDBPath, mirrorPath)
 	}
@@ -768,23 +778,111 @@ func copySQLiteFileAtomicVerified(ctx context.Context, sourcePath, targetPath st
 	return nil
 }
 
-func portableStoreRoot(dbPath string) (string, bool) {
+func portableStoreRoot(ctx context.Context, dbPath string) (string, bool, error) {
 	dir := filepath.Clean(filepath.Dir(dbPath))
 	for {
-		if info, err := os.Stat(filepath.Join(dir, ".git")); err == nil && info.IsDir() {
-			return dir, true
+		info, statErr := os.Stat(filepath.Join(dir, ".git"))
+		if statErr == nil && info.IsDir() {
+			isWorktree, err := probePortableStoreGitWorktree(ctx, dir)
+			if err != nil {
+				return "", false, fmt.Errorf("verify portable store candidate %s: %w", dir, err)
+			}
+			if isWorktree {
+				return dir, true, nil
+			}
+		} else if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+			return "", false, fmt.Errorf("inspect portable store candidate %s: %w", dir, statErr)
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return "", false
+			return "", false, nil
 		}
 		dir = parent
 	}
 }
 
-func portableStoreIsGitWorktree(ctx context.Context, dir string) bool {
-	out, err := gitOutput(ctx, "", "-C", dir, "rev-parse", "--is-inside-work-tree")
-	return err == nil && strings.TrimSpace(out) == "true"
+func probePortableStoreGitWorktree(ctx context.Context, dir string) (bool, error) {
+	initialized, err := gitMetadataLooksInitialized(filepath.Join(dir, ".git"))
+	if err != nil {
+		return false, err
+	}
+	if !initialized {
+		return false, nil
+	}
+
+	topLevel, stderr, err := runGitCommandOutputWithEnvSeparate(ctx, "", portableStoreGitProbeEnv(), "-C", dir, "rev-parse", "--show-toplevel")
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return false, ctxErr
+		}
+		return false, fmt.Errorf("resolve portable store worktree: %w\n%s", err, strings.TrimSpace(stderr))
+	}
+	if !sameExistingPath(strings.TrimSpace(topLevel), dir) {
+		return false, fmt.Errorf("Git resolved portable store candidate %s to worktree %s", dir, strings.TrimSpace(topLevel))
+	}
+
+	gitDir, stderr, err := runGitCommandOutputWithEnvSeparate(ctx, "", portableStoreGitProbeEnv(), "-C", dir, "rev-parse", "--absolute-git-dir")
+	if err != nil {
+		return false, fmt.Errorf("resolve portable store Git directory: %w\n%s", err, strings.TrimSpace(stderr))
+	}
+	if !sameExistingPath(strings.TrimSpace(gitDir), filepath.Join(dir, ".git")) {
+		return false, fmt.Errorf("Git resolved portable store candidate %s to Git directory %s", dir, strings.TrimSpace(gitDir))
+	}
+	return true, nil
+}
+
+func gitMetadataLooksInitialized(gitDir string) (bool, error) {
+	for _, name := range []string{"HEAD", "config", "objects", "refs"} {
+		_, err := os.Lstat(filepath.Join(gitDir, name))
+		switch {
+		case err == nil:
+			return true, nil
+		case errors.Is(err, os.ErrNotExist):
+			continue
+		default:
+			return false, fmt.Errorf("inspect Git metadata %s: %w", gitDir, err)
+		}
+	}
+	return false, nil
+}
+
+func sameExistingPath(left, right string) bool {
+	leftInfo, err := os.Stat(left)
+	if err != nil {
+		return false
+	}
+	rightInfo, err := os.Stat(right)
+	return err == nil && os.SameFile(leftInfo, rightInfo)
+}
+
+func portableStoreGitProbeEnv() []string {
+	repositoryEnv := map[string]struct{}{
+		"GIT_ALTERNATE_OBJECT_DIRECTORIES": {},
+		"GIT_CEILING_DIRECTORIES":          {},
+		"GIT_COMMON_DIR":                   {},
+		"GIT_DIR":                          {},
+		"GIT_DISCOVERY_ACROSS_FILESYSTEM":  {},
+		"GIT_GRAFT_FILE":                   {},
+		"GIT_INDEX_FILE":                   {},
+		"GIT_NAMESPACE":                    {},
+		"GIT_OBJECT_DIRECTORY":             {},
+		"GIT_PREFIX":                       {},
+		"GIT_QUARANTINE_PATH":              {},
+		"GIT_SHALLOW_FILE":                 {},
+		"GIT_WORK_TREE":                    {},
+	}
+	env := make([]string, 0, len(os.Environ()))
+	for _, entry := range os.Environ() {
+		name, _, _ := strings.Cut(entry, "=")
+		upperName := strings.ToUpper(name)
+		_, excluded := repositoryEnv[upperName]
+		if excluded || upperName == "GIT_CONFIG_COUNT" || upperName == "GIT_CONFIG_PARAMETERS" ||
+			strings.HasPrefix(upperName, "GIT_CONFIG_KEY_") || strings.HasPrefix(upperName, "GIT_CONFIG_VALUE_") {
+			continue
+		}
+		env = append(env, entry)
+	}
+	return env
 }
 
 func portableStoreRemoteURL(ctx context.Context, root string) string {

--- a/internal/cli/runtime_extra_test.go
+++ b/internal/cli/runtime_extra_test.go
@@ -2,11 +2,104 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 )
+
+func TestPortableStoreRootPropagatesGitProbeFailure(t *testing.T) {
+	dir := t.TempDir()
+	if err := runGit(context.Background(), "", "init", dir); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, err := portableStoreRoot(ctx, filepath.Join(dir, "gitcrawl.db"))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("portable store root error = %v, want context canceled", err)
+	}
+}
+
+func TestPortableStoreRootBindsCandidateToOwningWorktree(t *testing.T) {
+	ctx := context.Background()
+	outer := t.TempDir()
+	if err := runGit(ctx, "", "init", outer); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	nested := filepath.Join(outer, "data")
+	if err := os.MkdirAll(filepath.Join(nested, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir stray Git metadata: %v", err)
+	}
+
+	root, ok, err := portableStoreRoot(ctx, filepath.Join(nested, "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("portable store root: %v", err)
+	}
+	if !ok || !sameExistingPath(root, outer) {
+		t.Fatalf("portable store root = %q, ok=%v, want outer worktree %q", root, ok, outer)
+	}
+}
+
+func TestPortableStoreRootIgnoresInheritedGitSelection(t *testing.T) {
+	ctx := context.Background()
+	portable := t.TempDir()
+	if err := runGit(ctx, "", "init", portable); err != nil {
+		t.Fatalf("git init portable: %v", err)
+	}
+	other := t.TempDir()
+	if err := runGit(ctx, "", "init", other); err != nil {
+		t.Fatalf("git init other: %v", err)
+	}
+	t.Setenv("GIT_DIR", filepath.Join(other, ".git"))
+	t.Setenv("GIT_WORK_TREE", other)
+
+	root, ok, err := portableStoreRoot(ctx, filepath.Join(portable, "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("portable store root: %v", err)
+	}
+	if !ok || !sameExistingPath(root, portable) {
+		t.Fatalf("portable store root = %q, ok=%v, want %q", root, ok, portable)
+	}
+}
+
+func TestPortableStoreRootIgnoresGitTraceOutput(t *testing.T) {
+	ctx := context.Background()
+	portable := t.TempDir()
+	if err := runGit(ctx, "", "init", portable); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	t.Setenv("GIT_TRACE", "1")
+
+	root, ok, err := portableStoreRoot(ctx, filepath.Join(portable, "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("portable store root: %v", err)
+	}
+	if !ok || !sameExistingPath(root, portable) {
+		t.Fatalf("portable store root = %q, ok=%v, want %q", root, ok, portable)
+	}
+}
+
+func TestPortableStoreRootIgnoresCommandScopeGitConfig(t *testing.T) {
+	ctx := context.Background()
+	portable := t.TempDir()
+	if err := runGit(ctx, "", "init", portable); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	t.Setenv("GIT_CONFIG_COUNT", "1")
+	t.Setenv("GIT_CONFIG_KEY_0", "core.bare")
+	t.Setenv("GIT_CONFIG_VALUE_0", "true")
+
+	root, ok, err := portableStoreRoot(ctx, filepath.Join(portable, "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("portable store root: %v", err)
+	}
+	if !ok || !sameExistingPath(root, portable) {
+		t.Fatalf("portable store root = %q, ok=%v, want %q", root, ok, portable)
+	}
+}
 
 func TestPortableRuntimeUtilityBranches(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/cli/runtime_git_probe_test.go
+++ b/internal/cli/runtime_git_probe_test.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPortableStoreRootDoesNotRequireGitForUninitializedMetadata(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+
+	candidate := filepath.Join(dir, "data")
+	if err := os.MkdirAll(filepath.Join(candidate, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir stray Git metadata: %v", err)
+	}
+	root, ok, err := portableStoreRoot(context.Background(), filepath.Join(candidate, "gitcrawl.db"))
+	if err != nil {
+		t.Fatalf("portable store root: %v", err)
+	}
+	if ok || root != "" {
+		t.Fatalf("portable store root = %q, ok=%v, want local database", root, ok)
+	}
+}


### PR DESCRIPTION
Supersedes #105 with its contributor credit preserved in the commit trailer and changelog.

## What changed

- Verify that each ancestor `.git` directory owns the exact worktree Git resolved before classifying a database as portable.
- Ignore uninitialized stray metadata without requiring Git to be installed.
- Fail closed for initialized metadata when Git is missing, canceled, unsafe, corrupt, or resolves a mismatched worktree/Git directory.
- Isolate repository-selection and command-scope configuration environment variables during the ownership probe.
- Keep Git trace diagnostics on stderr so they cannot contaminate resolved paths.

## Proof

Current `main` reproduced the reported failure:

```text
stat portable source db: stat <proof-root>/main/data-root/nested/gitcrawl.db: no such file or directory
main_exit=1
```

The replacement branch used a freshly built binary and an isolated archive beneath an empty ancestor `.git` directory. It synced public PR #105 from GitHub and reported:

```json
{
  "repository": "openclaw/gitcrawl",
  "threads_synced": 1,
  "pull_requests_synced": 1,
  "numbers": [105]
}
```

Post-run status was `current`, with `1 threads across 1 repositories`, at the configured nested database path.

Validation:

```text
GOWORK=off go test ./...            PASS
GOWORK=off go vet ./...             PASS
./scripts/test-release.sh           PASS
.agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
```

Focused regressions cover stray metadata, nested candidates inside an enclosing worktree, inherited `GIT_DIR`/`GIT_WORK_TREE`, `GIT_TRACE`, command-scope Git config, missing Git for uninitialized metadata, cancellation, and existing portable runtime behavior.
