### PR TITLE
fix: keep portable doctor checks read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Treat portable runtime mirrors without pruned sync history as stale so `search issues|prs --sync-if-stale` can migrate and refresh them instead of failing on a missing `sync_runs` table.
 
+### Portable diagnostics
+
+- Keep `doctor --json` read-only for Git-backed portable stores by inspecting committed source databases as immutable SQLite files without leaving `-wal` or `-shm` sidecars in the checkout.
+
 ### Dependencies and maintenance
 
 - Update the current golden-test helpers, `golang.org/x/exp`, and `modernc.org/libc` patch release.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -3812,8 +3812,15 @@ func (a *App) runDoctor(ctx context.Context, args []string) error {
 		return err
 	}
 	storeStatus := store.Status{DBPath: cfg.DBPath}
-	sourceHealth := sqliteDBHealth(ctx, cfg.DBPath, cfg.DBPath)
+	_, portableSource, portableProbeErr := portableStoreRoot(ctx, cfg.DBPath)
+	if portableProbeErr != nil {
+		return portableProbeErr
+	}
+	sourceHealth := sqliteDBHealth(ctx, cfg.DBPath, cfg.DBPath, portableSource)
 	sourceSchema := store.InspectSchema(ctx, cfg.DBPath)
+	if portableSource {
+		sourceSchema = store.InspectPortableSourceSchema(ctx, cfg.DBPath)
+	}
 	dbSchema := sourceSchema
 	runtimeHealth := map[string]any{}
 	var runtimeSchema store.SchemaDiagnostics
