### PR TITLE
test: make token fallback hermetic

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -66,10 +66,11 @@ type App struct {
 	Stdout io.Writer
 	Stderr io.Writer
 
-	configPath          string
-	format              OutputFormat
-	getWorkingDirectory func() (string, error)
-	dbTargetNoticeOnce  sync.Once
+	configPath            string
+	format                OutputFormat
+	getWorkingDirectory   func() (string, error)
+	githubAuthTokenLookup func(context.Context) (string, error)
+	dbTargetNoticeOnce    sync.Once
 }
 
 type initResult struct {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -2140,7 +2140,12 @@ func TestCloudPublishStageOnlyThenResumesDefaultCutover(t *testing.T) {
 			stagedDatasetGeneratedAt = result.DatasetGeneratedAt
 			if stagedDatasetGeneratedAt != concurrentDatasetGeneratedAt ||
 				result.MutationToken != "" {
-				t.Fatalf("stage-only did not bind its generation: %#v", result)
+				t.Fatalf(
+					"stage-only generation mismatch: generation_matches=%t mutation_token_present=%t mutation_token_length=%d",
+					stagedDatasetGeneratedAt == concurrentDatasetGeneratedAt,
+					result.MutationToken != "",
+					len(result.MutationToken),
+				)
 			}
 			time.Sleep(2 * time.Millisecond)
 		}
@@ -2161,7 +2166,7 @@ func TestCloudPublishStageOnlyThenResumesDefaultCutover(t *testing.T) {
 				)
 			}
 			if result.MutationToken != "" {
-				t.Fatalf("resumed publish minted mutation token %q", result.MutationToken)
+				t.Fatalf("resumed publish minted mutation token: length=%d", len(result.MutationToken))
 			}
 		}
 	}
