### PR TITLE
fix: surface portable runtime-mirror redirects and publish pruned stores back to checkouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.8.5 - Unreleased
 
+### Portable stores
+
+- Report writable-command redirects to portable runtime mirrors on stderr and expose `db_target`, `db_target_path`, and `portable_source_db` in `sync`, `refresh`, and `portable prune` JSON output.
+- Publish the pruned database and manifest back to the portable checkout by default so the documented publishing flow cannot commit stale data, with `--no-publish` available for mirror-only pruning.
+- Remove temporary SQLite `-wal` and `-shm` sidecars after atomic copies and sweep orphaned aged temp files from portable runtime mirror directories.
+
 ## 0.8.4 - 2026-07-22
 
 ### Cached search

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -135,7 +135,7 @@ octopool gh api repos/openclaw/openclaw/pulls/123
 
 | Command | Purpose | Docs |
 | --- | --- | --- |
-| `gitcrawl portable prune [--body-chars --no-vacuum --include-sync-failures --json]` | Build a compact portable v2 backup and (optionally) `VACUUM` for publishing | [Portable stores](/portable-stores/#publishing-gitcrawl-portable-prune) |
+| `gitcrawl portable prune [--body-chars --no-vacuum --include-sync-failures --no-publish --json]` | Build a compact portable v2 backup and (optionally) `VACUUM` for publishing | [Portable stores](/portable-stores/#publishing-gitcrawl-portable-prune) |
 
 ## Not yet implemented
 

--- a/docs/portable-stores.md
+++ b/docs/portable-stores.md
@@ -60,13 +60,16 @@ If the remote is unreachable, the read still answers from the local checkout.
 
 ## How write commands behave
 
-Write commands (`embed`, `refresh`, `cluster`, neighbor generation) need to persist new data without mutating the published portable store. They open a **writable runtime mirror** alongside the portable checkout so vectors and overrides land in the runtime cache while the portable database remains read-only.
+Write commands (`sync`, `embed`, `refresh`, `portable prune`, `cluster`, neighbor generation) open a **writable runtime mirror** alongside the portable checkout so new GitHub data, vectors, and overrides persist without partially mutating the published portable store. When this redirect engages, gitcrawl prints one stderr notice naming both the runtime mirror and the checkout database.
+
+JSON output from `sync`, `refresh`, and `portable prune` makes that destination machine-readable: `db_target` is `runtime-mirror`, `db_target_path` names the database actually written, and `portable_source_db` names the database in the checkout. With a non-portable local database, `db_target` is `direct`, `db_target_path` names that database, and `portable_source_db` is omitted.
 
 This separation means:
 
 - You can `gitcrawl embed` against a portable store without dirtying the Git checkout
 - Local cluster overrides (`close-cluster`, exclusions, canonicals) live in the runtime mirror
-- Only the publishing workflow writes back into the portable checkout
+- Before publishing, even `refresh` writes only to the runtime mirror and leaves the checkout database untouched
+- The `portable prune` publishing step is the boundary that writes a validated database and manifest back into the checkout
 
 ## Publishing: `gitcrawl portable prune`
 
@@ -75,12 +78,13 @@ gitcrawl portable prune
 gitcrawl portable prune --body-chars 256       # default
 gitcrawl portable prune --body-chars 512 --no-vacuum
 gitcrawl portable prune --include-sync-failures # opt-in, error text redacted
+gitcrawl portable prune --no-publish            # prune only the runtime mirror
 gitcrawl portable prune --json
 ```
 
-`portable prune` validates the pruned database with SQLite `quick_check`, writes a `.manifest.json` next to the database with size and SHA-256 integrity, and includes the manifest path plus hash in JSON output. Consumers use that manifest to reject incomplete or mismatched portable-store downloads before replacing a known-good runtime mirror.
+`portable prune` validates the pruned runtime-mirror database with SQLite `quick_check` and writes a `.manifest.json` next to it with size and SHA-256 integrity. When the configured `db_path` is inside a portable checkout, prune then stages the database and manifest inside that checkout, validates the staged pair, and replaces the published files with atomic renames while preserving their existing permissions. A failed publish restores the previously published pair; an interrupted one is caught later by manifest validation and the standard repair path, the same way an interrupted `git pull` of the store is. Pass `--no-publish` to leave the pruned result only in the runtime mirror. Consumers use the manifest to reject incomplete or mismatched portable-store downloads before replacing a known-good runtime mirror.
 
-`prune` converts the database into the portable v2 backup format and (by default) runs SQLite `VACUUM` to reclaim space. The result is a smaller database suitable for committing back to Git.
+`prune` converts the database into the portable v2 backup format and (by default) runs SQLite `VACUUM` to reclaim space. The result is a smaller database and matching manifest ready to commit from the portable checkout. JSON output includes `published`, which is true only when this copy-back happened, plus `published_db_path` and `published_manifest_path` when published.
 
 Portable v2 keeps the data agents most often need for offline GitHub reads:
 
@@ -99,9 +103,10 @@ Portable mirrors retain existing revision-bound key summaries, but do not regene
 | `--body-chars <n>` | `256` | Maximum body characters to keep per thread/comment excerpt |
 | `--no-vacuum` | _(off)_ | Skip size-reclaim `VACUUM`; a present or pending failure ledger still forces a secure rewrite |
 | `--include-sync-failures` | _(off)_ | Keep the sync failure ledger while replacing every error message with a redaction marker |
+| `--no-publish` | _(off)_ | Prune the runtime mirror without publishing the database and manifest back to a portable checkout |
 | `--json` | _(off)_ | JSON output |
 
-After pruning, commit and push the database file from the portable checkout the way you would for any Git repository.
+After pruning, commit and push both the database and its `.manifest.json` from the portable checkout the way you would for any Git repository.
 
 ## A typical publishing flow
 
@@ -109,13 +114,13 @@ After pruning, commit and push the database file from the portable checkout the 
 # In the portable store checkout, refresh upstream data into the local runtime mirror.
 gitcrawl refresh owner/repo
 
-# Prune for a small, shareable footprint.
+# Prune for a small, shareable footprint and publish the database plus manifest into the checkout.
 gitcrawl portable prune --body-chars 256
 
 # Commit and push using normal Git from the configured portable checkout.
 cd ~/Library/Application\ Support/gitcrawl/stores/gitcrawl-store
 # Linux default: cd ~/.config/gitcrawl/stores/gitcrawl-store
-git add data/openclaw__openclaw.sync.db
+git add data/openclaw__openclaw.sync.db data/openclaw__openclaw.sync.db.manifest.json
 git commit -m "data: refresh openclaw/gitcrawl"
 git push
 ```
@@ -132,7 +137,7 @@ The v2 backup also keeps comments and PR-detail tables for local review, cluster
 
 - The portable store carries the SQLite database. It does not carry the Octopool `gh` cache.
 - Vectors regenerated on each consumer's machine after `embed` are not shared; portable pruning removes vector tables from the published database.
-- Portable stores are read-mostly. Multiple writers pushing concurrently will race the way any Git workflow does — gate writes through a single publisher or a CI workflow.
+- Portable stores are read-mostly. Multiple writers pushing concurrently — including concurrent `portable prune` publishers against the same checkout — race the way any Git workflow does; gate writes through a single publisher or a CI workflow.
 
 ## See also
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"text/tabwriter"
 	"time"
 
@@ -68,6 +69,7 @@ type App struct {
 	configPath          string
 	format              OutputFormat
 	getWorkingDirectory func() (string, error)
+	dbTargetNoticeOnce  sync.Once
 }
 
 type initResult struct {
@@ -349,6 +351,7 @@ type refreshResult struct {
 	Sync       *syncer.Stats   `json:"sync,omitempty"`
 	Embed      *embedResult    `json:"embed,omitempty"`
 	Cluster    map[string]any  `json:"cluster,omitempty"`
+	dbTargetInfo
 }
 
 func (a *App) runRefresh(ctx context.Context, args []string) error {
@@ -422,7 +425,7 @@ func (a *App) runRefresh(ctx context.Context, args []string) error {
 	}
 	if !*noSync {
 		fmt.Fprintln(a.Stderr, "[refresh] sync")
-		stats, err := a.syncRepository(ctx, owner, repoName, syncOptions{
+		stats, target, err := a.syncRepository(ctx, owner, repoName, syncOptions{
 			Since:            strings.TrimSpace(*since),
 			State:            strings.TrimSpace(*state),
 			Limit:            limit,
@@ -434,6 +437,7 @@ func (a *App) runRefresh(ctx context.Context, args []string) error {
 		}
 		result.Repository = stats.Repository
 		result.Sync = &stats
+		result.dbTargetInfo = target
 	}
 	if !*noEmbed {
 		fmt.Fprintln(a.Stderr, "[refresh] embed")
@@ -443,12 +447,18 @@ func (a *App) runRefresh(ctx context.Context, args []string) error {
 		}
 		result.Repository = embed.Repository
 		result.Embed = &embed
+		if result.DBTarget == "" {
+			result.dbTargetInfo = embed.dbTarget
+		}
 	}
 	if !*noCluster {
 		fmt.Fprintln(a.Stderr, "[refresh] cluster")
 		rt, err := a.openLocalRuntime(ctx)
 		if err != nil {
 			return err
+		}
+		if result.DBTarget == "" {
+			result.dbTargetInfo = rt.dbTarget()
 		}
 		repo, err := rt.repository(ctx, owner, repoName)
 		if err != nil {
@@ -1230,6 +1240,7 @@ type embedResult struct {
 	Status     string             `json:"status,omitempty"`
 	Failures   []embedFailureStat `json:"failures,omitempty"`
 	RunID      int64              `json:"run_id"`
+	dbTarget   dbTargetInfo
 }
 
 type embedFailureStat struct {
@@ -1425,6 +1436,7 @@ func (a *App) embedRepository(ctx context.Context, owner, repoName string, optio
 		Retries:    totalRetries,
 		Status:     status,
 		Failures:   failures,
+		dbTarget:   rt.dbTarget(),
 	}
 	statsJSON, _ := json.Marshal(result)
 	runRecord := store.RunRecord{
@@ -2895,7 +2907,7 @@ func (a *App) runSync(ctx context.Context, args []string) error {
 		return usageErr(err)
 	}
 
-	stats, err := a.syncRepository(ctx, owner, repo, syncOptions{
+	stats, target, err := a.syncRepository(ctx, owner, repo, syncOptions{
 		Since:            strings.TrimSpace(*since),
 		State:            strings.TrimSpace(*state),
 		Limit:            limit,
@@ -2906,7 +2918,11 @@ func (a *App) runSync(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	return a.writeOutput("sync", stats, true)
+	result := struct {
+		syncer.Stats
+		dbTargetInfo
+	}{Stats: stats, dbTargetInfo: target}
+	return a.writeOutput("sync", result, true)
 }
 
 type syncOptions struct {
@@ -3035,7 +3051,7 @@ func (a *App) runFillPRDetails(ctx context.Context, args []string) error {
 				Numbers:    batchNumbers,
 			})
 		}
-		stats, err := a.syncRepository(ctx, owner, repoName, syncOptions{
+		stats, _, err := a.syncRepository(ctx, owner, repoName, syncOptions{
 			Numbers:          batchNumbers,
 			IncludeComments:  *includeComments,
 			IncludePRDetails: true,
@@ -3175,23 +3191,24 @@ func parseSyncWith(value string) (map[string]bool, error) {
 	return out, nil
 }
 
-func (a *App) syncRepository(ctx context.Context, owner, repo string, options syncOptions) (syncer.Stats, error) {
+func (a *App) syncRepository(ctx context.Context, owner, repo string, options syncOptions) (syncer.Stats, dbTargetInfo, error) {
 	cfg, err := config.LoadRuntime(a.configPath)
 	if err != nil {
-		return syncer.Stats{}, err
+		return syncer.Stats{}, dbTargetInfo{}, err
 	}
 	token := a.resolveGitHubToken(ctx, cfg)
 	if token.Value == "" {
-		return syncer.Stats{}, fmt.Errorf("missing GitHub token: set %s or authenticate gh", cfg.GitHub.TokenEnv)
+		return syncer.Stats{}, dbTargetInfo{}, fmt.Errorf("missing GitHub token: set %s or authenticate gh", cfg.GitHub.TokenEnv)
 	}
 	if err := config.EnsureRuntimeDirs(cfg); err != nil {
-		return syncer.Stats{}, err
+		return syncer.Stats{}, dbTargetInfo{}, err
 	}
 	rt, err := a.openLocalRuntime(ctx)
 	if err != nil {
-		return syncer.Stats{}, err
+		return syncer.Stats{}, dbTargetInfo{}, err
 	}
 	defer rt.Store.Close()
+	target := rt.dbTarget()
 
 	var reporter gh.Reporter
 	var logger *slog.Logger
@@ -3222,9 +3239,9 @@ func (a *App) syncRepository(ctx context.Context, owner, repo string, options sy
 		Logger:           logger,
 	})
 	if err != nil {
-		return syncer.Stats{}, err
+		return syncer.Stats{}, target, err
 	}
-	return stats, nil
+	return stats, target, nil
 }
 
 func progressLogger(w io.Writer) *slog.Logger {
@@ -3388,6 +3405,7 @@ func (a *App) runPortablePrune(ctx context.Context, args []string) error {
 	bodyCharsRaw := fs.String("body-chars", "256", "maximum thread body characters to keep")
 	noVacuum := fs.Bool("no-vacuum", false, "skip size-reclaim vacuum unless needed to scrub failure history")
 	includeSyncFailures := fs.Bool("include-sync-failures", false, "include the sync failure ledger with redacted error messages")
+	noPublish := fs.Bool("no-publish", false, "do not publish the pruned runtime mirror back to the portable checkout")
 	jsonOut := fs.Bool("json", false, "write JSON output")
 	if err := fs.Parse(normalizeCommandArgs(args, map[string]bool{"body-chars": true})); err != nil {
 		return usageErr(err)
@@ -3408,6 +3426,9 @@ func (a *App) runPortablePrune(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	target := rt.dbTarget()
+	remoteSource := rt.RemoteSource
+	sourceDBPath := rt.SourceDBPath
 	stats, err := rt.Store.PrunePortablePayloads(ctx, store.PortablePruneOptions{
 		BodyChars:           bodyChars,
 		Vacuum:              !*noVacuum,
@@ -3430,7 +3451,24 @@ func (a *App) runPortablePrune(ctx context.Context, args []string) error {
 	stats.ManifestPath = manifestPath
 	stats.SHA256 = sha
 	stats.QuickCheck = "ok"
-	return a.writeOutput("portable prune", stats, true)
+	result := struct {
+		store.PortablePruneStats
+		dbTargetInfo
+		Published             bool   `json:"published"`
+		PublishedDBPath       string `json:"published_db_path,omitempty"`
+		PublishedManifestPath string `json:"published_manifest_path,omitempty"`
+	}{PortablePruneStats: stats, dbTargetInfo: target}
+	if remoteSource && !*noPublish {
+		publishedManifestPath := portableDBManifestPath(sourceDBPath)
+		if err := publishPortableCheckoutPair(ctx, stats.DBPath, manifestPath, sourceDBPath, publishedManifestPath); err != nil {
+			return fmt.Errorf("publish portable store: %w", err)
+		}
+		result.Published = true
+		result.PublishedDBPath = sourceDBPath
+		result.PublishedManifestPath = publishedManifestPath
+		fmt.Fprintf(a.Stderr, "gitcrawl: published pruned database to %s; commit both the database and %s.\n", sourceDBPath, publishedManifestPath)
+	}
+	return a.writeOutput("portable prune", result, true)
 }
 
 func writePortableDBManifest(stats store.PortablePruneStats) (string, string, error) {
@@ -5316,7 +5354,7 @@ The TUI quietly refreshes from the local store every 15 seconds and leaves the c
 const portableUsageText = `gitcrawl portable manages local portable-store snapshots.
 
 Usage:
-  gitcrawl portable prune [--body-chars N] [--no-vacuum] [--include-sync-failures] [--json]
+  gitcrawl portable prune [--body-chars N] [--no-vacuum] [--include-sync-failures] [--no-publish] [--json]
 
 Subcommands:
   prune               prune volatile payloads from the configured portable store
@@ -5324,4 +5362,6 @@ Subcommands:
 The sync failure ledger is excluded by default. --include-sync-failures keeps
 the ledger but replaces every error message with a redaction marker. A present
 or pending ledger forces a secure database rewrite even with --no-vacuum.
+For a portable checkout, prune publishes the database and manifest back into
+the checkout by default. --no-publish leaves them only in the runtime mirror.
 `

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -2564,7 +2564,7 @@ func TestMetadataStatusAndControlStatusJSON(t *testing.T) {
 	if err := help.printCommandUsage("portable"); err != nil {
 		t.Fatalf("portable help: %v", err)
 	}
-	if !strings.Contains(helpOut.String(), "portable") || !strings.Contains(helpOut.String(), "--include-sync-failures") || !strings.Contains(helpOut.String(), "redact") {
+	if !strings.Contains(helpOut.String(), "portable") || !strings.Contains(helpOut.String(), "--include-sync-failures") || !strings.Contains(helpOut.String(), "--no-publish") || !strings.Contains(helpOut.String(), "redact") {
 		t.Fatalf("portable help output = %q", helpOut.String())
 	}
 	helpOut.Reset()
@@ -4361,6 +4361,170 @@ func TestPortablePruneCommand(t *testing.T) {
 	if err := validatePortableSQLiteFile(context.Background(), dbPath, dbPath); err != nil {
 		t.Fatalf("portable prune should leave valid db + manifest: %v", err)
 	}
+	if payload["db_target"] != "direct" || payload["db_target_path"] != dbPath || payload["published"] != false {
+		t.Fatalf("direct portable prune target = %#v", payload)
+	}
+}
+
+type portablePruneTestFixture struct {
+	configPath string
+	checkoutDB string
+	mirrorDB   string
+}
+
+func newPortablePruneTestFixture(t *testing.T) portablePruneTestFixture {
+	t.Helper()
+	ctx := context.Background()
+	dir := t.TempDir()
+	remoteDir := filepath.Join(dir, "remote")
+	checkoutDir := filepath.Join(dir, "checkout")
+	dbRel := filepath.Join("data", "openclaw__openclaw.sync.db")
+	remoteDB := filepath.Join(remoteDir, dbRel)
+	if err := os.MkdirAll(filepath.Dir(remoteDB), 0o755); err != nil {
+		t.Fatalf("mkdir remote data: %v", err)
+	}
+	if err := runGit(ctx, remoteDir, "init", "-b", "main"); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	seedPortableThread(t, remoteDB, 1, strings.Repeat("portable publish payload ", 32))
+	if err := runGit(ctx, remoteDir, "add", dbRel); err != nil {
+		t.Fatalf("git add seed: %v", err)
+	}
+	if err := runGit(ctx, remoteDir, "-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-m", "seed store"); err != nil {
+		t.Fatalf("git commit seed: %v", err)
+	}
+
+	configPath := filepath.Join(dir, "config.toml")
+	initApp := New()
+	initApp.Stdout = io.Discard
+	initApp.Stderr = io.Discard
+	if err := initApp.Run(ctx, []string{
+		"--config", configPath,
+		"init",
+		"--portable-store", remoteDir,
+		"--portable-db", filepath.ToSlash(dbRel),
+		"--store-dir", checkoutDir,
+	}); err != nil {
+		t.Fatalf("init portable store: %v", err)
+	}
+	checkoutDB := filepath.Join(checkoutDir, dbRel)
+	pathApp := New()
+	pathApp.configPath = configPath
+	mirrorDB, err := pathApp.portableRuntimeDBPath(ctx, checkoutDB)
+	if err != nil {
+		t.Fatalf("portable runtime db path: %v", err)
+	}
+	return portablePruneTestFixture{configPath: configPath, checkoutDB: checkoutDB, mirrorDB: mirrorDB}
+}
+
+func TestPortablePrunePublishesRuntimeMirrorToCheckout(t *testing.T) {
+	ctx := context.Background()
+	fixture := newPortablePruneTestFixture(t)
+	if err := os.Chmod(fixture.checkoutDB, 0o600); err != nil {
+		t.Fatalf("restrict checkout db mode: %v", err)
+	}
+	before, err := os.ReadFile(fixture.checkoutDB)
+	if err != nil {
+		t.Fatalf("read checkout db before prune: %v", err)
+	}
+	app := New()
+	var stdout, stderr bytes.Buffer
+	app.Stdout = &stdout
+	app.Stderr = &stderr
+	if err := app.Run(ctx, []string{"--config", fixture.configPath, "portable", "prune", "--json"}); err != nil {
+		t.Fatalf("portable prune: %v\nstderr:\n%s", err, stderr.String())
+	}
+	var payload struct {
+		DBTarget              string `json:"db_target"`
+		DBTargetPath          string `json:"db_target_path"`
+		PortableSourceDB      string `json:"portable_source_db"`
+		Published             bool   `json:"published"`
+		PublishedDBPath       string `json:"published_db_path"`
+		PublishedManifestPath string `json:"published_manifest_path"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("parse portable prune json: %v\n%s", err, stdout.String())
+	}
+	if payload.DBTarget != "runtime-mirror" || payload.DBTargetPath != fixture.mirrorDB || payload.PortableSourceDB != fixture.checkoutDB {
+		t.Fatalf("portable prune target = %+v, mirror=%s source=%s", payload, fixture.mirrorDB, fixture.checkoutDB)
+	}
+	wantManifest := portableDBManifestPath(fixture.checkoutDB)
+	if !payload.Published || payload.PublishedDBPath != fixture.checkoutDB || payload.PublishedManifestPath != wantManifest {
+		t.Fatalf("portable prune publish result = %+v", payload)
+	}
+	after, err := os.ReadFile(fixture.checkoutDB)
+	if err != nil {
+		t.Fatalf("read checkout db after prune: %v", err)
+	}
+	if bytes.Equal(after, before) {
+		t.Fatal("published checkout database bytes did not change")
+	}
+	for _, suffix := range []string{"-wal", "-shm"} {
+		if _, err := os.Stat(fixture.checkoutDB + suffix); !os.IsNotExist(err) {
+			t.Fatalf("published checkout sidecar %s still exists: %v", suffix, err)
+		}
+	}
+	if err := validatePortableSQLiteSourceFile(ctx, fixture.checkoutDB, fixture.checkoutDB); err != nil {
+		t.Fatalf("validate published checkout db: %v", err)
+	}
+	for _, suffix := range []string{"-wal", "-shm"} {
+		if _, err := os.Stat(fixture.checkoutDB + suffix); !os.IsNotExist(err) {
+			t.Fatalf("checkout sidecar %s exists after validation: %v", suffix, err)
+		}
+	}
+	for _, path := range []string{fixture.checkoutDB, wantManifest} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat published file %s: %v", path, err)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Fatalf("published file %s mode = %o, want the preserved 600", path, info.Mode().Perm())
+		}
+	}
+	wantNotice := fmt.Sprintf("gitcrawl: portable store checkout detected; writes go to the runtime mirror at %s, not the checkout database %s. Run 'gitcrawl portable prune' to publish.", fixture.mirrorDB, fixture.checkoutDB)
+	if strings.Count(stderr.String(), wantNotice) != 1 {
+		t.Fatalf("redirect notice count = %d, want 1\nstderr:\n%s", strings.Count(stderr.String(), wantNotice), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "published pruned database to "+fixture.checkoutDB) || !strings.Contains(stderr.String(), wantManifest) {
+		t.Fatalf("publish notice missing paths:\n%s", stderr.String())
+	}
+	t.Logf("portable prune JSON: %s", strings.TrimSpace(stdout.String()))
+}
+
+func TestPortablePruneNoPublishLeavesCheckoutUnchanged(t *testing.T) {
+	fixture := newPortablePruneTestFixture(t)
+	before, err := os.ReadFile(fixture.checkoutDB)
+	if err != nil {
+		t.Fatalf("read checkout db before prune: %v", err)
+	}
+	app := New()
+	var stdout, stderr bytes.Buffer
+	app.Stdout = &stdout
+	app.Stderr = &stderr
+	if err := app.Run(context.Background(), []string{"--config", fixture.configPath, "portable", "prune", "--no-publish", "--json"}); err != nil {
+		t.Fatalf("portable prune --no-publish: %v\nstderr:\n%s", err, stderr.String())
+	}
+	var payload struct {
+		Published             bool   `json:"published"`
+		PublishedDBPath       string `json:"published_db_path"`
+		PublishedManifestPath string `json:"published_manifest_path"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("parse portable prune json: %v\n%s", err, stdout.String())
+	}
+	if payload.Published || payload.PublishedDBPath != "" || payload.PublishedManifestPath != "" {
+		t.Fatalf("no-publish result = %+v", payload)
+	}
+	after, err := os.ReadFile(fixture.checkoutDB)
+	if err != nil {
+		t.Fatalf("read checkout db after prune: %v", err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatal("--no-publish changed checkout database bytes")
+	}
+	if _, err := os.Stat(portableDBManifestPath(fixture.checkoutDB)); !os.IsNotExist(err) {
+		t.Fatalf("--no-publish wrote checkout manifest: %v", err)
+	}
 }
 
 func TestPortablePruneCommandCanIncludeRedactedSyncFailures(t *testing.T) {
@@ -5736,15 +5900,20 @@ func TestSyncCommandUsesConfiguredGitHubBaseURLAndHydratesComments(t *testing.T)
 		t.Fatalf("sync: %v", err)
 	}
 	var stats struct {
-		ThreadsSynced      int `json:"threads_synced"`
-		PullRequestsSynced int `json:"pull_requests_synced"`
-		CommentsSynced     int `json:"comments_synced"`
+		ThreadsSynced      int    `json:"threads_synced"`
+		PullRequestsSynced int    `json:"pull_requests_synced"`
+		CommentsSynced     int    `json:"comments_synced"`
+		DBTarget           string `json:"db_target"`
+		DBTargetPath       string `json:"db_target_path"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &stats); err != nil {
 		t.Fatalf("decode sync stats: %v\n%s", err, stdout.String())
 	}
 	if stats.ThreadsSynced != 2 || stats.PullRequestsSynced != 1 || stats.CommentsSynced != 4 {
 		t.Fatalf("sync stats = %+v", stats)
+	}
+	if stats.DBTarget != "direct" || stats.DBTargetPath != dbPath {
+		t.Fatalf("sync db target = %+v", stats)
 	}
 
 	st, err := store.Open(ctx, dbPath)
@@ -6262,6 +6431,9 @@ func TestRefreshRunsSyncEmbedAndClusterWithLocalServers(t *testing.T) {
 	}
 	if payload.Cluster == nil || int(payload.Cluster["vector_count"].(float64)) != 2 {
 		t.Fatalf("cluster payload = %+v", payload.Cluster)
+	}
+	if payload.DBTarget != "direct" || payload.DBTargetPath != dbPath {
+		t.Fatalf("refresh db target = %+v", payload.dbTargetInfo)
 	}
 	for _, want := range []string{"[refresh] sync", "[refresh] embed", "[refresh] cluster"} {
 		if !strings.Contains(stderr.String(), want) {
@@ -8439,6 +8611,13 @@ func TestRefreshEmbedsAndClustersWithoutSync(t *testing.T) {
 	}
 	if !strings.Contains(out, `"cluster_count": 2`) {
 		t.Fatalf("refresh did not persist cluster: %q", out)
+	}
+	var target dbTargetInfo
+	if err := json.Unmarshal(stdout.Bytes(), &target); err != nil {
+		t.Fatalf("decode refresh db target: %v", err)
+	}
+	if target.DBTarget != "direct" || target.DBTargetPath != dbPath {
+		t.Fatalf("no-sync refresh db target = %+v", target)
 	}
 
 	st, err = store.Open(ctx, dbPath)

--- a/internal/cli/gh_search.go
+++ b/internal/cli/gh_search.go
@@ -164,7 +164,7 @@ func (a *App) syncGHSearchIfStale(ctx context.Context, owner, repoName, state st
 	} else {
 		fmt.Fprintf(a.Stderr, "gitcrawl: cached sync for %s/%s is older than %s; syncing before search\n", owner, repoName, maxAge)
 	}
-	_, err = a.syncRepository(ctx, owner, repoName, syncOptions{State: state})
+	_, _, err = a.syncRepository(ctx, owner, repoName, syncOptions{State: state})
 	return err
 }
 

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -25,10 +25,28 @@ type localRuntime struct {
 	RemoteSource bool
 }
 
+type dbTargetInfo struct {
+	DBTarget         string `json:"db_target,omitempty"`
+	DBTargetPath     string `json:"db_target_path,omitempty"`
+	PortableSourceDB string `json:"portable_source_db,omitempty"`
+}
+
+func (rt localRuntime) dbTarget() dbTargetInfo {
+	if rt.RemoteSource {
+		return dbTargetInfo{
+			DBTarget:         "runtime-mirror",
+			DBTargetPath:     rt.Config.DBPath,
+			PortableSourceDB: rt.SourceDBPath,
+		}
+	}
+	return dbTargetInfo{DBTarget: "direct", DBTargetPath: rt.Config.DBPath}
+}
+
 const portableStoreRefreshTimeout = 15 * time.Second
 const portableStoreRepairTimeout = 90 * time.Second
 const portableStoreRefreshTTL = 2 * time.Minute
 const portableStoreRefreshFailureBackoff = time.Minute
+const portableRuntimeTempMaxAge = time.Hour
 const portableStoreMarkerFile = "gitcrawl-portable-store"
 const staleGitIndexLockAge = 2 * time.Second
 
@@ -53,6 +71,9 @@ func (a *App) openLocalRuntime(ctx context.Context) (localRuntime, error) {
 		}
 		cfg.DBPath = mirrorPath
 		remoteSource = true
+		a.dbTargetNoticeOnce.Do(func() {
+			fmt.Fprintf(a.Stderr, "gitcrawl: portable store checkout detected; writes go to the runtime mirror at %s, not the checkout database %s. Run 'gitcrawl portable prune' to publish.\n", mirrorPath, sourceDBPath)
+		})
 	}
 	st, err := store.Open(ctx, cfg.DBPath)
 	if err != nil {
@@ -244,6 +265,7 @@ func (a *App) portableRuntimeDBPath(ctx context.Context, sourceDBPath string) (s
 func refreshPortableRuntimeDB(ctx context.Context, sourceDBPath, mirrorPath string, refresh bool, configPath string) (bool, error) {
 	portableRuntimeMu.Lock()
 	defer portableRuntimeMu.Unlock()
+	sweepOrphanPortableRuntimeTempFiles(mirrorPath, portableRuntimeTempMaxAge)
 	_, isPortableSource, err := portableStoreRoot(ctx, sourceDBPath)
 	if err != nil {
 		return false, err
@@ -752,76 +774,68 @@ func portableRuntimeNeedsCopy(sourceDBPath, mirrorPath string) (bool, error) {
 }
 
 func copyFileAtomic(sourcePath, targetPath string) error {
-	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
-		return fmt.Errorf("create portable runtime dir: %w", err)
-	}
-	source, err := os.Open(sourcePath)
+	tempPath, err := stageFileCopyTemp(sourcePath, targetPath, 0o600)
 	if err != nil {
-		return fmt.Errorf("open portable source db: %w", err)
-	}
-	defer source.Close()
-	temp, err := os.CreateTemp(filepath.Dir(targetPath), "."+filepath.Base(targetPath)+".tmp-*")
-	if err != nil {
-		return fmt.Errorf("create portable runtime temp db: %w", err)
-	}
-	tempPath := temp.Name()
-	cleanup := true
-	defer func() {
-		if cleanup {
-			_ = os.Remove(tempPath)
-		}
-	}()
-	if _, err := io.Copy(temp, source); err != nil {
-		_ = temp.Close()
-		return fmt.Errorf("copy portable runtime db: %w", err)
-	}
-	if err := temp.Chmod(0o600); err != nil {
-		_ = temp.Close()
-		return fmt.Errorf("chmod portable runtime db: %w", err)
-	}
-	if err := temp.Close(); err != nil {
-		return fmt.Errorf("close portable runtime db: %w", err)
+		return err
 	}
 	if err := os.Rename(tempPath, targetPath); err != nil {
+		_ = os.Remove(tempPath)
+		removeSQLiteTempSidecars(tempPath)
 		return fmt.Errorf("replace portable runtime db: %w", err)
 	}
-	cleanup = false
-	_ = os.Remove(targetPath + "-wal")
-	_ = os.Remove(targetPath + "-shm")
+	removeSQLiteTempSidecars(tempPath)
+	removeSQLiteTempSidecars(targetPath)
 	return nil
 }
 
-func copySQLiteFileAtomicVerified(ctx context.Context, sourcePath, targetPath string) error {
+func stageFileCopyTemp(sourcePath, targetPath string, mode os.FileMode) (string, error) {
 	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
-		return fmt.Errorf("create portable runtime dir: %w", err)
+		return "", fmt.Errorf("create portable runtime dir: %w", err)
 	}
 	source, err := os.Open(sourcePath)
 	if err != nil {
-		return fmt.Errorf("open portable source db: %w", err)
+		return "", fmt.Errorf("open portable source db: %w", err)
 	}
 	defer source.Close()
 	temp, err := os.CreateTemp(filepath.Dir(targetPath), "."+filepath.Base(targetPath)+".tmp-*")
 	if err != nil {
-		return fmt.Errorf("create portable runtime temp db: %w", err)
+		return "", fmt.Errorf("create portable runtime temp db: %w", err)
 	}
 	tempPath := temp.Name()
 	cleanup := true
 	defer func() {
 		if cleanup {
 			_ = os.Remove(tempPath)
+			removeSQLiteTempSidecars(tempPath)
 		}
 	}()
 	if _, err := io.Copy(temp, source); err != nil {
 		_ = temp.Close()
-		return fmt.Errorf("copy portable runtime db: %w", err)
+		return "", fmt.Errorf("copy portable runtime db: %w", err)
 	}
-	if err := temp.Chmod(0o600); err != nil {
+	if err := temp.Chmod(mode); err != nil {
 		_ = temp.Close()
-		return fmt.Errorf("chmod portable runtime db: %w", err)
+		return "", fmt.Errorf("chmod portable runtime db: %w", err)
 	}
 	if err := temp.Close(); err != nil {
-		return fmt.Errorf("close portable runtime db: %w", err)
+		return "", fmt.Errorf("close portable runtime db: %w", err)
 	}
+	cleanup = false
+	return tempPath, nil
+}
+
+func copySQLiteFileAtomicVerified(ctx context.Context, sourcePath, targetPath string) error {
+	tempPath, err := stageFileCopyTemp(sourcePath, targetPath, 0o600)
+	if err != nil {
+		return err
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tempPath)
+			removeSQLiteTempSidecars(tempPath)
+		}
+	}()
 	if err := validatePortableSQLiteFile(ctx, tempPath, sourcePath); err != nil {
 		return fmt.Errorf("validate portable runtime temp db: %w", err)
 	}
@@ -829,9 +843,147 @@ func copySQLiteFileAtomicVerified(ctx context.Context, sourcePath, targetPath st
 		return fmt.Errorf("replace portable runtime db: %w", err)
 	}
 	cleanup = false
-	_ = os.Remove(targetPath + "-wal")
-	_ = os.Remove(targetPath + "-shm")
+	removeSQLiteTempSidecars(tempPath)
+	removeSQLiteTempSidecars(targetPath)
 	return nil
+}
+
+// publishPortableCheckoutPair replaces the checkout database and manifest with
+// the pruned mirror pair. Both files are staged and validated inside the
+// checkout before the first rename so a staging or validation failure leaves
+// the previously published pair untouched.
+func publishPortableCheckoutPair(ctx context.Context, mirrorDBPath, mirrorManifestPath, checkoutDBPath, checkoutManifestPath string) error {
+	mode := os.FileMode(0o644)
+	if info, err := os.Stat(checkoutDBPath); err == nil {
+		mode = info.Mode().Perm()
+	}
+	manifestMode := mode
+	if info, err := os.Stat(checkoutManifestPath); err == nil {
+		manifestMode = info.Mode().Perm()
+	}
+	tempDB, err := stageFileCopyTemp(mirrorDBPath, checkoutDBPath, mode)
+	if err != nil {
+		return fmt.Errorf("stage published portable db: %w", err)
+	}
+	stagedDB := tempDB
+	defer func() {
+		if tempDB != "" {
+			_ = os.Remove(tempDB)
+		}
+		removeSQLiteTempSidecars(stagedDB)
+	}()
+	tempManifest, err := stageFileCopyTemp(mirrorManifestPath, checkoutManifestPath, manifestMode)
+	if err != nil {
+		return fmt.Errorf("stage published portable manifest: %w", err)
+	}
+	defer func() {
+		if tempManifest != "" {
+			_ = os.Remove(tempManifest)
+		}
+	}()
+	if err := sqliteStoreImmutableHealth(ctx, tempDB); err != nil {
+		return fmt.Errorf("validate staged portable db: %w", err)
+	}
+	if err := validatePortableDBManifest(tempDB, tempManifest); err != nil {
+		return fmt.Errorf("validate staged portable manifest: %w", err)
+	}
+	// The pair is replaced with two adjacent renames; a crash between them is
+	// the same manifest-mismatch state a consumer's interrupted `git pull` can
+	// produce, and manifest validation plus the git-based repair path recover
+	// it. Concurrent publishers are out of contract (see the portable-store
+	// caveats) the same way concurrent `git push` publishers are. A failed
+	// manifest rename rolls the database back from the backup so an error
+	// return leaves a consistent previous pair.
+	rollbackDB := ""
+	if _, err := os.Stat(checkoutDBPath); err == nil {
+		backup, err := stageRollbackBackup(checkoutDBPath)
+		if err != nil {
+			return fmt.Errorf("back up published portable db: %w", err)
+		}
+		rollbackDB = backup
+	}
+	defer func() {
+		if rollbackDB != "" {
+			_ = os.Remove(rollbackDB)
+		}
+	}()
+	if err := os.Rename(tempDB, checkoutDBPath); err != nil {
+		return fmt.Errorf("replace published portable db: %w", err)
+	}
+	tempDB = ""
+	removeSQLiteTempSidecars(checkoutDBPath)
+	if err := os.Rename(tempManifest, checkoutManifestPath); err != nil {
+		if rollbackDB != "" {
+			backupPath := rollbackDB
+			rollbackDB = ""
+			if restoreErr := os.Rename(backupPath, checkoutDBPath); restoreErr != nil {
+				// Keep the backup on disk for manual recovery.
+				return fmt.Errorf("replace published portable manifest: %w; restoring the previous database from %s also failed: %v", err, backupPath, restoreErr)
+			}
+		}
+		return fmt.Errorf("replace published portable manifest: %w", err)
+	}
+	tempManifest = ""
+	return nil
+}
+
+// stageRollbackBackup snapshots path under a unique sibling name, preferring a
+// hard link and falling back to a byte copy on filesystems without link
+// support. The caller owns the returned file.
+func stageRollbackBackup(path string) (string, error) {
+	placeholder, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".publish-rollback-*")
+	if err != nil {
+		return "", err
+	}
+	backupPath := placeholder.Name()
+	if err := placeholder.Close(); err != nil {
+		_ = os.Remove(backupPath)
+		return "", err
+	}
+	if err := os.Remove(backupPath); err != nil {
+		return "", err
+	}
+	if err := os.Link(path, backupPath); err == nil {
+		return backupPath, nil
+	}
+	mode := os.FileMode(0o600)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	}
+	temp, err := stageFileCopyTemp(path, backupPath, mode)
+	if err != nil {
+		return "", err
+	}
+	if err := os.Rename(temp, backupPath); err != nil {
+		_ = os.Remove(temp)
+		removeSQLiteTempSidecars(temp)
+		return "", err
+	}
+	return backupPath, nil
+}
+
+func removeSQLiteTempSidecars(path string) {
+	_ = os.Remove(path + "-wal")
+	_ = os.Remove(path + "-shm")
+}
+
+func sweepOrphanPortableRuntimeTempFiles(mirrorPath string, maxAge time.Duration) {
+	dir := filepath.Dir(mirrorPath)
+	prefix := "." + filepath.Base(mirrorPath) + ".tmp-"
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-maxAge)
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.Type().IsRegular() && strings.HasPrefix(name, prefix) {
+			info, err := entry.Info()
+			if err == nil && info.ModTime().Before(cutoff) {
+				_ = os.Remove(filepath.Join(dir, name))
+			}
+		}
+	}
 }
 
 func portableStoreRoot(ctx context.Context, dbPath string) (string, bool, error) {

--- a/internal/cli/runtime_extra_test.go
+++ b/internal/cli/runtime_extra_test.go
@@ -1,13 +1,295 @@
 package cli
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/openclaw/gitcrawl/internal/config"
 )
+
+func TestLocalRuntimeDBTarget(t *testing.T) {
+	direct := localRuntime{Config: config.Config{DBPath: "/data/gitcrawl.db"}}
+	if got, want := direct.dbTarget(), (dbTargetInfo{DBTarget: "direct", DBTargetPath: "/data/gitcrawl.db"}); got != want {
+		t.Fatalf("direct db target = %+v, want %+v", got, want)
+	}
+
+	redirected := localRuntime{
+		Config:       config.Config{DBPath: "/runtime/store/data/gitcrawl.db"},
+		SourceDBPath: "/checkout/data/gitcrawl.db",
+		RemoteSource: true,
+	}
+	want := dbTargetInfo{
+		DBTarget:         "runtime-mirror",
+		DBTargetPath:     "/runtime/store/data/gitcrawl.db",
+		PortableSourceDB: "/checkout/data/gitcrawl.db",
+	}
+	if got := redirected.dbTarget(); got != want {
+		t.Fatalf("redirected db target = %+v, want %+v", got, want)
+	}
+}
+
+func TestSweepOrphanPortableRuntimeTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	mirrorPath := filepath.Join(dir, "x.db")
+	old := time.Now().Add(-2 * portableRuntimeTempMaxAge)
+	oldMatching := []string{".x.db.tmp-123", ".x.db.tmp-123-wal", ".x.db.tmp-123-shm"}
+	oldPreserved := []string{"old.db", ".other.db.tmp-9", ".notes.tmp-backup"}
+	for _, name := range append(append([]string(nil), oldMatching...), oldPreserved...) {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(name), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		if err := os.Chtimes(path, old, old); err != nil {
+			t.Fatalf("backdate %s: %v", name, err)
+		}
+	}
+	fresh := filepath.Join(dir, ".x.db.tmp-fresh")
+	if err := os.WriteFile(fresh, []byte("fresh"), 0o600); err != nil {
+		t.Fatalf("write fresh temp: %v", err)
+	}
+
+	sweepOrphanPortableRuntimeTempFiles(mirrorPath, portableRuntimeTempMaxAge)
+
+	for _, name := range oldMatching {
+		if _, err := os.Stat(filepath.Join(dir, name)); !os.IsNotExist(err) {
+			t.Fatalf("old matching temp %s still exists: %v", name, err)
+		}
+	}
+	preserved := []string{fresh}
+	for _, name := range oldPreserved {
+		preserved = append(preserved, filepath.Join(dir, name))
+	}
+	for _, path := range preserved {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("preserved file %s: %v", path, err)
+		}
+	}
+}
+
+func TestCopySQLiteFileAtomicVerifiedRemovesTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source.db")
+	target := filepath.Join(dir, "target.db")
+	seedPortableThread(t, source, 1, "copy temp cleanup")
+	if err := copySQLiteFileAtomicVerified(context.Background(), source, target); err != nil {
+		t.Fatalf("copy verified sqlite file: %v", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, ".target.db.tmp-*"))
+	if err != nil {
+		t.Fatalf("glob temp files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("verified copy left temp files: %v", matches)
+	}
+	invalidSource := filepath.Join(dir, "invalid.db")
+	failedTarget := filepath.Join(dir, "failed.db")
+	if err := os.WriteFile(invalidSource, []byte("not sqlite"), 0o600); err != nil {
+		t.Fatalf("write invalid source: %v", err)
+	}
+	if err := copySQLiteFileAtomicVerified(context.Background(), invalidSource, failedTarget); err == nil {
+		t.Fatal("invalid sqlite source should fail validation")
+	}
+	matches, err = filepath.Glob(filepath.Join(dir, ".failed.db.tmp-*"))
+	if err != nil {
+		t.Fatalf("glob failed-copy temp files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("failed verified copy left temp files: %v", matches)
+	}
+
+	tempPath := filepath.Join(dir, ".failed.db.tmp-123")
+	for _, suffix := range []string{"-wal", "-shm"} {
+		if err := os.WriteFile(tempPath+suffix, []byte("sidecar"), 0o600); err != nil {
+			t.Fatalf("write temp sidecar: %v", err)
+		}
+	}
+	removeSQLiteTempSidecars(tempPath)
+	for _, suffix := range []string{"-wal", "-shm"} {
+		if _, err := os.Stat(tempPath + suffix); !os.IsNotExist(err) {
+			t.Fatalf("temp sidecar %s still exists: %v", suffix, err)
+		}
+	}
+}
+
+func writeTestPortableManifest(t *testing.T, dbPath string) string {
+	t.Helper()
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("stat db for manifest: %v", err)
+	}
+	sum, err := fileSHA256(dbPath)
+	if err != nil {
+		t.Fatalf("hash db for manifest: %v", err)
+	}
+	manifest := portableDBManifest{
+		Schema:      "gitcrawl-portable-sync-v2",
+		ExportedAt:  time.Now().UTC().Format(time.RFC3339Nano),
+		OutputPath:  filepath.Base(dbPath),
+		OutputBytes: info.Size(),
+		SHA256:      fmt.Sprintf("%x", sum),
+		QuickCheck:  "ok",
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	manifestPath := portableDBManifestPath(dbPath)
+	if err := os.WriteFile(manifestPath, data, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return manifestPath
+}
+
+func TestPublishPortableCheckoutPairPreservesCheckoutMode(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	mirrorDB := filepath.Join(dir, "mirror", "x.db")
+	checkoutDB := filepath.Join(dir, "checkout", "x.db")
+	seedPortableThread(t, mirrorDB, 1, "publish pair source")
+	mirrorManifest := writeTestPortableManifest(t, mirrorDB)
+	seedPortableThread(t, checkoutDB, 2, "old checkout content")
+	if err := os.Chmod(checkoutDB, 0o600); err != nil {
+		t.Fatalf("chmod checkout db: %v", err)
+	}
+	checkoutManifest := portableDBManifestPath(checkoutDB)
+	if err := os.WriteFile(checkoutManifest, []byte("old manifest"), 0o640); err != nil {
+		t.Fatalf("write old checkout manifest: %v", err)
+	}
+
+	if err := publishPortableCheckoutPair(ctx, mirrorDB, mirrorManifest, checkoutDB, checkoutManifest); err != nil {
+		t.Fatalf("publish portable checkout pair: %v", err)
+	}
+	want, err := os.ReadFile(mirrorDB)
+	if err != nil {
+		t.Fatalf("read mirror db: %v", err)
+	}
+	got, err := os.ReadFile(checkoutDB)
+	if err != nil {
+		t.Fatalf("read published checkout db: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatal("published checkout db does not match mirror db")
+	}
+	for path, want := range map[string]os.FileMode{checkoutDB: 0o600, checkoutManifest: 0o640} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat published file %s: %v", path, err)
+		}
+		if info.Mode().Perm() != want {
+			t.Fatalf("published file %s mode = %o, want the preserved %o", path, info.Mode().Perm(), want)
+		}
+	}
+	for _, pattern := range []string{".*.tmp-*", ".*.publish-rollback-*"} {
+		leftovers, err := filepath.Glob(filepath.Join(filepath.Dir(checkoutDB), pattern))
+		if err != nil {
+			t.Fatalf("glob %s leftovers: %v", pattern, err)
+		}
+		if len(leftovers) != 0 {
+			t.Fatalf("publish left %s files: %v", pattern, leftovers)
+		}
+	}
+}
+
+func TestPublishPortableCheckoutPairKeepsOldPairOnValidationFailure(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	mirrorDB := filepath.Join(dir, "mirror", "x.db")
+	if err := os.MkdirAll(filepath.Dir(mirrorDB), 0o755); err != nil {
+		t.Fatalf("mkdir mirror: %v", err)
+	}
+	if err := os.WriteFile(mirrorDB, []byte("not sqlite"), 0o600); err != nil {
+		t.Fatalf("write corrupt mirror db: %v", err)
+	}
+	mirrorManifest := mirrorDB + ".manifest.json"
+	if err := os.WriteFile(mirrorManifest, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write mirror manifest: %v", err)
+	}
+	checkoutDB := filepath.Join(dir, "checkout", "x.db")
+	seedPortableThread(t, checkoutDB, 1, "existing published content")
+	checkoutManifest := writeTestPortableManifest(t, checkoutDB)
+	beforeDB, err := os.ReadFile(checkoutDB)
+	if err != nil {
+		t.Fatalf("read checkout db: %v", err)
+	}
+	beforeManifest, err := os.ReadFile(checkoutManifest)
+	if err != nil {
+		t.Fatalf("read checkout manifest: %v", err)
+	}
+
+	if err := publishPortableCheckoutPair(ctx, mirrorDB, mirrorManifest, checkoutDB, checkoutManifest); err == nil {
+		t.Fatal("corrupt mirror db should fail staged validation")
+	}
+	afterDB, err := os.ReadFile(checkoutDB)
+	if err != nil {
+		t.Fatalf("read checkout db after failure: %v", err)
+	}
+	afterManifest, err := os.ReadFile(checkoutManifest)
+	if err != nil {
+		t.Fatalf("read checkout manifest after failure: %v", err)
+	}
+	if !bytes.Equal(beforeDB, afterDB) || !bytes.Equal(beforeManifest, afterManifest) {
+		t.Fatal("failed publish must leave the previous checkout pair untouched")
+	}
+	leftovers, err := filepath.Glob(filepath.Join(filepath.Dir(checkoutDB), ".*.tmp-*"))
+	if err != nil {
+		t.Fatalf("glob staged temps: %v", err)
+	}
+	if len(leftovers) != 0 {
+		t.Fatalf("failed publish left staged temp files: %v", leftovers)
+	}
+}
+
+func TestPublishPortableCheckoutPairRollsBackDBWhenManifestRenameFails(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	mirrorDB := filepath.Join(dir, "mirror", "x.db")
+	seedPortableThread(t, mirrorDB, 1, "new publish content")
+	mirrorManifest := writeTestPortableManifest(t, mirrorDB)
+	checkoutDB := filepath.Join(dir, "checkout", "x.db")
+	seedPortableThread(t, checkoutDB, 2, "old publish content")
+	checkoutManifest := portableDBManifestPath(checkoutDB)
+	// A directory at the manifest destination makes the final rename fail
+	// after the database rename already succeeded.
+	if err := os.MkdirAll(checkoutManifest, 0o755); err != nil {
+		t.Fatalf("mkdir manifest blocker: %v", err)
+	}
+	before, err := os.ReadFile(checkoutDB)
+	if err != nil {
+		t.Fatalf("read checkout db: %v", err)
+	}
+
+	if err := publishPortableCheckoutPair(ctx, mirrorDB, mirrorManifest, checkoutDB, checkoutManifest); err == nil {
+		t.Fatal("manifest rename onto a directory should fail")
+	}
+	after, err := os.ReadFile(checkoutDB)
+	if err != nil {
+		t.Fatalf("read checkout db after failed publish: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("failed manifest rename must roll the checkout db back")
+	}
+	backups, err := filepath.Glob(filepath.Join(filepath.Dir(checkoutDB), ".*.publish-rollback-*"))
+	if err != nil {
+		t.Fatalf("glob rollback backups: %v", err)
+	}
+	if len(backups) != 0 {
+		t.Fatalf("rollback backup should be consumed after a successful restore: %v", backups)
+	}
+	leftovers, err := filepath.Glob(filepath.Join(filepath.Dir(checkoutDB), ".*.tmp-*"))
+	if err != nil {
+		t.Fatalf("glob staged temps: %v", err)
+	}
+	if len(leftovers) != 0 {
+		t.Fatalf("failed publish left staged temp files: %v", leftovers)
+	}
+}
 
 func TestPortableStoreRootPropagatesGitProbeFailure(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
- **Problem:** when config `db_path` points inside a portable store checkout, all writable opens silently redirect to the runtime mirror; `sync`/`refresh` report success while the checkout DB stays frozen, and the documented publish flow (`refresh` + `portable prune` + `git add`) commits stale data because prune also operates on the mirror. This froze the openclaw/gitcrawl-store publisher's exported DB for 12 days in production.
- **Changes:** one-time stderr notice on redirected writable opens; additive `db_target` / `db_target_path` / `portable_source_db` JSON fields on `sync`, `refresh`, and `portable prune`; `portable prune` now stages, validates, and publishes the pruned DB + manifest back into the checkout by default (`--no-publish` opts out), preserving file permissions with rollback on failure; temp `-wal`/`-shm` sidecars from atomic mirror copies are cleaned up and aged `.<db>.tmp-*` orphans are swept from the mirror dir; docs + changelog updated (publish flow now also commits the manifest).
- **Proof:** `GOWORK=off go test ./...` green across all 13 packages; `go vet` and `gofmt -l` clean; new tests cover publish/no-publish, staged-validation failure, manifest-rename rollback, permission preservation, sweep scoping, and temp cleanup. Codex autoreview clean ("patch is correct").
