### PR TITLE
build(deps): use stable lipgloss release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/kong v1.16.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
-	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
+	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/mattn/go-isatty v0.0.23
 	github.com/openclaw/crawlkit v0.14.2

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlv
 github.com/charmbracelet/bubbletea v1.3.10/go.mod h1:ORQfo0fk8U+po9VaNvnV95UPWA1BitP1E0N6xJPlHr4=
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
-github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 h1:ZR7e0ro+SZZiIZD7msJyA+NjkCNNavuiPBLgerbOziE=
-github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834/go.mod h1:aKC/t2arECF6rNOnaKaVU6y4t4ZeHQzqfxedE/VkVhA=
+github.com/charmbracelet/lipgloss v1.1.0 h1:vYXsiLHVkK7fp74RkV7b2kq9+zDLoEU4MZoFqR/noCY=
+github.com/charmbracelet/lipgloss v1.1.0/go.mod h1:/6Q8FR2o+kj8rz4Dq0zQc3vYf7X+B0binUUBwA0aL30=
 github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dAYC84jI=
 github.com/charmbracelet/x/ansi v0.11.7/go.mod h1:9qGpnAVYz+8ACONkZBUWPtL7lulP9No6p1epAihUZwQ=
 github.com/charmbracelet/x/cellbuf v0.0.15 h1:ur3pZy0o6z/R7EylET877CBxaiE1Sp1GMxoFPAIztPI=


### PR DESCRIPTION
## Summary

- replace the unreleased Lip Gloss v1.1.1 pseudo-version with the latest stable v1 release, v1.1.0
- confirm CrawlKit v0.14.2 and every other same-major direct dependency are already current

## Proof

- go mod tidy is stable
- gofmt clean
- go vet ./... passed
- govulncheck v1.4.0 reported no vulnerabilities
- deadcode v0.45.0 reported no unreachable production/test code
- make test-coverage passed at 85.1%
- real binary build, version, metadata, status, and TUI help smokes passed
- scripted PTY launched the real TUI, rendered openclaw/gitcrawl with cluster/member/detail panes, reached Ready, and exited cleanly with q
- scripts/test-release.sh passed
- AutoReview clean

## Deferred major migration

The stable Charm v2 modules were evaluated at Bubble Tea v2.0.8, Bubbles v2.1.1, and Lip Gloss v2.0.5. Their canonical charm.land module paths compile only after a broad TUI migration: declarative tea.View, new keyboard and mouse messages, viewport getter/setter APIs, color types, and extensive test fixtures. The attempted import migration produced more than 100 compiler failures. That product-facing TUI rewrite is intentionally deferred from the 0.8.0 release freeze.