@@ -2389,7 +2394,13 @@ func TestRemoteLoginStoresKeyringToken(t *testing.T) {
 		t.Fatalf("remote login: %v", err)
 	}
 	if pollSecretHash == "" || pollSecret == "" || crawlremote.LoginPollSecretHash(pollSecret) != pollSecretHash {
-		t.Fatalf("poll secret/hash not linked: secret=%q hash=%q", pollSecret, pollSecretHash)
+		t.Fatalf(
+			"poll secret/hash not linked: secret_present=%t secret_length=%d hash_present=%t hash_length=%d",
+			pollSecret != "",
+			len(pollSecret),
+			pollSecretHash != "",
+			len(pollSecretHash),
+		)
 	}
 	cfg, err := config.Load(configPath)
 	if err != nil {
@@ -2403,7 +2414,7 @@ func TestRemoteLoginStoresKeyringToken(t *testing.T) {
 		t.Fatalf("keyring get: %v", err)
 	}
 	if stored != "session-token" {
-		t.Fatalf("stored token = %q", stored)
+		t.Fatalf("stored token mismatch: present=%t length=%d", stored != "", len(stored))
 	}
 
 	whoami := New()
@@ -2461,7 +2472,7 @@ func TestRemoteLoginWithGitHubTokenEnvStoresKeyringToken(t *testing.T) {
 		t.Fatalf("remote login: %v", err)
 	}
 	if sawToken != "github-token" {
-		t.Fatalf("github token = %q", sawToken)
+		t.Fatalf("github token mismatch: present=%t length=%d", sawToken != "", len(sawToken))
 	}
 	if !strings.Contains(out.String(), `"login_method": "github-token"`) {
 		t.Fatalf("login output = %s", out.String())
@@ -2475,7 +2486,7 @@ func TestRemoteLoginWithGitHubTokenEnvStoresKeyringToken(t *testing.T) {
 		t.Fatalf("keyring get: %v", err)
 	}
 	if stored != "session-token" {
-		t.Fatalf("stored token = %q", stored)
+		t.Fatalf("stored token mismatch: present=%t length=%d", stored != "", len(stored))
 	}
 
 	whoami := New()
@@ -2995,7 +3006,7 @@ func TestSameGitRemoteIgnoresHTTPSCredentials(t *testing.T) {
 func TestGitRemoteForMessageRedactsURLCredentials(t *testing.T) {
 	got := gitRemoteForMessage("https://user:secret@example.com/org/store.git")
 	if strings.Contains(got, "user") || strings.Contains(got, "secret") {
-		t.Fatalf("remote message leaked credentials: %q", got)
+		t.Fatal("remote message leaked credentials")
 	}
 	if got != "https://example.com/org/store.git" {
 		t.Fatalf("remote message = %q, want sanitized URL", got)
@@ -5840,7 +5851,7 @@ func TestCommandFlowCoversSearchEmbedNeighborsClusterDetailRunsAndRefresh(t *tes
 			t.Fatalf("unexpected OpenAI path: %s", r.URL.Path)
 		}
 		if got := r.Header.Get("Authorization"); got != "Bearer test-openai-key" {
-			t.Fatalf("authorization = %q", got)
+			t.Fatalf("authorization mismatch: present=%t length=%d", got != "", len(got))
 		}
 		var payload struct {
 			Input []string `json:"input"`
@@ -6289,7 +6300,7 @@ func TestSyncCommandUsesConfiguredGitHubBaseURLAndHydratesComments(t *testing.T)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer test-gh-token" {
-			t.Fatalf("authorization = %q", got)
+			t.Fatalf("authorization mismatch: present=%t length=%d", got != "", len(got))
 		}
 		switch r.URL.Path {
 		case "/repos/openclaw/openclaw":
@@ -6459,7 +6470,7 @@ func TestFillPRDetailsHydratesMissingPullRequestDetails(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer test-gh-token" {
-			t.Fatalf("authorization = %q", got)
+			t.Fatalf("authorization mismatch: present=%t length=%d", got != "", len(got))
 		}
 		w.Header().Set("X-RateLimit-Limit", "5000")
 		w.Header().Set("X-RateLimit-Remaining", "4990")
@@ -6710,7 +6721,7 @@ func TestFillPRDetailsReserveRateLimitStopsBeforeCrossingDuringBatch(t *testing.
 	var coreCalls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer test-gh-token" {
-			t.Fatalf("authorization = %q", got)
+			t.Fatalf("authorization mismatch: present=%t length=%d", got != "", len(got))
 		}
 		if r.URL.Path == "/rate_limit" {
 			remaining := 12 - int(rateStatusCalls.Add(1))

--- a/internal/cli/cloud_commands_test.go
+++ b/internal/cli/cloud_commands_test.go
@@ -162,7 +162,7 @@ func TestSendSnapshotIngestDatasetStreamsBoundedBatches(t *testing.T) {
 		t.Fatalf("stream dataset: %v", err)
 	}
 	if progress.RowsAccepted != 501 || progress.MutationToken != "mutation-3" {
-		t.Fatalf("progress = %#v", progress)
+		t.Fatalf("progress mismatch: rows_accepted=%d mutation_token_present=%t mutation_token_length=%d", progress.RowsAccepted, progress.MutationToken != "", len(progress.MutationToken))
 	}
 	if len(requests) != 3 {
 		t.Fatalf("requests = %d, want 3", len(requests))
@@ -253,7 +253,7 @@ func TestSendSnapshotIngestDatasetFlushesBeforeEncodedByteLimit(t *testing.T) {
 		t.Fatalf("stream byte-bounded dataset: %v", err)
 	}
 	if progress.RowsAccepted != 3 || progress.MutationToken != "mutation-3" {
-		t.Fatalf("progress = %#v", progress)
+		t.Fatalf("progress mismatch: rows_accepted=%d mutation_token_present=%t mutation_token_length=%d", progress.RowsAccepted, progress.MutationToken != "", len(progress.MutationToken))
 	}
 	if len(requests) != 3 {
 		t.Fatalf("requests = %d, want one per large row", len(requests))
@@ -331,7 +331,7 @@ func TestSendSnapshotIngestRowsFlushesBeforeEncodedByteLimit(t *testing.T) {
 		t.Fatalf("send byte-bounded rows: %v", err)
 	}
 	if progress.RowsAccepted != 3 || progress.MutationToken != "mutation-3" {
-		t.Fatalf("progress = %#v", progress)
+		t.Fatalf("progress mismatch: rows_accepted=%d mutation_token_present=%t mutation_token_length=%d", progress.RowsAccepted, progress.MutationToken != "", len(progress.MutationToken))
 	}
 	if len(requests) != 3 {
 		t.Fatalf("requests = %d, want one per large row", len(requests))

--- a/internal/cli/github_token.go
+++ b/internal/cli/github_token.go
@@ -16,7 +16,11 @@ func (a *App) resolveGitHubToken(ctx context.Context, cfg config.Config) config.
 	if token.Value != "" {
 		return token
 	}
-	if value, err := a.githubAuthToken(ctx); err == nil && value != "" {
+	lookup := a.githubAuthToken
+	if a.githubAuthTokenLookup != nil {
+		lookup = a.githubAuthTokenLookup
+	}
+	if value, err := lookup(ctx); err == nil && value != "" {
 		return config.TokenResolution{Value: value, Source: "gh auth token"}
 	}
 	return token

--- a/internal/cli/github_token_test.go
+++ b/internal/cli/github_token_test.go
@@ -13,35 +13,31 @@ import (
 )
 
 func TestResolveGitHubTokenFallsBackToGHAuthToken(t *testing.T) {
-	dir := t.TempDir()
-	ghPath := filepath.Join(dir, "gh")
-	if err := os.WriteFile(ghPath, []byte("#!/bin/sh\nif [ \"$1\" = auth ] && [ \"$2\" = token ]; then echo gh-fallback-token; exit 0; fi\nexit 1\n"), 0o755); err != nil {
-		t.Fatalf("write fake gh: %v", err)
-	}
 	t.Setenv("GITHUB_TOKEN", "")
-	t.Setenv("GITCRAWL_GH_PATH", ghPath)
 
-	token := New().resolveGitHubToken(context.Background(), config.Default())
+	app := New()
+	app.githubAuthTokenLookup = func(context.Context) (string, error) {
+		return "gh-fallback-token", nil
+	}
+	token := app.resolveGitHubToken(context.Background(), config.Default())
 	if token.Value != "gh-fallback-token" || token.Source != "gh auth token" {
-		t.Fatalf("token = %#v", token)
+		t.Fatalf("token mismatch: source=%q value_present=%t value_length=%d", token.Source, token.Value != "", len(token.Value))
 	}
 }
 
 func TestDoctorReportsGHAuthTokenFallback(t *testing.T) {
 	dir := t.TempDir()
-	ghPath := filepath.Join(dir, "gh")
-	if err := os.WriteFile(ghPath, []byte("#!/bin/sh\nif [ \"$1\" = auth ] && [ \"$2\" = token ]; then echo gh-fallback-token; exit 0; fi\nexit 1\n"), 0o755); err != nil {
-		t.Fatalf("write fake gh: %v", err)
-	}
 	configPath := filepath.Join(dir, "config.toml")
 	dbPath := filepath.Join(dir, "gitcrawl.db")
 	if err := os.WriteFile(configPath, []byte("version = 1\ndb_path = "+strconv.Quote(dbPath)+"\n[github]\ntoken_env = 'GITHUB_TOKEN'\n"), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 	t.Setenv("GITHUB_TOKEN", "")
-	t.Setenv("GITCRAWL_GH_PATH", ghPath)
 
 	doctor := New()
+	doctor.githubAuthTokenLookup = func(context.Context) (string, error) {
+		return "gh-fallback-token", nil
+	}
 	var stdout bytes.Buffer
 	doctor.Stdout = &stdout
 	if err := doctor.Run(context.Background(), []string{"--config", configPath, "doctor", "--json"}); err != nil {
@@ -49,12 +45,12 @@ func TestDoctorReportsGHAuthTokenFallback(t *testing.T) {
 	}
 	var payload map[string]any
 	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
-		t.Fatalf("parse doctor json: %v\n%s", err, stdout.String())
+		t.Fatalf("parse doctor json: %v (output_bytes=%d)", err, stdout.Len())
 	}
 	if got := payload["github_token_present"]; got != true {
-		t.Fatalf("github_token_present = %#v, payload=%s", got, stdout.String())
+		t.Fatalf("github_token_present = %#v", got)
 	}
 	if got := payload["github_token_source"]; got != "gh auth token" {
-		t.Fatalf("github_token_source = %#v, payload=%s", got, stdout.String())
+		t.Fatalf("github_token_source = %#v", got)
 	}
 }

--- a/internal/cli/remote_commands_test.go
+++ b/internal/cli/remote_commands_test.go
@@ -81,7 +81,13 @@ func TestPollRemoteLoginStates(t *testing.T) {
 			t.Fatalf("poll login: %v", err)
 		}
 		if result.Token != "session-token" || polls != 2 {
-			t.Fatalf("result=%#v polls=%d", result, polls)
+			t.Fatalf(
+				"poll result mismatch: status=%q token_present=%t token_length=%d polls=%d",
+				result.Status,
+				result.Token != "",
+				len(result.Token),
+				polls,
+			)
 		}
 	})
 
@@ -154,10 +160,10 @@ func TestSendIngestRowsBatchesAndFinalizes(t *testing.T) {
 		t.Fatalf("requests len = %d", len(requests))
 	}
 	if requests[0].Cursor != "" || requests[0].Final || len(requests[0].Rows) != gitcrawlCloudBatchSize {
-		t.Fatalf("first request = %#v", requests[0])
+		t.Fatalf("first request mismatch: cursor=%q final=%t rows=%d", requests[0].Cursor, requests[0].Final, len(requests[0].Rows))
 	}
 	if requests[1].Cursor != "250" || !requests[1].Final || len(requests[1].Rows) != 1 {
-		t.Fatalf("second request = %#v", requests[1])
+		t.Fatalf("second request mismatch: cursor=%q final=%t rows=%d", requests[1].Cursor, requests[1].Final, len(requests[1].Rows))
 	}
 }
 
@@ -207,16 +213,16 @@ func TestSendSnapshotIngestRowsRotatesMutationTokens(t *testing.T) {
 		t.Fatalf("send snapshot ingest: %v", err)
 	}
 	if progress.RowsAccepted != int64(len(rows)) || progress.MutationToken != "generation-2" {
-		t.Fatalf("progress = %#v", progress)
+		t.Fatalf("progress mismatch: rows_accepted=%d mutation_token_present=%t mutation_token_length=%d", progress.RowsAccepted, progress.MutationToken != "", len(progress.MutationToken))
 	}
 	if len(requests) != 2 {
-		t.Fatalf("requests = %#v", requests)
+		t.Fatalf("requests length = %d, want 2", len(requests))
 	}
 	if requests[0].Cursor != "" || requests[0].MutationToken != "previous-dataset" {
-		t.Fatalf("first request = %#v", requests[0])
+		t.Fatalf("first request mismatch: cursor=%q mutation_token_present=%t mutation_token_length=%d", requests[0].Cursor, requests[0].MutationToken != "", len(requests[0].MutationToken))
 	}
 	if requests[1].Cursor != "250" || requests[1].MutationToken != "generation-1" || !requests[1].Final {
-		t.Fatalf("second request = %#v", requests[1])
+		t.Fatalf("second request mismatch: cursor=%q final=%t mutation_token_present=%t mutation_token_length=%d", requests[1].Cursor, requests[1].Final, requests[1].MutationToken != "", len(requests[1].MutationToken))
 	}
 }
 
@@ -287,17 +293,20 @@ func TestSendIngestRowsDrainsRemoteResetBeforeRetry(t *testing.T) {
 		t.Fatalf("send ingest: %v", err)
 	}
 	if progress.RowsAccepted != 1 || progress.MutationToken != "generation-current" {
-		t.Fatalf("progress = %#v", progress)
+		t.Fatalf("progress mismatch: rows_accepted=%d mutation_token_present=%t mutation_token_length=%d", progress.RowsAccepted, progress.MutationToken != "", len(progress.MutationToken))
 	}
 	if resetCalls != 2 {
 		t.Fatalf("resetCalls = %d", resetCalls)
 	}
-	if len(requests) != 1 || requests[0].Cursor != "" || !requests[0].Final {
-		t.Fatalf("data requests = %#v", requests)
+	if len(requests) != 1 {
+		t.Fatalf("data requests length = %d, want 1", len(requests))
+	}
+	if requests[0].Cursor != "" || !requests[0].Final {
+		t.Fatalf("data request mismatch: cursor=%q final=%t", requests[0].Cursor, requests[0].Final)
 	}
 	for index, request := range drainRequests {
 		if request.MutationToken != "generation-current" {
-			t.Fatalf("drain request %d mutation token = %q", index, request.MutationToken)
+			t.Fatalf("drain request %d mutation token mismatch: present=%t length=%d", index, request.MutationToken != "", len(request.MutationToken))
 		}
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -319,10 +319,10 @@ func TestResolveTokens(t *testing.T) {
 
 	cfg := Default()
 	if got := ResolveGitHubToken(cfg); got.Value != "ghp_test" || got.Source != "GITHUB_TOKEN" {
-		t.Fatalf("github token resolution mismatch: %#v", got)
+		t.Fatalf("github token resolution mismatch: source=%q value_present=%t value_length=%d", got.Source, got.Value != "", len(got.Value))
 	}
 	if got := ResolveOpenAIKey(cfg); got.Value != "sk_test" || got.Source != "OPENAI_API_KEY" {
-		t.Fatalf("openai key resolution mismatch: %#v", got)
+		t.Fatalf("openai key resolution mismatch: source=%q value_present=%t value_length=%d", got.Source, got.Value != "", len(got.Value))
 	}
 
 	t.Setenv("GITHUB_TOKEN", "")
@@ -332,19 +332,19 @@ func TestResolveTokens(t *testing.T) {
 	t.Setenv("CUSTOM_GITHUB_TOKEN", "custom-gh")
 	t.Setenv("CUSTOM_OPENAI_KEY", "custom-openai")
 	if got := ResolveGitHubToken(cfg); got.Value != "custom-gh" || got.Source != "CUSTOM_GITHUB_TOKEN" {
-		t.Fatalf("custom github token mismatch: %#v", got)
+		t.Fatalf("custom github token mismatch: source=%q value_present=%t value_length=%d", got.Source, got.Value != "", len(got.Value))
 	}
 	if got := ResolveOpenAIKey(cfg); got.Value != "custom-openai" || got.Source != "CUSTOM_OPENAI_KEY" {
-		t.Fatalf("custom openai key mismatch: %#v", got)
+		t.Fatalf("custom openai key mismatch: source=%q value_present=%t value_length=%d", got.Source, got.Value != "", len(got.Value))
 	}
 
 	t.Setenv("CUSTOM_GITHUB_TOKEN", "")
 	t.Setenv("CUSTOM_OPENAI_KEY", "")
 	if got := ResolveGitHubToken(cfg); got.Value != "" || got.Source != "" {
-		t.Fatalf("empty github token mismatch: %#v", got)
+		t.Fatalf("empty github token mismatch: source=%q value_present=%t value_length=%d", got.Source, got.Value != "", len(got.Value))
 	}
 	if got := ResolveOpenAIKey(cfg); got.Value != "" || got.Source != "" {
-		t.Fatalf("empty openai key mismatch: %#v", got)
+		t.Fatalf("empty openai key mismatch: source=%q value_present=%t value_length=%d", got.Source, got.Value != "", len(got.Value))
 	}
 }
 
@@ -358,15 +358,15 @@ func TestResolveTokensFromConfigEnv(t *testing.T) {
 		"OPENAI_API_KEY": "config-openai",
 	}
 	if got := ResolveGitHubToken(cfg); got.Value != "config-gh" || got.Source != "config.toml [env].GITHUB_TOKEN" {
-		t.Fatalf("github token config env mismatch: %#v", got)
+		t.Fatalf("github token config env mismatch: source=%q value_present=%t value_length=%d", got.Source, got.Value != "", len(got.Value))
 	}
 	if got := ResolveOpenAIKey(cfg); got.Value != "config-openai" || got.Source != "config.toml [env].OPENAI_API_KEY" {
-		t.Fatalf("openai key config env mismatch: %#v", got)
+		t.Fatalf("openai key config env mismatch: source=%q value_present=%t value_length=%d", got.Source, got.Value != "", len(got.Value))
 	}
 
 	t.Setenv("GITHUB_TOKEN", "process-gh")
 	if got := ResolveGitHubToken(cfg); got.Value != "process-gh" || got.Source != "GITHUB_TOKEN" {
-		t.Fatalf("process env should win: %#v", got)
+		t.Fatalf("process env should win: source=%q value_present=%t value_length=%d", got.Source, got.Value != "", len(got.Value))
 	}
 }
 
@@ -384,15 +384,15 @@ func TestResolveTokensFromCustomConfigEnv(t *testing.T) {
 		"OPENAI_API_KEY":      "ignored-default-openai",
 	}
 	if got := ResolveGitHubToken(cfg); got.Value != "config-custom-gh" || got.Source != "config.toml [env].CUSTOM_GITHUB_TOKEN" {
-		t.Fatalf("custom github token config env mismatch: %#v", got)
+		t.Fatalf("custom github token config env mismatch: source=%q value_present=%t value_length=%d", got.Source, got.Value != "", len(got.Value))
 	}
 	if got := ResolveOpenAIKey(cfg); got.Value != "config-custom-openai" || got.Source != "config.toml [env].CUSTOM_OPENAI_KEY" {
-		t.Fatalf("custom openai key config env mismatch: %#v", got)
+		t.Fatalf("custom openai key config env mismatch: source=%q value_present=%t value_length=%d", got.Source, got.Value != "", len(got.Value))
 	}
 
 	cfg.Env["CUSTOM_GITHUB_TOKEN"] = "   "
 	if got := ResolveGitHubToken(cfg); got.Value != "" || got.Source != "" {
-		t.Fatalf("empty config env should be ignored: %#v", got)
+		t.Fatalf("empty config env should be ignored: source=%q value_present=%t value_length=%d", got.Source, got.Value != "", len(got.Value))
 	}
 }
 

--- a/internal/config/remote_token_test.go
+++ b/internal/config/remote_token_test.go
@@ -40,7 +40,7 @@ func TestRemoteTokenResolutionWithKeyring(t *testing.T) {
 		t.Fatalf("resolve env token: %v", err)
 	}
 	if resolved.Value != "env-session" || resolved.Source != "GITCRAWL_TEST_REMOTE_TOKEN" {
-		t.Fatalf("env token = %#v", resolved)
+		t.Fatalf("env token mismatch: source=%q value_present=%t value_length=%d", resolved.Source, resolved.Value != "", len(resolved.Value))
 	}
 
 	t.Setenv("GITCRAWL_TEST_REMOTE_TOKEN", "")
@@ -57,7 +57,7 @@ func TestRemoteTokenResolutionWithKeyring(t *testing.T) {
 		t.Fatalf("resolve keyring token: %v", err)
 	}
 	if resolved.Value != "keyring-session" || resolved.Source != "keyring" {
-		t.Fatalf("keyring token = %#v", resolved)
+		t.Fatalf("keyring token mismatch: source=%q value_present=%t value_length=%d", resolved.Source, resolved.Value != "", len(resolved.Value))
 	}
 
 	cfg.Remote.Auth.TokenSource = "none"

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -27,8 +27,8 @@ func writeRateLimits(t *testing.T, w http.ResponseWriter, resetAt time.Time, cor
 
 func TestListRepositoryIssuesPaginatesAndLimits(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") != "Bearer token" {
-			t.Fatalf("missing auth header: %q", r.Header.Get("Authorization"))
+		if got := r.Header.Get("Authorization"); got != "Bearer token" {
+			t.Fatalf("auth header mismatch: present=%t length=%d", got != "", len(got))
 		}
 		switch r.URL.Query().Get("page") {
 		case "":

--- a/internal/openai/summaries_test.go
+++ b/internal/openai/summaries_test.go
@@ -18,7 +18,7 @@ func TestSummarizeUsesResponsesOutputText(t *testing.T) {
 			t.Fatalf("path = %q", r.URL.Path)
 		}
 		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
-			t.Fatalf("authorization = %q", got)
+			t.Fatalf("authorization mismatch: present=%t length=%d", got != "", len(got))
 		}
 		var request summaryRequest
 		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {

--- a/internal/store/sync_failures_test.go
+++ b/internal/store/sync_failures_test.go
@@ -402,6 +402,6 @@ func assertPortableFileDoesNotContain(t *testing.T, path, value string) {
 		t.Fatalf("read portable database bytes: %v", err)
 	}
 	if bytes.Contains(data, []byte(value)) {
-		t.Fatalf("portable database retains scrubbed value %q", value)
+		t.Fatal("portable database retains a scrubbed credential value")
 	}
 }


### PR DESCRIPTION
## Summary

- inject the GitHub CLI token lookup in fallback tests so they cannot execute the real `gh` binary
- remove the subprocess timeout dependency from the fallback and doctor tests
- keep credential-bearing assertion failures useful without printing token, secret, or authorization values

## Root cause

The fallback test configured a fake `gh`, but production lookup continued to system `gh` candidates if the fake process exceeded its three-second timeout. Under load, that made the test both flaky and capable of reading a real authenticated token. Its failure assertion then formatted the complete token resolution.

## Verification

- `CI=true go test ./internal/cli -run '^TestResolveGitHubTokenFallsBackToGHAuthToken$' -count=20`
- `CI=true make check`
- canonical Codex autoreview: clean, no accepted/actionable findings
