### PR TITLE
build(deps): refresh 0.8.1 dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,12 @@ jobs:
         run: go vet ./...
 
       - name: Vulnerability scan
-        run: GOWORK=off go run golang.org/x/vuln/cmd/govulncheck@v1.4.0 ./...
+        run: GOWORK=off go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
 
       - name: Deadcode
         run: |
           output_file=$(mktemp)
-          go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./... > "$output_file"
+          go run golang.org/x/tools/cmd/deadcode@v0.48.0 -test ./... > "$output_file"
           if [ -s "$output_file" ]; then
             cat "$output_file"
             exit 1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Require every official macOS release binary to pass hardened-runtime signing, Apple notarization, and independent Foundation and notarized-requirement verification before packaging.
 - Route embedding and semantic-search requests through a configurable embedding-only OpenAI-compatible endpoint while preserving the shared endpoint fallback. Thanks @larroy.
+- Update CrawlKit to v0.14.3, Alpine to 3.24, `actions/setup-node` to v7, govulncheck to v1.6.0, and deadcode to v0.48.0.
 
 ## 0.8.0 - 2026-07-17
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 ARG GO_VERSION=1.26.5
-ARG ALPINE_VERSION=3.23
+ARG ALPINE_VERSION=3.24
 
 FROM golang:${GO_VERSION}-alpine AS build
 RUN apk add --no-cache ca-certificates git

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/mattn/go-isatty v0.0.23
-	github.com/openclaw/crawlkit v0.14.2
+	github.com/openclaw/crawlkit v0.14.3
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/sys v0.47.0
 	modernc.org/sqlite v1.54.0

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.14.2 h1:NA0+fDlyYnQjrI6krkhajHDKMTOt9q8JTlMFsGH37pg=
-github.com/openclaw/crawlkit v0.14.2/go.mod h1:u5oK8v0gtLzIXtj6gehF0JV2cGX1D/xiogZGCJwONGs=
+github.com/openclaw/crawlkit v0.14.3 h1:HFb28kbb95A9dBqyN6vM5KXSd/8gpJxIFb55SpD299o=
+github.com/openclaw/crawlkit v0.14.3/go.mod h1:BWZCEIQH3C8q7nn4iZTLI2xUgX+XitkZCjaA19D+Hh4=
 github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
 github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## Summary

- update CrawlKit first from v0.14.2 to its latest stable release, v0.14.3
- update the remaining stale direct tooling pins: Alpine 3.24, `actions/setup-node` v7, govulncheck v1.6.0, and deadcode/x-tools v0.48.0
- retain current pins already at latest stable: all other direct Go modules, Go 1.26.5, sqlc v1.31.1, GitHub Actions, GoReleaser Action v7.2.3, and TruffleHog v3.95.9

## Proof

- `go test ./...` immediately after the CrawlKit update: pass
- `go mod tidy`; clean `go.mod`/`go.sum` diff; `gofmt`; `go vet ./...`: pass
- `GOWORK=off go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...`: no vulnerabilities
- `go run golang.org/x/tools/cmd/deadcode@v0.48.0 -test ./...`: clean
- `go test ./... -covermode=atomic`: pass, 85.1% total coverage
- real CLI build plus version, metadata, status, and TUI-help smoke: pass
- `./scripts/test-release.sh`: pass
- credential-free GoReleaser snapshot: pass for all six targets
- `node scripts/build-docs-site.mjs`: pass
- Alpine 3.24 Docker build plus CLI and bundled-Git smoke: pass
- AutoReview on each pre-commit diff and the final branch: clean

No dependency was deferred.
