### PR TITLE
fix: escalate portable repair failures to the reclone fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.8.7 - Unreleased
 
+### Portable stores
+
+- Escalate reset-pull repair failures to the reclone fallback with a 15-minute backoff so checkouts with broken Git metadata self-heal instead of requiring manual recovery.
+
 ## 0.8.6 - 2026-07-26
 
 ### Portable stores

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -3326,6 +3326,238 @@ func TestReadCommandRepairsMalformedDirtyPortableStore(t *testing.T) {
 	}
 }
 
+type portableRepairFailureFixture struct {
+	dir         string
+	checkoutDir string
+	checkoutDB  string
+	dbRel       string
+	configPath  string
+}
+
+func newPortableRepairFailureFixture(t *testing.T) portableRepairFailureFixture {
+	t.Helper()
+	ctx := context.Background()
+	dir := t.TempDir()
+	remoteDir := filepath.Join(dir, "remote")
+	checkoutDir := filepath.Join(dir, "checkout")
+	dbRel := filepath.Join("data", "openclaw__openclaw.sync.db")
+	if err := os.MkdirAll(filepath.Join(remoteDir, "data"), 0o755); err != nil {
+		t.Fatalf("mkdir remote data: %v", err)
+	}
+	if err := runGit(ctx, remoteDir, "init", "-b", "main"); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	seedPortableThread(t, filepath.Join(remoteDir, dbRel), 1, "portable repair fallback")
+	if err := runGit(ctx, remoteDir, "add", dbRel); err != nil {
+		t.Fatalf("git add seed: %v", err)
+	}
+	if err := runGit(ctx, remoteDir, "-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-m", "seed store"); err != nil {
+		t.Fatalf("git commit seed: %v", err)
+	}
+	if _, err := syncPortableStore(ctx, remoteDir, checkoutDir); err != nil {
+		t.Fatalf("clone portable store: %v", err)
+	}
+	return portableRepairFailureFixture{
+		dir:         dir,
+		checkoutDir: checkoutDir,
+		checkoutDB:  filepath.Join(checkoutDir, dbRel),
+		dbRel:       dbRel,
+		configPath:  filepath.Join(dir, "config.toml"),
+	}
+}
+
+func corruptPortableCheckoutIndex(t *testing.T, checkoutDir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(checkoutDir, ".git", "index"), []byte{0x01, 0x02, 0x03, 0x04}, 0o644); err != nil {
+		t.Fatalf("corrupt checkout index: %v", err)
+	}
+	if err := runGit(context.Background(), "", "-C", checkoutDir, "reset", "--hard", "HEAD"); err == nil {
+		t.Fatal("git reset --hard HEAD unexpectedly accepted the corrupt index")
+	}
+}
+
+func countPortableCheckoutMalformedBackups(t *testing.T, dir string) int {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Join(dir, "backups"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0
+		}
+		t.Fatalf("read portable backups: %v", err)
+	}
+	count := 0
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), "checkout-malformed-") {
+			count++
+		}
+	}
+	return count
+}
+
+func TestPortableRuntimeReclonesWhenRepairFails(t *testing.T) {
+	ctx := context.Background()
+	fixture := newPortableRepairFailureFixture(t)
+	mirrorPath := filepath.Join(fixture.dir, "runtime", fixture.dbRel)
+	statePath := portableStoreRefreshStatePath(mirrorPath)
+	if err := os.WriteFile(fixture.checkoutDB, []byte("not a sqlite database"), 0o600); err != nil {
+		t.Fatalf("corrupt checkout db: %v", err)
+	}
+	corruptPortableCheckoutIndex(t, fixture.checkoutDir)
+
+	repair, repairErr := repairMalformedPortableStoreForDB(ctx, fixture.checkoutDB, fixture.configPath)
+	if repairErr == nil {
+		t.Fatal("repair unexpectedly succeeded with a corrupt Git index")
+	}
+	recordPortableRepairState(statePath, repair, repairErr)
+	if state := readPortableStoreRefreshState(statePath); state.LastRepairError != repairErr.Error() {
+		t.Fatalf("recorded repair error = %q, want %q", state.LastRepairError, repairErr.Error())
+	}
+
+	changed, err := refreshPortableRuntimeDB(ctx, fixture.checkoutDB, mirrorPath, false, fixture.configPath)
+	if err != nil {
+		t.Fatalf("refresh portable runtime db: %v", err)
+	}
+	if !changed {
+		t.Fatal("successful reclone should refresh the runtime mirror")
+	}
+	if err := sqliteStoreHealth(ctx, fixture.checkoutDB); err != nil {
+		t.Fatalf("recloned checkout db should be healthy: %v", err)
+	}
+	if err := sqliteStoreHealth(ctx, mirrorPath); err != nil {
+		t.Fatalf("runtime mirror should be healthy: %v", err)
+	}
+	if err := runGit(ctx, "", "-C", fixture.checkoutDir, "status", "--short"); err != nil {
+		t.Fatalf("recloned checkout git status: %v", err)
+	}
+	if got := countPortableCheckoutMalformedBackups(t, fixture.dir); got != 1 {
+		t.Fatalf("recloned checkout backups = %d, want 1", got)
+	}
+	state := readPortableStoreRefreshState(statePath)
+	if state.LastRecloneAttempt == "" {
+		t.Fatal("last_reclone_attempt should be recorded")
+	}
+	if state.LastRepair != "recloned" {
+		t.Fatalf("last_repair = %q, want recloned", state.LastRepair)
+	}
+}
+
+func TestPortableRuntimeRecloneEscalationBacksOff(t *testing.T) {
+	ctx := context.Background()
+	fixture := newPortableRepairFailureFixture(t)
+	mirrorPath := filepath.Join(fixture.dir, "runtime", fixture.dbRel)
+	if err := copyFileAtomic(fixture.checkoutDB, mirrorPath); err != nil {
+		t.Fatalf("seed healthy mirror: %v", err)
+	}
+	past := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(mirrorPath, past, past); err != nil {
+		t.Fatalf("age healthy mirror: %v", err)
+	}
+	if err := os.WriteFile(fixture.checkoutDB, []byte("not a sqlite database"), 0o600); err != nil {
+		t.Fatalf("corrupt checkout db: %v", err)
+	}
+	corruptPortableCheckoutIndex(t, fixture.checkoutDir)
+
+	statePath := portableStoreRefreshStatePath(mirrorPath)
+	recloneAttempt := time.Now().UTC().Format(time.RFC3339Nano)
+	if err := writePortableStoreRefreshState(statePath, portableStoreRefreshState{LastRecloneAttempt: recloneAttempt}); err != nil {
+		t.Fatalf("write reclone backoff state: %v", err)
+	}
+	backupsBefore := countPortableCheckoutMalformedBackups(t, fixture.dir)
+	changed, err := refreshPortableRuntimeDB(ctx, fixture.checkoutDB, mirrorPath, false, fixture.configPath)
+	if err != nil {
+		t.Fatalf("healthy mirror fallback: %v", err)
+	}
+	if changed {
+		t.Fatal("backed-off reclone should keep serving the existing mirror")
+	}
+	if got := countPortableCheckoutMalformedBackups(t, fixture.dir); got != backupsBefore {
+		t.Fatalf("backed-off reclone created checkout backup: %d -> %d", backupsBefore, got)
+	}
+	if err := sqliteStoreHealth(ctx, mirrorPath); err != nil {
+		t.Fatalf("healthy mirror should remain usable: %v", err)
+	}
+	if err := sqliteStoreHealth(ctx, fixture.checkoutDB); err == nil {
+		t.Fatal("broken checkout database unexpectedly became healthy")
+	}
+	if err := runGit(ctx, "", "-C", fixture.checkoutDir, "status", "--short"); err == nil {
+		t.Fatal("broken checkout Git index unexpectedly became usable")
+	}
+	state := readPortableStoreRefreshState(statePath)
+	if state.LastRecloneAttempt != recloneAttempt {
+		t.Fatalf("last_reclone_attempt = %q, want unchanged %q", state.LastRecloneAttempt, recloneAttempt)
+	}
+	if state.LastRepairError == "" {
+		t.Fatal("failed repair should record last_repair_error")
+	}
+}
+
+func TestPortableRuntimeFailedRecloneStillEstablishesBackoff(t *testing.T) {
+	ctx := context.Background()
+	fixture := newPortableRepairFailureFixture(t)
+	mirrorPath := filepath.Join(fixture.dir, "runtime", fixture.dbRel)
+	if err := copyFileAtomic(fixture.checkoutDB, mirrorPath); err != nil {
+		t.Fatalf("seed healthy mirror: %v", err)
+	}
+	past := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(mirrorPath, past, past); err != nil {
+		t.Fatalf("age healthy mirror: %v", err)
+	}
+	if err := os.WriteFile(fixture.checkoutDB, []byte("not a sqlite database"), 0o600); err != nil {
+		t.Fatalf("corrupt checkout db: %v", err)
+	}
+	// Break repair (corrupt index) AND reclone (unreachable remote) so the
+	// escalation itself fails; the attempt must still stamp the backoff.
+	if err := runGit(ctx, "", "-C", fixture.checkoutDir, "remote", "set-url", "origin", filepath.Join(fixture.dir, "no-such-remote")); err != nil {
+		t.Fatalf("break remote url: %v", err)
+	}
+	corruptPortableCheckoutIndex(t, fixture.checkoutDir)
+
+	statePath := portableStoreRefreshStatePath(mirrorPath)
+	if changed, err := refreshPortableRuntimeDB(ctx, fixture.checkoutDB, mirrorPath, false, fixture.configPath); err != nil || changed {
+		t.Fatalf("failed reclone should fall back to the healthy mirror, changed=%v err=%v", changed, err)
+	}
+	state := readPortableStoreRefreshState(statePath)
+	if state.LastRecloneAttempt == "" {
+		t.Fatal("failed reclone must still record last_reclone_attempt")
+	}
+	firstAttempt := state.LastRecloneAttempt
+
+	if changed, err := refreshPortableRuntimeDB(ctx, fixture.checkoutDB, mirrorPath, false, fixture.configPath); err != nil || changed {
+		t.Fatalf("backed-off retry should keep serving the mirror, changed=%v err=%v", changed, err)
+	}
+	state = readPortableStoreRefreshState(statePath)
+	if state.LastRecloneAttempt != firstAttempt {
+		t.Fatalf("backed-off retry must not re-attempt reclone: %q -> %q", firstAttempt, state.LastRecloneAttempt)
+	}
+}
+
+func TestRecoverMissingPortableSourceReclonesWhenRepairFails(t *testing.T) {
+	ctx := context.Background()
+	fixture := newPortableRepairFailureFixture(t)
+	if err := os.Remove(fixture.checkoutDB); err != nil {
+		t.Fatalf("remove checkout db: %v", err)
+	}
+	corruptPortableCheckoutIndex(t, fixture.checkoutDir)
+
+	statePath := filepath.Join(fixture.dir, "runtime", ".portable-refresh.json")
+	if err := recoverMissingPortableSource(ctx, fixture.checkoutDB, fixture.configPath, statePath); err != nil {
+		t.Fatalf("recover missing portable source: %v", err)
+	}
+	if err := sqliteStoreHealth(ctx, fixture.checkoutDB); err != nil {
+		t.Fatalf("recloned checkout db should be healthy: %v", err)
+	}
+	if err := runGit(ctx, "", "-C", fixture.checkoutDir, "status", "--short"); err != nil {
+		t.Fatalf("recloned checkout git status: %v", err)
+	}
+	state := readPortableStoreRefreshState(statePath)
+	if state.LastRecloneAttempt == "" {
+		t.Fatal("last_reclone_attempt should be recorded")
+	}
+	if state.LastRepair != "recloned" {
+		t.Fatalf("last_repair = %q, want recloned", state.LastRepair)
+	}
+}
+
 func TestRecloneMalformedPortableStorePreservesBranch(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -330,6 +330,16 @@ func refreshPortableRuntimeDB(ctx context.Context, sourceDBPath, mirrorPath stri
 			repair, err := repairMalformedPortableStoreForDB(ctx, sourceDBPath, configPath)
 			recordPortableRepairState(statePath, repair, err)
 			if err != nil {
+				state := readPortableStoreRefreshState(statePath)
+				if !recentPortableRefresh(state.LastRecloneAttempt, time.Now().UTC(), portableSourceRecoveryBackoff) {
+					reclone, recloneErr := recloneMalformedPortableStoreForDB(ctx, sourceDBPath, configPath)
+					recordPortableRepairState(statePath, reclone, recloneErr)
+					if recloneErr == nil {
+						err = nil
+					}
+				}
+			}
+			if err != nil {
 				if !mirrorCorrupt {
 					if mirrorHealthErr := sqliteStoreHealth(ctx, mirrorPath); mirrorHealthErr == nil {
 						return false, nil
@@ -377,12 +387,25 @@ type portableStoreRefreshState struct {
 	LastRepairBackup            string `json:"last_repair_backup,omitempty"`
 	LastRepairAt                string `json:"last_repair_at,omitempty"`
 	LastRepairError             string `json:"last_repair_error,omitempty"`
+	LastRecloneAttempt          string `json:"last_reclone_attempt,omitempty"`
 }
 
 func recoverMissingPortableSource(ctx context.Context, sourceDBPath, configPath, statePath string) error {
 	repair, err := repairMalformedPortableStoreForDB(ctx, sourceDBPath, configPath)
 	recordPortableRepairState(statePath, repair, err)
 	if err != nil {
+		state := readPortableStoreRefreshState(statePath)
+		if !recentPortableRefresh(state.LastRecloneAttempt, time.Now().UTC(), portableSourceRecoveryBackoff) {
+			reclone, recloneErr := recloneMalformedPortableStoreForDB(ctx, sourceDBPath, configPath)
+			recordPortableRepairState(statePath, reclone, recloneErr)
+			if recloneErr == nil {
+				// The caller re-stats the source and falls back to a healthy
+				// mirror if the recloned store still lacks the database;
+				// falling through here would reclone a second time.
+				return nil
+			}
+			return fmt.Errorf("repair malformed portable store db: %w; reclone fallback: %v", err, recloneErr)
+		}
 		return fmt.Errorf("repair malformed portable store db: %w", err)
 	}
 	if _, statErr := os.Stat(sourceDBPath); errors.Is(statErr, os.ErrNotExist) {
@@ -487,8 +510,12 @@ func recordPortableRepairState(path string, result portableRepairResult, repairE
 		return
 	}
 	state := readPortableStoreRefreshState(path)
+	now := time.Now().UTC().Format(time.RFC3339Nano)
 	state.LastRepair = result.Action
-	state.LastRepairAt = time.Now().UTC().Format(time.RFC3339Nano)
+	state.LastRepairAt = now
+	if result.Action == "recloned" {
+		state.LastRecloneAttempt = now
+	}
 	state.LastRepairBackup = result.DBBackupPath
 	if result.StoreBackupPath != "" {
 		state.LastRepairBackup = result.StoreBackupPath
@@ -498,6 +525,10 @@ func recordPortableRepairState(path string, result portableRepairResult, repairE
 	} else {
 		state.LastRepairError = ""
 	}
+	// The state file gates repair/reclone backoffs; without its parent
+	// directory (fresh install, mirror never created) a silent write failure
+	// would leave recovery attempts unbounded.
+	_ = os.MkdirAll(filepath.Dir(path), 0o755)
 	_ = writePortableStoreRefreshState(path, state)
 }
 


### PR DESCRIPTION
Follow-up to #128.

When reset/pull repair fails—corrupt Git index/metadata, the class behind the 2026-07-26 broken-checkout incident—both the corruption and missing-source recovery paths now escalate to the existing reclone fallback.

Reclone attempts are bounded by a 15-minute backoff on a new `last_reclone_attempt` stamp recorded for successful and failed attempts. The state directory is created before persisting the stamp so fresh installs cannot loop unbounded. Healthy-mirror fallbacks are preserved.

Proof:

- Four new regression tests: successful escalation with deterministic repair failure via a truncated `.git/index`, pre-seeded backoff, failed-reclone-still-stamps-backoff across two reads, and missing-source escalation.
- Full suite green, with a `-count=2` flake check on the new tests.
- Autoreview clean: "patch is correct."
