### PR TITLE
chore(release): prepare 0.8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.8.8 - Unreleased
+## 0.8.8 - 2026-08-01
 
 ### Maintenance
 


### PR DESCRIPTION
## Summary

- date the 0.8.8 changelog section as required by the canonical release guide

## Proof

- `git diff --check`
- autoreview clean with no accepted or actionable findings

This is the non-credentialed release-preparation step. Tag signing and workflow dispatch remain gated by the repository's SSH-signed-tag requirement.
