### PR TITLE
ci(release): delegate tag creation

### DIFF
--- a/.github/release-allowed-signers
+++ b/.github/release-allowed-signers
@@ -1,1 +1,0 @@
-steipete@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII9XsaCcr8TInPnHcuTVfvXXcsoUFrOE7menfbEIHFW9 steipete@gmail.com

--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -28,7 +28,6 @@ jobs:
       checksum-filename: checksums.txt
       nfpm: auto
       stable-identifier: org.openclaw.gitcrawl
-      require-signed-tag: true
       darwin-universal: disabled
       ci-check-events: '["push","pull_request"]'
     secrets:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -5,7 +5,7 @@ permalink: /releasing/
 
 # Releasing Gitcrawl
 
-`.github/workflows/release-unified.yml` is the only official release path. It calls `openclaw/release-workflows@v1` from protected `main`, requires an existing SSH-signed version tag, preserves Gitcrawl's six thin platform archives and `checksums.txt`, signs and notarizes both macOS binaries as `org.openclaw.gitcrawl`, verifies the complete asset inventory independently on arm64 and Intel macOS, and waits for `openclaw/homebrew-tap` to update successfully.
+`.github/workflows/release-unified.yml` is the only official release path. It calls `openclaw/release-workflows@v1` from protected `main`, creates and owns the immutable annotated version tag, preserves Gitcrawl's six thin platform archives and `checksums.txt`, signs and notarizes both macOS binaries as `org.openclaw.gitcrawl`, verifies the complete asset inventory independently on arm64 and Intel macOS, and waits for `openclaw/homebrew-tap` to update successfully.
 
 The public compatibility contract remains:
 
@@ -19,14 +19,13 @@ The shared pipeline also publishes verifier control assets (`ASSET-INVENTORY.jso
 
 ## Release
 
-Prepare a dated changelog section and land it on protected `main`. The `user.signingkey` SSH key must be listed for your principal in `.github/release-allowed-signers`. Create the annotated signed tag, verify it explicitly against the repository allowlist, push it, and dispatch the workflow:
+Prepare a dated changelog section, land it on protected `main`, and dispatch the workflow:
 
 ```sh
-git -c gpg.format=ssh tag -s vX.Y.Z -m "Release X.Y.Z"
-git -c gpg.format=ssh -c gpg.ssh.allowedSignersFile=.github/release-allowed-signers tag -v vX.Y.Z
-git push origin vX.Y.Z
 gh workflow run release-unified.yml --repo openclaw/gitcrawl -f version=X.Y.Z
 ```
+
+The first run freezes the exact protected `main` head with an immutable annotated tag. Retries reuse that tag and target commit. Tagging, signing, notarization, and Homebrew delivery use only GitHub Actions and repository or organization secrets; maintainers need no local release credentials.
 
 The release is complete only when the GitHub Release contains the full asset set, both native macOS verification jobs pass, and the Homebrew handoff is green.
 

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -174,8 +174,15 @@ grep -F 'uses: openclaw/release-workflows/.github/workflows/release-go-cli.yml@v
 grep -F 'checksum-filename: checksums.txt' "$release_workflow" >/dev/null
 grep -F 'archive-files: '\''["CHANGELOG.md","LICENSE","README.md"]'\''' "$release_workflow" >/dev/null
 grep -F 'stable-identifier: org.openclaw.gitcrawl' "$release_workflow" >/dev/null
-grep -F 'require-signed-tag: true' "$release_workflow" >/dev/null
 grep -F 'darwin-universal: disabled' "$release_workflow" >/dev/null
+if grep -F 'require-signed-tag:' "$release_workflow" >/dev/null; then
+  echo "unified release must own the annotated tag" >&2
+  exit 1
+fi
+if [[ -e "$ROOT/.github/release-allowed-signers" ]]; then
+  echo "unified release must not require a local tag-signing allowlist" >&2
+  exit 1
+fi
 if grep -R -F 'NOTARYTOOL_KEYCHAIN_PROFILE' "$ROOT/.github/workflows" >/dev/null; then
   echo "notary profile must not be configured in GitHub Actions" >&2
   exit 1


### PR DESCRIPTION
## Summary

- let `release-go-cli.yml@v1` create and own the immutable annotated release tag
- remove the obsolete local SSH tag-signing allowlist and instructions
- retain Gitcrawl's archive, checksum, signing identifier, thin Darwin, and Homebrew compatibility inputs
- assert the workflow-owned tag model in release regression tests

## Variant selection

`openclaw/release-workflows@v1` currently exposes one reusable release variant: `release-go-cli.yml`. Gitcrawl is a Go CLI with the required GoReleaser Darwin matrix, so it matches that archetype. `openclaw/homebrew-tap` already contains `Formula/gitcrawl.rb`, so the handoff remains enabled with `nfpm: auto`.

## Proof

- `make test-release`
- `actionlint .github/workflows/release-unified.yml`
- `git diff --check`
- autoreview clean with no accepted or actionable findings
