### PR TITLE
fix(release): accept workflow archive paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Maintenance
+
+- Update `actions/stale` to v11 and expose its debug-only mode for safe manual policy validation.
+- Accept the shared release workflow's leading `./` archive-member notation in local release verification.
+
 ## 0.8.8 - 2026-08-01
 
 ### Maintenance

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -138,7 +138,7 @@ for arch in amd64 arm64; do
   cp "$test_binary" "$stage/gitcrawl"
   cp "$ROOT/CHANGELOG.md" "$ROOT/LICENSE" "$ROOT/README.md" "$stage/"
   archive="gitcrawl_0.7.1_darwin_${arch}.tar.gz"
-  tar -czf "$ARTIFACTS/$archive" -C "$stage" CHANGELOG.md LICENSE README.md gitcrawl
+  tar -czf "$ARTIFACTS/$archive" -C "$stage" .
   shasum -a 256 "$ARTIFACTS/$archive" | awk -v name="$archive" '{ print $1 "  " name }' >> "$ARTIFACTS/checksums.txt"
 done
 

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -57,7 +57,7 @@ for goarch in "${architectures[@]}"; do
   }
 
   expected_listing=$'CHANGELOG.md\nLICENSE\nREADME.md\ngitcrawl'
-  actual_listing=$(tar -tzf "$archive" | LC_ALL=C sort)
+  actual_listing=$(tar -tzf "$archive" | sed -E 's#^\./##' | sed '/^$/d' | LC_ALL=C sort)
   [[ "$actual_listing" == "$expected_listing" ]] || {
     echo "unexpected archive contents: $archive" >&2
     exit 1


### PR DESCRIPTION
## Summary

- accept the shared release workflow's leading `./` tar-member notation in the local Darwin verifier
- exercise that exact archive layout in the release regression fixture
- record the `actions/stale` v11 update and verifier fix under the next Unreleased section

## Proof

- `make test-release`
- `bash -n scripts/verify-release.sh scripts/test-release.sh`
- `scripts/verify-release.sh v0.8.8 <downloaded-release-assets>` against the published 0.8.8 artifacts; both signed Darwin binaries passed designated-requirement, architecture, embedded-version, and online notarization checks
- `git diff --check`
- autoreview clean with no accepted or actionable findings