@@ -3837,12 +3844,10 @@ func (a *App) runDoctor(ctx context.Context, args []string) error {
 	} else {
 		defer rt.Store.Close()
 		lockDBPath = rt.Config.DBPath
-		sourceHealth = sqliteDBHealth(ctx, rt.SourceDBPath, rt.SourceDBPath)
-		sourceSchema = store.InspectSchema(ctx, rt.SourceDBPath)
-		dbSchema = sourceSchema
+		sourceHealth = sqliteDBHealth(ctx, rt.SourceDBPath, rt.SourceDBPath, rt.RemoteSource)
 		if rt.RemoteSource {
 			sourceSchema = store.InspectPortableSourceSchema(ctx, rt.SourceDBPath)
-			runtimeHealth = sqliteDBHealth(ctx, rt.Config.DBPath, "")
+			runtimeHealth = sqliteDBHealth(ctx, rt.Config.DBPath, "", false)
 			runtimeSchema = store.InspectSchema(ctx, rt.Config.DBPath)
 			runtimeSchemaAvailable = true
 			dbSchema = runtimeSchema
@@ -3853,6 +3858,9 @@ func (a *App) runDoctor(ctx context.Context, args []string) error {
 			if repairAction == "" {
 				repairAction = "none"
 			}
+		} else {
+			sourceSchema = store.InspectSchema(ctx, rt.SourceDBPath)
+			dbSchema = sourceSchema
 		}
 		storeStatus, err = rt.Store.Status(ctx)
 		if err != nil {
@@ -4001,7 +4009,7 @@ func (a *App) runRemoteDoctor(ctx context.Context, cfg config.Config, configExis
 	return a.writeOutput("doctor", payload, true)
 }
 
-func sqliteDBHealth(ctx context.Context, dbPath, manifestDBPath string) map[string]any {
+func sqliteDBHealth(ctx context.Context, dbPath, manifestDBPath string, immutable bool) map[string]any {
 	result := map[string]any{
 		"path":   dbPath,
 		"exists": false,
@@ -4048,7 +4056,11 @@ func sqliteDBHealth(ctx context.Context, dbPath, manifestDBPath string) map[stri
 	} else {
 		result["manifest"] = "missing"
 	}
-	if err := validatePortableSQLiteFile(ctx, dbPath, manifestDBPath); err != nil {
+	validate := validatePortableSQLiteFile
+	if immutable {
+		validate = validatePortableSQLiteSourceFile
+	}
+	if err := validate(ctx, dbPath, manifestDBPath); err != nil {
 		result["health"] = "error"
 		result["error"] = err.Error()
 	} else {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -3681,6 +3681,93 @@ func TestWritableRuntimeUsesPortableMirror(t *testing.T) {
 	}
 }
 
+func TestDoctorLeavesCanonicalPortableStoreClean(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	remoteDir := filepath.Join(dir, "remote")
+	checkoutDir := filepath.Join(dir, "checkout")
+	dbRel := filepath.Join("data", "openclaw__openclaw.sync.db")
+	remoteDB := filepath.Join(remoteDir, dbRel)
+	if err := os.MkdirAll(filepath.Dir(remoteDB), 0o755); err != nil {
+		t.Fatalf("mkdir remote data: %v", err)
+	}
+	if err := runGit(ctx, remoteDir, "init", "-b", "main"); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	seedPortableThread(t, remoteDB, 1, "portable issue")
+	prunePortableTestStore(t, remoteDB)
+	if err := runGit(ctx, remoteDir, "add", dbRel, portableDBManifestPath(remoteDB)); err != nil {
+		t.Fatalf("git add seed: %v", err)
+	}
+	if err := runGit(ctx, remoteDir, "-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-m", "seed store"); err != nil {
+		t.Fatalf("git commit seed: %v", err)
+	}
+	if _, err := syncPortableStore(ctx, remoteDir, checkoutDir); err != nil {
+		t.Fatalf("clone portable store: %v", err)
+	}
+
+	checkoutDB := filepath.Join(checkoutDir, dbRel)
+	configPath := filepath.Join(dir, "config.toml")
+	if err := New().Run(ctx, []string{"--config", configPath, "init", "--db", checkoutDB}); err != nil {
+		t.Fatalf("init config: %v", err)
+	}
+	if !gitWorktreeClean(ctx, checkoutDir) {
+		t.Fatal("portable checkout should start clean")
+	}
+
+	payload := runDoctorJSON(t, ctx, configPath)
+	if got := doctorMap(t, payload, "source_db_schema")["state"]; got != "current" {
+		t.Fatalf("source_db_schema.state = %#v, payload=%#v", got, payload)
+	}
+	if !gitWorktreeClean(ctx, checkoutDir) {
+		t.Fatal("doctor should leave the portable checkout clean")
+	}
+	for _, suffix := range []string{"-wal", "-shm"} {
+		if _, err := os.Stat(checkoutDB + suffix); !os.IsNotExist(err) {
+			t.Fatalf("doctor left portable SQLite sidecar %s: %v", suffix, err)
+		}
+	}
+}
+
+func TestDoctorPortableProbeFailureDoesNotCreateSidecars(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "data", "gitcrawl.db")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatalf("mkdir data: %v", err)
+	}
+	st, err := store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	for _, suffix := range []string{"-wal", "-shm"} {
+		if err := os.Remove(dbPath + suffix); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("remove setup sidecar %s: %v", suffix, err)
+		}
+	}
+	gitDir := filepath.Join(dir, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatalf("mkdir malformed git metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatalf("write malformed git head: %v", err)
+	}
+	configPath := writeDoctorTestConfig(t, dir, dbPath)
+
+	err = New().Run(ctx, []string{"--config", configPath, "doctor", "--json"})
+	if err == nil || !strings.Contains(err.Error(), "verify portable store candidate") {
+		t.Fatalf("doctor error = %v, want portable probe failure", err)
+	}
+	for _, suffix := range []string{"-wal", "-shm"} {
+		if _, err := os.Stat(dbPath + suffix); !os.IsNotExist(err) {
+			t.Fatalf("doctor probe failure left SQLite sidecar %s: %v", suffix, err)
+		}
+	}
+}
+
 func TestDoctorRefreshesPortableStore(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -272,7 +272,7 @@ func refreshPortableRuntimeDB(ctx context.Context, sourceDBPath, mirrorPath stri
 		}
 	}
 	if needsCopy && isRepairablePortableSource {
-		sourceHealthErr := validatePortableSQLiteFile(ctx, sourceDBPath, sourceDBPath)
+		sourceHealthErr := validatePortableSQLiteSourceFile(ctx, sourceDBPath, sourceDBPath)
 		if sourceHealthErr != nil && isPortableSourceRepairableHealthError(sourceHealthErr) {
 			repair, err := repairMalformedPortableStoreForDB(ctx, sourceDBPath, configPath)
 			recordPortableRepairState(statePath, repair, err)
@@ -284,14 +284,14 @@ func refreshPortableRuntimeDB(ctx context.Context, sourceDBPath, mirrorPath stri
 				}
 				return false, fmt.Errorf("repair malformed portable store db: %w", err)
 			}
-			sourceHealthErr = validatePortableSQLiteFile(ctx, sourceDBPath, sourceDBPath)
+			sourceHealthErr = validatePortableSQLiteSourceFile(ctx, sourceDBPath, sourceDBPath)
 			if sourceHealthErr != nil && isPortableSourceRepairableHealthError(sourceHealthErr) {
 				reclone, err := recloneMalformedPortableStoreForDB(ctx, sourceDBPath, configPath)
 				recordPortableRepairState(statePath, reclone, err)
 				if err != nil {
 					return false, fmt.Errorf("reclone malformed portable store db: %w", err)
 				}
-				sourceHealthErr = validatePortableSQLiteFile(ctx, sourceDBPath, sourceDBPath)
+				sourceHealthErr = validatePortableSQLiteSourceFile(ctx, sourceDBPath, sourceDBPath)
 			}
 		}
 		if sourceHealthErr != nil {
@@ -558,7 +558,15 @@ func portableDBManifestStamp(dbPath string) (string, int64, string, error) {
 }
 
 func sqliteStoreHealth(ctx context.Context, path string) error {
-	st, err := store.OpenReadOnly(ctx, path)
+	return sqliteStoreHealthWithOpen(ctx, path, store.OpenReadOnly)
+}
+
+func sqliteStoreImmutableHealth(ctx context.Context, path string) error {
+	return sqliteStoreHealthWithOpen(ctx, path, store.OpenReadOnlyImmutable)
+}
+
+func sqliteStoreHealthWithOpen(ctx context.Context, path string, open func(context.Context, string) (*store.Store, error)) error {
+	st, err := open(ctx, path)
 	if err != nil {
 		return err
 	}
@@ -602,6 +610,13 @@ func portableDBManifestPath(dbPath string) string {
 
 func validatePortableSQLiteFile(ctx context.Context, dbPath, manifestDBPath string) error {
 	if err := sqliteStoreHealth(ctx, dbPath); err != nil {
+		return err
+	}
+	return validatePortableDBManifest(dbPath, portableDBManifestPath(manifestDBPath))
+}
+
+func validatePortableSQLiteSourceFile(ctx context.Context, dbPath, manifestDBPath string) error {
+	if err := sqliteStoreImmutableHealth(ctx, dbPath); err != nil {
 		return err
 	}
 	return validatePortableDBManifest(dbPath, portableDBManifestPath(manifestDBPath))

--- a/internal/store/schema_diagnostics.go
+++ b/internal/store/schema_diagnostics.go
@@ -73,7 +73,18 @@ func inspectSchema(ctx context.Context, path string, portableSource bool) Schema
 	}
 	diag.Exists = true
 
-	base, err := crawlstore.OpenReadOnly(ctx, path)
+	openPath := path
+	if portableSource {
+		immutablePath, err := immutableSQLiteURI(path)
+		if err != nil {
+			diag.State = "error"
+			diag.Error = err.Error()
+			diag.NextSteps = []string{"Check the configured db_path before running write commands."}
+			return diag
+		}
+		openPath = immutablePath
+	}
+	base, err := crawlstore.OpenReadOnly(ctx, openPath)
 	if err != nil {
 		diag.State = "error"
 		diag.Error = err.Error()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -5,6 +5,10 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -67,7 +71,26 @@ func Open(ctx context.Context, path string) (*Store, error) {
 }
 
 func OpenReadOnly(ctx context.Context, path string) (*Store, error) {
-	base, err := crawlstore.OpenReadOnly(ctx, path)
+	return openReadOnly(ctx, path, path)
+}
+
+func OpenReadOnlyImmutable(ctx context.Context, path string) (*Store, error) {
+	resolvedPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve sqlite db path: %w", err)
+	}
+	if _, err := os.Stat(resolvedPath); err != nil {
+		return nil, fmt.Errorf("stat sqlite db: %w", err)
+	}
+	openPath, err := immutableSQLiteURI(resolvedPath)
+	if err != nil {
+		return nil, err
+	}
+	return openReadOnly(ctx, path, openPath)
+}
+
+func openReadOnly(ctx context.Context, path, openPath string) (*Store, error) {
+	base, err := crawlstore.OpenReadOnly(ctx, openPath)
 	if err != nil {
 		return nil, err
 	}
@@ -83,6 +106,24 @@ func OpenReadOnly(ctx context.Context, path string) (*Store, error) {
 		return nil, fmt.Errorf("database schema version %d is newer than supported version %d", current, schemaVersion)
 	}
 	return st, nil
+}
+
+func immutableSQLiteURI(path string) (string, error) {
+	resolvedPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve sqlite db path: %w", err)
+	}
+	if runtime.GOOS == "windows" {
+		resolvedPath = filepath.ToSlash(resolvedPath)
+		if filepath.VolumeName(resolvedPath) != "" && !strings.HasPrefix(resolvedPath, "/") {
+			resolvedPath = "/" + resolvedPath
+		}
+	}
+	u := url.URL{Scheme: "file", Path: resolvedPath}
+	query := u.Query()
+	query.Set("immutable", "1")
+	u.RawQuery = query.Encode()
+	return u.String(), nil
 }
 
 func (s *Store) Close() error {


### PR DESCRIPTION
## Summary

- inspect committed portable source databases through immutable SQLite URI connections
- keep ordinary local databases and writable runtime mirrors on the existing normal read-only path
- fail closed before opening SQLite when Git portability probing itself fails
- add end-to-end coverage proving `doctor --json` leaves canonical portable checkouts clean, plus a probe-failure regression

## Root cause

SQLite may create `-wal` and `-shm` files even for an ordinary read-only connection to a WAL-mode database. Gitcrawl used those connections while inspecting the committed portable source database, so a nominally read-only doctor command could dirty the portable checkout.

## Verification

- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./...`
- total coverage: 85.0%
- Windows amd64 cross-compilation of affected CLI/store tests
- `govulncheck ./...`: no vulnerabilities found
- deadcode: clean
- release-script tests: passed
- black-box validation: two consecutive doctor runs reported current portable source diagnostics, pending runtime migration, and a clean checkout without `-wal` or `-shm`
- Codex autoreview: no accepted/actionable findings
