### PR TITLE
feat: report db_target metadata in fill-pr-details JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ### Portable stores
 
-- Report writable-command redirects to portable runtime mirrors on stderr and expose `db_target`, `db_target_path`, and `portable_source_db` in `sync`, `refresh`, and `portable prune` JSON output.
+- Report writable-command redirects to portable runtime mirrors on stderr and expose `db_target`, `db_target_path`, and `portable_source_db` in `sync`, `refresh`, `fill-pr-details`, and `portable prune` JSON output.
 - Publish the pruned database and manifest back to the portable checkout by default so the documented publishing flow cannot commit stale data, with `--no-publish` available for mirror-only pruning.
 - Remove temporary SQLite `-wal` and `-shm` sidecars after atomic copies and sweep orphaned aged temp files from portable runtime mirror directories.
+
+### Dependencies and maintenance
+
+- Update `github.com/mattn/go-isatty` to 0.0.24.
 
 ## 0.8.4 - 2026-07-22
 

--- a/docs/portable-stores.md
+++ b/docs/portable-stores.md
@@ -62,7 +62,7 @@ If the remote is unreachable, the read still answers from the local checkout.
 
 Write commands (`sync`, `embed`, `refresh`, `portable prune`, `cluster`, neighbor generation) open a **writable runtime mirror** alongside the portable checkout so new GitHub data, vectors, and overrides persist without partially mutating the published portable store. When this redirect engages, gitcrawl prints one stderr notice naming both the runtime mirror and the checkout database.
 
-JSON output from `sync`, `refresh`, and `portable prune` makes that destination machine-readable: `db_target` is `runtime-mirror`, `db_target_path` names the database actually written, and `portable_source_db` names the database in the checkout. With a non-portable local database, `db_target` is `direct`, `db_target_path` names that database, and `portable_source_db` is omitted.
+JSON output from `sync`, `refresh`, `fill-pr-details`, and `portable prune` makes that destination machine-readable: `db_target` is `runtime-mirror`, `db_target_path` names the database actually written, and `portable_source_db` names the database in the checkout. With a non-portable local database, `db_target` is `direct`, `db_target_path` names that database, and `portable_source_db` is omitted.
 
 This separation means:
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -2953,6 +2953,7 @@ type fillPRDetailsResult struct {
 	IncludeComments  bool                 `json:"include_comments,omitempty"`
 	JSONProgress     bool                 `json:"json_progress,omitempty"`
 	ReserveRateLimit int                  `json:"reserve_rate_limit,omitempty"`
+	dbTargetInfo
 }
 
 type fillPRDetailsBatch struct {
@@ -3036,6 +3037,7 @@ func (a *App) runFillPRDetails(ctx context.Context, args []string) error {
 		IncludeComments:  *includeComments,
 		JSONProgress:     *jsonProgress,
 		ReserveRateLimit: reserve,
+		dbTargetInfo:     rt.dbTarget(),
 	}
 	for i := 0; i < len(numbers); i += batchSize {
 		end := i + batchSize

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -6036,14 +6036,19 @@ func TestFillPRDetailsHydratesMissingPullRequestDetails(t *testing.T) {
 		t.Fatalf("fill-pr-details: %v\nstderr=%s", err, stderr.String())
 	}
 	var result struct {
-		Selected int `json:"selected"`
-		Filled   int `json:"filled"`
+		Selected     int    `json:"selected"`
+		Filled       int    `json:"filled"`
+		DBTarget     string `json:"db_target"`
+		DBTargetPath string `json:"db_target_path"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
 		t.Fatalf("decode fill result: %v\n%s", err, stdout.String())
 	}
 	if result.Selected != 1 || result.Filled != 1 {
 		t.Fatalf("fill result = %+v", result)
+	}
+	if result.DBTarget != "direct" || result.DBTargetPath != dbPath {
+		t.Fatalf("fill db target = %+v", result)
 	}
 	if !strings.Contains(stderr.String(), `"event":"batch_start"`) || !strings.Contains(stderr.String(), `"event":"batch_done"`) {
 		t.Fatalf("missing json progress events: %s", stderr.String())


### PR DESCRIPTION
Follow-up to #126: `fill-pr-details` now reports the same `db_target` / `db_target_path` / `portable_source_db` JSON fields as `sync`, `refresh`, and `portable prune`, captured from the runtime it opens, so hydration pipelines can assert they write to the intended database.

Also records the #125 go-isatty 0.0.24 bump in the 0.8.5 changelog (maintainer-adds-on-merge convention).

Proof: full `GOWORK=off go test ./...` green locally; existing fill-pr-details integration test extended to assert `db_target: "direct"` + `db_target_path`; Codex autoreview clean ("patch is correct").
