### PR TITLE
feat(portable): add current-state export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Portable stores
 
-- Add streamlined `portable export` generations with atomic validation, patch-free repository scoping, counted manifests, progress diagnostics, and clean interruption.
+- Add streamlined `portable export` generations with chunked online backups, compact final files, atomic validation, progress diagnostics, and clean interruption.
 
 ## 0.9.0 - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Portable stores
+
+- Add `portable export` with the `current-state-v1` profile for atomic, validated, size-bounded derived database generations that leave the active archive unchanged.
+
 ## 0.9.0 - 2026-08-08
 
 ### Portable stores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Portable stores
 
-- Add `portable export` with the `current-state-v1` profile for atomic, validated, size-bounded derived database generations that leave the active archive unchanged.
+- Add `portable export` with the `current-state-v1` profile for atomic, validated, optionally repository-scoped derived database generations with counted manifests that leave the active archive unchanged.
 
 ## 0.9.0 - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Portable stores
 
-- Add streamlined `portable export` generations with chunked online backups, journal-free staging, compact final files, granular progress, and clean interruption.
+- Add streamlined `portable export` generations with sanitized compatibility columns, journal-free staging, compact final files, granular progress, and clean interruption.
 
 ## 0.9.0 - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Portable stores
 
-- Add `portable export` with the `current-state-v1` profile for atomic, validated, patch-free, optionally repository-scoped generations with counted manifests that leave the active archive unchanged.
+- Add streamlined `portable export` generations with atomic validation, patch-free repository scoping, counted manifests, progress diagnostics, and clean interruption.
 
 ## 0.9.0 - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Portable stores
 
-- Add streamlined `portable export` generations with chunked online backups, compact final files, atomic validation, progress diagnostics, and clean interruption.
+- Add streamlined `portable export` generations with chunked online backups, journal-free staging, compact final files, granular progress, and clean interruption.
 
 ## 0.9.0 - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Portable stores
 
-- Add `portable export` with the `current-state-v1` profile for atomic, validated, optionally repository-scoped derived database generations with counted manifests that leave the active archive unchanged.
+- Add `portable export` with the `current-state-v1` profile for atomic, validated, patch-free, optionally repository-scoped generations with counted manifests that leave the active archive unchanged.
 
 ## 0.9.0 - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Portable stores
 
-- Add streamlined `portable export` generations with sanitized compatibility columns, journal-free staging, compact final files, granular progress, and clean interruption.
+- Add streamlined `portable export` generations with single-pass sanitized compatibility tables, journal-free staging, compact final files, granular progress, and clean interruption.
 
 ## 0.9.0 - 2026-08-08
 

--- a/cmd/gitcrawl/main.go
+++ b/cmd/gitcrawl/main.go
@@ -11,12 +11,14 @@ import (
 )
 
 func main() {
+	ctx, stop := signalContext(context.Background())
+	defer stop()
 	args := os.Args[1:]
 	name := strings.TrimSuffix(filepath.Base(os.Args[0]), ".exe")
 	if name == "gh" || name == "gitcrawl-gh" {
 		args = append([]string{"gh"}, args...)
 	}
-	if err := cli.New().Run(context.Background(), args); err != nil {
+	if err := cli.New().Run(ctx, args); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(cli.ExitCode(err))
 	}

--- a/cmd/gitcrawl/signal_context.go
+++ b/cmd/gitcrawl/signal_context.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"context"
+	"os/signal"
+)
+
+func signalContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(parent, commandSignals()...)
+}

--- a/cmd/gitcrawl/signal_context_unix_test.go
+++ b/cmd/gitcrawl/signal_context_unix_test.go
@@ -1,0 +1,37 @@
+//go:build !windows
+
+package main
+
+import (
+	"context"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestSignalContextCancelsOnInterrupt(t *testing.T) {
+	testSignalContextCancellation(t, os.Interrupt)
+}
+
+func TestSignalContextCancelsOnSIGTERM(t *testing.T) {
+	testSignalContextCancellation(t, syscall.SIGTERM)
+}
+
+func testSignalContextCancellation(t *testing.T, processSignal os.Signal) {
+	t.Helper()
+	ctx, stop := signalContext(context.Background())
+	defer stop()
+	process, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("find process: %v", err)
+	}
+	if err := process.Signal(processSignal); err != nil {
+		t.Fatalf("send %v: %v", processSignal, err)
+	}
+	select {
+	case <-ctx.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("signal context did not cancel")
+	}
+}

--- a/cmd/gitcrawl/signals_unix.go
+++ b/cmd/gitcrawl/signals_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func commandSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM, syscall.SIGHUP}
+}

--- a/cmd/gitcrawl/signals_windows.go
+++ b/cmd/gitcrawl/signals_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package main
+
+import "os"
+
+func commandSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -137,7 +137,7 @@ octopool gh api repos/openclaw/openclaw/pulls/123
 | Command | Purpose | Docs |
 | --- | --- | --- |
 | `gitcrawl portable prune [--body-chars --no-vacuum --include-sync-failures --no-publish --json]` | Build a compact portable v2 backup and (optionally) `VACUUM` for publishing | [Portable stores](/portable-stores/#publishing-gitcrawl-portable-prune) |
-| `gitcrawl portable export --profile current-state-v1 --output-dir PATH [--body-chars --database-name --public-path --max-bytes --json]` | Create a validated derived database-and-manifest generation without changing or publishing the active database | [Portable stores](/portable-stores/#derived-generations-gitcrawl-portable-export) |
+| `gitcrawl portable export --profile current-state-v1 --output-dir PATH [--repository owner/repo --body-chars --database-name --public-path --max-bytes --json]` | Create a validated, optionally repository-scoped database-and-manifest generation without changing or publishing the active database | [Portable stores](/portable-stores/#derived-generations-gitcrawl-portable-export) |
 
 ## Not yet implemented
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -137,6 +137,7 @@ octopool gh api repos/openclaw/openclaw/pulls/123
 | Command | Purpose | Docs |
 | --- | --- | --- |
 | `gitcrawl portable prune [--body-chars --no-vacuum --include-sync-failures --no-publish --json]` | Build a compact portable v2 backup and (optionally) `VACUUM` for publishing | [Portable stores](/portable-stores/#publishing-gitcrawl-portable-prune) |
+| `gitcrawl portable export --profile current-state-v1 --output-dir PATH [--body-chars --database-name --public-path --max-bytes --json]` | Create a validated derived database-and-manifest generation without changing or publishing the active database | [Portable stores](/portable-stores/#derived-generations-gitcrawl-portable-export) |
 
 ## Not yet implemented
 

--- a/docs/portable-stores.md
+++ b/docs/portable-stores.md
@@ -175,6 +175,15 @@ while `pull_request_files.patch` diff payloads are set to `NULL`. It also remove
 while retaining primary keys, unique constraints, and explicit unique indexes.
 The manifest records the exact dropped tables and indexes.
 
+Derived exports record `column_profile=sanitized-compatibility` in SQLite
+metadata and `columnProfile: sanitized-compatibility` in the manifest. They keep
+the full-schema compatibility columns `repositories.raw_json`,
+`threads.raw_json`, and `threads.body` to avoid three full-table SQLite rewrites;
+the raw JSON values are empty and `threads.body` contains only `body_excerpt`.
+The final `VACUUM INTO` ensures the removed full payload bytes are absent. The
+portable schema identifier remains `gitcrawl-portable-sync-v2`, and ordinary
+`portable prune` continues to physically drop these columns.
+
 Those history and governance omissions are intentional data loss in the
 generation, not a promise that every omission can be rebuilt. Opening the
 export writable lets the current Gitcrawl migration recreate missing tables and

--- a/docs/portable-stores.md
+++ b/docs/portable-stores.md
@@ -134,6 +134,7 @@ gitcrawl --config /path/to/config.toml portable export \
   --output-dir /path/to/artifact.next \
   --database-name openclaw__openclaw.sync.db \
   --public-path data/openclaw__openclaw.sync.db \
+  --repository openclaw/openclaw \
   --max-bytes 99999999 \
   --json
 ```
@@ -147,6 +148,14 @@ to that name and is a clean relative slash path recorded in the manifest and
 host path. `--body-chars` defaults to `256`. `--max-bytes` is optional and
 inclusive, so a deployment requiring a database smaller than 100,000,000 bytes
 should pass `99999999` rather than relying on a Gitcrawl-specific hosting limit.
+The optional `--repository owner/repo` is semantic export behavior: Gitcrawl
+removes all other repositories and their dependent rows from the disposable
+snapshot, verifies the exact remaining identity, and records it in the manifest.
+Without the flag, multi-repository artifacts remain supported.
+The manifest reports every retained table as a sorted `{name, rows}` object.
+It includes a singular repository object for scoped exports and for unscoped
+artifacts that naturally contain exactly one repository; multi-repository
+artifacts omit that singular field.
 
 The `current-state-v1` profile starts with portable v2 shaping and keeps current
 repositories, issue and pull-request threads, current comments, compact thread
@@ -178,6 +187,7 @@ output directory absent and removes the private staging directory.
 | `--output-dir <path>` | _(required)_ | New artifact directory; must not already exist |
 | `--database-name <name>` | `gitcrawl.db` | Safe database basename inside the generation |
 | `--public-path <path>` | database name | Logical relative slash path recorded in metadata and the manifest |
+| `--repository <owner/repo>` | _(unset)_ | Semantically restrict the artifact to exactly one repository |
 | `--body-chars <n>` | `256` | Maximum body characters retained in compact excerpts |
 | `--max-bytes <n>` | _(unset)_ | Inclusive maximum finalized database size |
 | `--json` | _(off)_ | Stable structured result, including local source and output paths |

--- a/docs/portable-stores.md
+++ b/docs/portable-stores.md
@@ -175,12 +175,15 @@ local maintainer decisions do not return. Rebuildable derived state may be
 generated again from the retained current data where the relevant command
 supports it.
 
-Before committing the generation, export runs a final `VACUUM`, removes SQLite
-sidecars, requires `quick_check` and full `integrity_check` to return `ok`,
-requires an empty `foreign_key_check`, enforces the optional finalized byte
+Before removing transport-only indexes, export requires an empty
+`foreign_key_check` while those indexes still make relationship proof efficient.
+It then runs one final `VACUUM`, removes SQLite sidecars, requires `quick_check`
+and full `integrity_check` to return `ok`, enforces the optional finalized byte
 budget, hashes the database with SHA-256, writes and fsyncs the manifest, then
-re-reads the pair and validates it again. Any failure leaves the requested
-output directory absent and removes the private staging directory.
+re-reads the pair without repeating the unindexed foreign-key scan. Concise
+stage progress is written to stderr, including during JSON output. Any failure
+or handled interrupt leaves the requested output directory absent and removes
+the private staging directory.
 
 | Flag | Default | Description |
 | --- | --- | --- |

--- a/docs/portable-stores.md
+++ b/docs/portable-stores.md
@@ -118,6 +118,70 @@ Portable mirrors retain existing revision-bound key summaries, but do not regene
 
 After pruning, commit and push both the database and its `.manifest.json` from the portable checkout the way you would for any Git repository.
 
+## Derived generations: `gitcrawl portable export`
+
+`portable export` creates a new, validated database-and-manifest generation from
+the configured active database without changing that database. It is generic
+artifact production: Gitcrawl owns the consistent SQLite snapshot, semantic
+shaping, validation, size budget, digest, and manifest. Promotion into a
+repository, replacement of an older generation, Git commits, and publication
+remain external operations.
+
+```bash
+gitcrawl --config /path/to/config.toml portable export \
+  --profile current-state-v1 \
+  --body-chars 32 \
+  --output-dir /path/to/artifact.next \
+  --database-name openclaw__openclaw.sync.db \
+  --public-path data/openclaw__openclaw.sync.db \
+  --max-bytes 99999999 \
+  --json
+```
+
+The required `--profile` currently accepts only `current-state-v1`.
+`--output-dir` is also required and must not exist; export builds beside it and
+renames the complete pair into place only after validation. The database name
+defaults to `gitcrawl.db` and must be a safe basename. `--public-path` defaults
+to that name and is a clean relative slash path recorded in the manifest and
+`portable_metadata`; it is a logical consumer path, never the source or output
+host path. `--body-chars` defaults to `256`. `--max-bytes` is optional and
+inclusive, so a deployment requiring a database smaller than 100,000,000 bytes
+should pass `99999999` rather than relying on a Gitcrawl-specific hosting limit.
+
+The `current-state-v1` profile starts with portable v2 shaping and keeps current
+repositories, issue and pull-request threads, current comments, compact thread
+revisions and fingerprints, pull-request detail/review/check state, workflow
+runs, and child observation memberships. It omits comment revision history,
+generated thread key summaries, and derived cluster groups, memberships,
+lineage, overrides, and closures. It also removes ordinary non-unique indexes
+while retaining primary keys, unique constraints, and explicit unique indexes.
+The manifest records the exact dropped tables and indexes.
+
+Those history and governance omissions are intentional data loss in the
+generation, not a promise that every omission can be rebuilt. Opening the
+export writable lets the current Gitcrawl migration recreate missing tables and
+ordinary schema indexes, but the omitted historical snapshots, summaries, and
+local maintainer decisions do not return. Rebuildable derived state may be
+generated again from the retained current data where the relevant command
+supports it.
+
+Before committing the generation, export runs a final `VACUUM`, removes SQLite
+sidecars, requires `quick_check` and full `integrity_check` to return `ok`,
+requires an empty `foreign_key_check`, enforces the optional finalized byte
+budget, hashes the database with SHA-256, writes and fsyncs the manifest, then
+re-reads the pair and validates it again. Any failure leaves the requested
+output directory absent and removes the private staging directory.
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--profile <name>` | _(required)_ | Semantic export profile; currently `current-state-v1` |
+| `--output-dir <path>` | _(required)_ | New artifact directory; must not already exist |
+| `--database-name <name>` | `gitcrawl.db` | Safe database basename inside the generation |
+| `--public-path <path>` | database name | Logical relative slash path recorded in metadata and the manifest |
+| `--body-chars <n>` | `256` | Maximum body characters retained in compact excerpts |
+| `--max-bytes <n>` | _(unset)_ | Inclusive maximum finalized database size |
+| `--json` | _(off)_ | Stable structured result, including local source and output paths |
+
 ## A typical publishing flow
 
 ```bash

--- a/docs/portable-stores.md
+++ b/docs/portable-stores.md
@@ -130,6 +130,10 @@ remain external operations.
 The initial snapshot uses SQLite's online backup API in bounded page chunks, so
 committed WAL state is captured consistently and cancellation can be observed
 between chunks without compacting the multi-gigabyte source first.
+The private working copy disables journaling, synchronous writes, and secure
+deletion because it is never exposed and is deleted on any error. Privacy and
+durability come from the separate compact generation, full validation, hashing,
+fsync, and atomic directory commit.
 
 ```bash
 gitcrawl --config /path/to/config.toml portable export \

--- a/docs/portable-stores.md
+++ b/docs/portable-stores.md
@@ -104,7 +104,7 @@ Portable v2 keeps the data agents most often need for offline GitHub reads:
 - PR details, files, commits, status checks, and workflow runs
 - Thread revisions, deterministic fingerprints, and key summaries used by duplicate and cluster-oriented workflows
 
-It strips the data that is large, private, easy to regenerate, or mainly useful for exact API replay: raw GitHub JSON, generated documents and FTS indexes, embeddings and vectors, code snapshots and diff blobs, cluster run history, the sync failure ledger, similarity edges, and blob storage. Pass `--include-sync-failures` only when failure history is useful to portable-store readers; the table is retained but every `error_message` is replaced with `[redacted for portable export]`. Once the source schema contains the ledger, pruning securely rewrites the database even with `--no-vacuum` so current, deleted, and historical retry text cannot remain in free pages. An interrupted rewrite remains marked pending and is retried by the next prune. The database records this contract in `portable_metadata` with `schema=gitcrawl-portable-sync-v2`, `includes`, `excluded`, `capabilities`, and `thread_author_profile` keys. The added revision, fingerprint, summary, and author-association fields are additive; the portable schema identifier remains v2 so older readers can continue using the columns and tables they understand.
+It strips the data that is large, private, easy to regenerate, or mainly useful for exact API replay: raw GitHub JSON, generated documents and FTS indexes, embeddings and vectors, code snapshots and diff blobs (including `pull_request_files.patch`), cluster run history, the sync failure ledger, similarity edges, and blob storage. PR file path, status, line counts, rename metadata, and other current file identity remain. Pass `--include-sync-failures` only when failure history is useful to portable-store readers; the table is retained but every `error_message` is replaced with `[redacted for portable export]`. Once the source schema contains the ledger, pruning securely rewrites the database even with `--no-vacuum` so current, deleted, and historical retry text cannot remain in free pages. An interrupted rewrite remains marked pending and is retried by the next prune. The database records this contract in `portable_metadata` with `schema=gitcrawl-portable-sync-v2`, `includes`, `excluded`, `capabilities`, and `thread_author_profile` keys. The added revision, fingerprint, summary, and author-association fields are additive; the portable schema identifier remains v2 so older readers can continue using the columns and tables they understand.
 
 Portable mirrors retain existing revision-bound key summaries, but do not regenerate them from compact body excerpts. Pruning removes canonical revision evidence blobs, so run a fully hydrated sync in a writable archive before `summarize`; the summary queue requires the exact content-addressed payload bound to the revision.
 
@@ -162,7 +162,8 @@ repositories, issue and pull-request threads, current comments, compact thread
 revisions and fingerprints, pull-request detail/review/check state, workflow
 runs, and child observation memberships. It omits comment revision history,
 generated thread key summaries, and derived cluster groups, memberships,
-lineage, overrides, and closures. It also removes ordinary non-unique indexes
+lineage, overrides, and closures. PR file identity and change counts remain,
+while `pull_request_files.patch` diff payloads are set to `NULL`. It also removes ordinary non-unique indexes
 while retaining primary keys, unique constraints, and explicit unique indexes.
 The manifest records the exact dropped tables and indexes.
 

--- a/docs/portable-stores.md
+++ b/docs/portable-stores.md
@@ -180,6 +180,11 @@ metadata and `columnProfile: sanitized-compatibility` in the manifest. They keep
 the full-schema compatibility columns `repositories.raw_json`,
 `threads.raw_json`, and `threads.body` to avoid three full-table SQLite rewrites;
 the raw JSON values are empty and `threads.body` contains only `body_excerpt`.
+Export rebuilds `threads` once from its stored constrained table definition,
+preserving table constraints, explicit unique indexes, triggers, child foreign
+keys, and all other columns while omitting ordinary transport indexes. Custom
+INSERT/DELETE triggers are retained; unsupported custom UPDATE-trigger semantics
+fail closed rather than silently diverging during the bulk copy.
 The final `VACUUM INTO` ensures the removed full payload bytes are absent. The
 portable schema identifier remains `gitcrawl-portable-sync-v2`, and ordinary
 `portable prune` continues to physically drop these columns.

--- a/docs/portable-stores.md
+++ b/docs/portable-stores.md
@@ -127,6 +127,10 @@ shaping, validation, size budget, digest, and manifest. Promotion into a
 repository, replacement of an older generation, Git commits, and publication
 remain external operations.
 
+The initial snapshot uses SQLite's online backup API in bounded page chunks, so
+committed WAL state is captured consistently and cancellation can be observed
+between chunks without compacting the multi-gigabyte source first.
+
 ```bash
 gitcrawl --config /path/to/config.toml portable export \
   --profile current-state-v1 \
@@ -177,8 +181,10 @@ supports it.
 
 Before removing transport-only indexes, export requires an empty
 `foreign_key_check` while those indexes still make relationship proof efficient.
-It then runs one final `VACUUM`, removes SQLite sidecars, requires `quick_check`
-and full `integrity_check` to return `ok`, enforces the optional finalized byte
+It then creates one compact final generation with `VACUUM INTO`, closes and
+removes the larger private working database, and promotes the compact file
+within staging. The compact file must pass `quick_check` and full
+`integrity_check`; export then enforces the optional finalized byte
 budget, hashes the database with SHA-256, writes and fsyncs the manifest, then
 re-reads the pair without repeating the unindexed foreign-key scan. Concise
 stage progress is written to stderr, including during JSON output. Any failure

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openclaw/gitcrawl/internal/config"
 	gh "github.com/openclaw/gitcrawl/internal/github"
 	"github.com/openclaw/gitcrawl/internal/openai"
+	portableexport "github.com/openclaw/gitcrawl/internal/portable"
 	"github.com/openclaw/gitcrawl/internal/store"
 	"github.com/openclaw/gitcrawl/internal/syncer"
 	"github.com/openclaw/gitcrawl/internal/vector"
@@ -3423,9 +3424,89 @@ func (a *App) runPortable(ctx context.Context, args []string) error {
 		return a.printCommandUsage("portable")
 	case "prune":
 		return a.runPortablePrune(ctx, args[1:])
+	case "export":
+		return a.runPortableExport(ctx, args[1:])
 	default:
 		return usageErr(fmt.Errorf("unknown portable subcommand %q", args[0]))
 	}
+}
+
+func (a *App) runPortableExport(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("portable export", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	profile := fs.String("profile", "", "portable export profile")
+	bodyCharsRaw := fs.String("body-chars", "256", "maximum thread body characters to keep")
+	outputDir := fs.String("output-dir", "", "new artifact directory")
+	databaseName := fs.String("database-name", "gitcrawl.db", "portable database basename")
+	publicPath := fs.String("public-path", "", "logical portable database path")
+	maxBytesRaw := fs.String("max-bytes", "", "maximum finalized database bytes")
+	jsonOut := fs.Bool("json", false, "write JSON output")
+	valueFlags := map[string]bool{
+		"profile": true, "body-chars": true, "output-dir": true,
+		"database-name": true, "public-path": true, "max-bytes": true,
+	}
+	if err := fs.Parse(normalizeCommandArgs(args, valueFlags)); err != nil {
+		return usageErr(err)
+	}
+	a.applyCommandJSON(*jsonOut)
+	if fs.NArg() != 0 {
+		return usageErr(fmt.Errorf("portable export does not take positional arguments"))
+	}
+	if strings.TrimSpace(*profile) == "" {
+		return usageErr(fmt.Errorf("--profile is required"))
+	}
+	if strings.TrimSpace(*outputDir) == "" {
+		return usageErr(fmt.Errorf("--output-dir is required"))
+	}
+	bodyChars, err := parseOptionalPositiveInt(*bodyCharsRaw)
+	if err != nil {
+		return usageErr(err)
+	}
+	if bodyChars == 0 {
+		bodyChars = 256
+	}
+	var maxBytes *int64
+	if strings.TrimSpace(*maxBytesRaw) != "" {
+		parsed, err := strconv.ParseInt(strings.TrimSpace(*maxBytesRaw), 10, 64)
+		if err != nil || parsed <= 0 {
+			return usageErr(fmt.Errorf("--max-bytes must be a positive integer"))
+		}
+		maxBytes = &parsed
+	}
+	logicalPath := *publicPath
+	if logicalPath == "" {
+		logicalPath = *databaseName
+	}
+	if _, err := portableexport.ResolveProfile(*profile); err != nil {
+		return usageErr(err)
+	}
+	if err := portableexport.ValidateDatabaseName(*databaseName); err != nil {
+		return usageErr(err)
+	}
+	if err := portableexport.ValidatePublicPath(logicalPath); err != nil {
+		return usageErr(err)
+	}
+	rt, err := a.openLocalRuntimeReadOnly(ctx)
+	if err != nil {
+		return err
+	}
+	sourceDBPath := rt.Store.Path()
+	if err := rt.Store.Close(); err != nil {
+		return err
+	}
+	result, err := portableexport.Export(ctx, portableexport.ExportOptions{
+		SourceDBPath: sourceDBPath,
+		OutputDir:    *outputDir,
+		DatabaseName: *databaseName,
+		PublicPath:   logicalPath,
+		Profile:      *profile,
+		BodyChars:    bodyChars,
+		MaxBytes:     maxBytes,
+	})
+	if err != nil {
+		return err
+	}
+	return a.writeOutput("portable export", result, true)
 }
 
 func (a *App) runPortablePrune(ctx context.Context, args []string) error {
@@ -5179,6 +5260,7 @@ Core commands:
   search               search local thread and source documents; also supports search issues|prs gh syntax
   gh                   moved to Octopool; prints migration note
   portable prune       prune volatile payloads from a portable store
+  portable export      create an immutable derived portable generation
   tui [owner/repo]     browse clusters in the terminal UI; repo is inferred when omitted
 
 No API server is provided. There is intentionally no serve command.
@@ -5395,13 +5477,17 @@ const portableUsageText = `gitcrawl portable manages local portable-store snapsh
 
 Usage:
   gitcrawl portable prune [--body-chars N] [--no-vacuum] [--include-sync-failures] [--no-publish] [--json]
+  gitcrawl portable export --profile current-state-v1 --output-dir PATH [--database-name NAME] [--public-path PATH] [--body-chars N] [--max-bytes N] [--json]
 
 Subcommands:
   prune               prune volatile payloads from the configured portable store
+  export              create a validated portable artifact in a new directory
 
 The sync failure ledger is excluded by default. --include-sync-failures keeps
 the ledger but replaces every error message with a redaction marker. A present
 or pending ledger forces a secure database rewrite even with --no-vacuum.
 For a portable checkout, prune publishes the database and manifest back into
 the checkout by default. --no-publish leaves them only in the runtime mirror.
+Export never changes the active database or publishes the artifact. It creates
+a complete database and manifest generation at a previously nonexistent path.
 `

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -3439,11 +3439,12 @@ func (a *App) runPortableExport(ctx context.Context, args []string) error {
 	outputDir := fs.String("output-dir", "", "new artifact directory")
 	databaseName := fs.String("database-name", "gitcrawl.db", "portable database basename")
 	publicPath := fs.String("public-path", "", "logical portable database path")
+	repositoryRaw := fs.String("repository", "", "restrict the artifact to one owner/repo")
 	maxBytesRaw := fs.String("max-bytes", "", "maximum finalized database bytes")
 	jsonOut := fs.Bool("json", false, "write JSON output")
 	valueFlags := map[string]bool{
 		"profile": true, "body-chars": true, "output-dir": true,
-		"database-name": true, "public-path": true, "max-bytes": true,
+		"database-name": true, "public-path": true, "repository": true, "max-bytes": true,
 	}
 	if err := fs.Parse(normalizeCommandArgs(args, valueFlags)); err != nil {
 		return usageErr(err)
@@ -3486,6 +3487,17 @@ func (a *App) runPortableExport(ctx context.Context, args []string) error {
 	if err := portableexport.ValidatePublicPath(logicalPath); err != nil {
 		return usageErr(err)
 	}
+	repository := ""
+	if strings.TrimSpace(*repositoryRaw) != "" {
+		owner, name, err := parseOwnerRepo(*repositoryRaw)
+		if err != nil {
+			return usageErr(fmt.Errorf("repository: %w", err))
+		}
+		repository = owner + "/" + name
+		if strings.TrimSpace(*repositoryRaw) != repository {
+			return usageErr(fmt.Errorf("repository: expected owner/repo, got %q", *repositoryRaw))
+		}
+	}
 	rt, err := a.openLocalRuntimeReadOnly(ctx)
 	if err != nil {
 		return err
@@ -3500,6 +3512,7 @@ func (a *App) runPortableExport(ctx context.Context, args []string) error {
 		DatabaseName: *databaseName,
 		PublicPath:   logicalPath,
 		Profile:      *profile,
+		Repository:   repository,
 		BodyChars:    bodyChars,
 		MaxBytes:     maxBytes,
 	})
@@ -5477,7 +5490,7 @@ const portableUsageText = `gitcrawl portable manages local portable-store snapsh
 
 Usage:
   gitcrawl portable prune [--body-chars N] [--no-vacuum] [--include-sync-failures] [--no-publish] [--json]
-  gitcrawl portable export --profile current-state-v1 --output-dir PATH [--database-name NAME] [--public-path PATH] [--body-chars N] [--max-bytes N] [--json]
+  gitcrawl portable export --profile current-state-v1 --output-dir PATH [--repository owner/repo] [--database-name NAME] [--public-path PATH] [--body-chars N] [--max-bytes N] [--json]
 
 Subcommands:
   prune               prune volatile payloads from the configured portable store
@@ -5490,4 +5503,5 @@ For a portable checkout, prune publishes the database and manifest back into
 the checkout by default. --no-publish leaves them only in the runtime mirror.
 Export never changes the active database or publishes the artifact. It creates
 a complete database and manifest generation at a previously nonexistent path.
+--repository semantically restricts the disposable snapshot to one owner/repo.
 `

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -3506,6 +3506,8 @@ func (a *App) runPortableExport(ctx context.Context, args []string) error {
 	if err := rt.Store.Close(); err != nil {
 		return err
 	}
+	progressStarted := time.Now()
+	progressPrevious := progressStarted
 	result, err := portableexport.Export(ctx, portableexport.ExportOptions{
 		SourceDBPath: sourceDBPath,
 		OutputDir:    *outputDir,
@@ -3516,13 +3518,28 @@ func (a *App) runPortableExport(ctx context.Context, args []string) error {
 		BodyChars:    bodyChars,
 		MaxBytes:     maxBytes,
 		Progress: func(stage portableexport.Stage) {
-			fmt.Fprintf(a.Stderr, "gitcrawl: portable export: %s\n", stage)
+			now := time.Now()
+			fmt.Fprintf(
+				a.Stderr,
+				"gitcrawl: portable export: stage=%s after=%s total=%s\n",
+				stage,
+				formatPortableProgressDuration(now.Sub(progressPrevious)),
+				formatPortableProgressDuration(now.Sub(progressStarted)),
+			)
+			progressPrevious = now
 		},
 	})
 	if err != nil {
 		return err
 	}
 	return a.writeOutput("portable export", result, true)
+}
+
+func formatPortableProgressDuration(value time.Duration) string {
+	if value < 0 {
+		value = 0
+	}
+	return value.Round(100 * time.Millisecond).String()
 }
 
 func (a *App) runPortablePrune(ctx context.Context, args []string) error {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -3515,6 +3515,9 @@ func (a *App) runPortableExport(ctx context.Context, args []string) error {
 		Repository:   repository,
 		BodyChars:    bodyChars,
 		MaxBytes:     maxBytes,
+		Progress: func(stage portableexport.Stage) {
+			fmt.Fprintf(a.Stderr, "gitcrawl: portable export: %s\n", stage)
+		},
 	})
 	if err != nil {
 		return err

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -4902,6 +4902,7 @@ func TestPortableExportCommandCreatesCurrentStateGenerationFromLiveWAL(t *testin
 		"canonical shaping: fingerprints and summaries",
 		"canonical shaping: discarded tables and failure ledger",
 		"canonical shaping: canonical schema finalization",
+		"canonical shaping: canonical schema finalization: disposable table drop",
 		"canonical shaping: threads rebuild: preflight",
 		"canonical shaping: threads rebuild: foreign key proof",
 		"canonical shaping: threads rebuild: compact copy",

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -4799,6 +4799,103 @@ func TestPortablePruneCommand(t *testing.T) {
 	}
 }
 
+func TestPortableExportCommandCreatesCurrentStateGenerationFromLiveWAL(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	dbPath := filepath.Join(dir, "source.db")
+	if err := New().Run(ctx, []string{"--config", configPath, "init", "--db", dbPath}); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	seedPortableThread(t, dbPath, 7, "live WAL title")
+	writer, err := store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open writer: %v", err)
+	}
+	defer writer.Close()
+	writer.DB().SetMaxOpenConns(1)
+	if _, err := writer.DB().ExecContext(ctx, `pragma wal_autocheckpoint = 0`); err != nil {
+		t.Fatalf("disable WAL autocheckpoint: %v", err)
+	}
+	if _, err := writer.DB().ExecContext(ctx, `update threads set title = 'committed WAL title' where number = 7`); err != nil {
+		t.Fatalf("write live WAL state: %v", err)
+	}
+
+	outputDir := filepath.Join(dir, "artifact.next")
+	app := New()
+	var stdout bytes.Buffer
+	app.Stdout = &stdout
+	if err := app.Run(ctx, []string{
+		"--config", configPath,
+		"portable", "export",
+		"--profile", "current-state-v1",
+		"--body-chars", "32",
+		"--output-dir", outputDir,
+		"--database-name", "openclaw__openclaw.sync.db",
+		"--public-path", "data/openclaw__openclaw.sync.db",
+		"--max-bytes", "99999999",
+		"--json",
+	}); err != nil {
+		t.Fatalf("portable export: %v", err)
+	}
+	var payload struct {
+		Profile              string `json:"profile"`
+		PortableSchema       string `json:"portable_schema"`
+		SourceDBPath         string `json:"source_db_path"`
+		OutputDir            string `json:"output_dir"`
+		DatabasePath         string `json:"database_path"`
+		ManifestPath         string `json:"manifest_path"`
+		PublicPath           string `json:"public_path"`
+		BodyChars            int    `json:"body_chars"`
+		BytesAfter           int64  `json:"bytes_after"`
+		MaxBytes             int64  `json:"max_bytes"`
+		ArtifactID           string `json:"artifact_id"`
+		SHA256               string `json:"sha256"`
+		QuickCheck           string `json:"quick_check"`
+		IntegrityCheck       string `json:"integrity_check"`
+		ForeignKeyViolations int    `json:"foreign_key_violations"`
+		ArtifactCommitted    bool   `json:"artifact_committed"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("parse portable export JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.Profile != "current-state-v1" || payload.PortableSchema != "gitcrawl-portable-sync-v2" ||
+		payload.SourceDBPath != dbPath || payload.OutputDir != outputDir || payload.PublicPath != "data/openclaw__openclaw.sync.db" ||
+		payload.BodyChars != 32 || payload.MaxBytes != 99999999 || payload.BytesAfter <= 0 || payload.ArtifactID != payload.SHA256 ||
+		payload.QuickCheck != "ok" || payload.IntegrityCheck != "ok" || payload.ForeignKeyViolations != 0 || !payload.ArtifactCommitted {
+		t.Fatalf("portable export payload = %+v", payload)
+	}
+	artifact, err := sql.Open("sqlite", payload.DatabasePath)
+	if err != nil {
+		t.Fatalf("open artifact: %v", err)
+	}
+	defer artifact.Close()
+	var title, sourcePath string
+	if err := artifact.QueryRowContext(ctx, `select title from threads where number = 7`).Scan(&title); err != nil {
+		t.Fatalf("read exported thread: %v", err)
+	}
+	if err := artifact.QueryRowContext(ctx, `select value from portable_metadata where key = 'source_path'`).Scan(&sourcePath); err != nil {
+		t.Fatalf("read portable source path: %v", err)
+	}
+	if title != "committed WAL title" || sourcePath != payload.PublicPath || strings.Contains(sourcePath, dir) {
+		t.Fatalf("artifact title/source = %q / %q", title, sourcePath)
+	}
+	if _, err := os.Stat(payload.ManifestPath); err != nil {
+		t.Fatalf("manifest missing: %v", err)
+	}
+}
+
+func TestPortableExportCommandValidatesProfileBeforeOpeningSource(t *testing.T) {
+	app := New()
+	err := app.Run(context.Background(), []string{
+		"--config", filepath.Join(t.TempDir(), "missing.toml"),
+		"portable", "export", "--profile", "future-v2", "--output-dir", filepath.Join(t.TempDir(), "out"),
+	})
+	if err == nil || !strings.Contains(err.Error(), `unsupported portable export profile "future-v2"`) {
+		t.Fatalf("unknown profile error = %v", err)
+	}
+}
+
 type portablePruneTestFixture struct {
 	configPath string
 	checkoutDB string

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -4894,6 +4894,12 @@ func TestPortableExportCommandCreatesCurrentStateGenerationFromLiveWAL(t *testin
 	}
 	for _, stage := range []string{
 		"snapshot", "repository scope", "profile omissions", "canonical shaping",
+		"canonical shaping: thread bodies",
+		"canonical shaping: comment and review bodies",
+		"canonical shaping: metadata and raw payload cleanup",
+		"canonical shaping: fingerprints and summaries",
+		"canonical shaping: discarded tables and failure ledger",
+		"canonical shaping: canonical schema drops",
 		"foreign key proof", "index removal", "final vacuum", "validation", "manifest", "artifact commit", "complete",
 	} {
 		prefix := "gitcrawl: portable export: stage=" + stage + " "

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -4894,13 +4894,20 @@ func TestPortableExportCommandCreatesCurrentStateGenerationFromLiveWAL(t *testin
 	}
 	for _, stage := range []string{
 		"snapshot", "repository scope", "profile omissions", "canonical shaping",
-		"foreign key proof", "index removal", "final vacuum", "validation", "manifest", "artifact commit",
+		"foreign key proof", "index removal", "final vacuum", "validation", "manifest", "artifact commit", "complete",
 	} {
-		line := "gitcrawl: portable export: " + stage
-		if !strings.Contains(stderr.String(), line) {
-			t.Fatalf("progress missing %q:\n%s", line, stderr.String())
+		prefix := "gitcrawl: portable export: stage=" + stage + " "
+		var progressLine string
+		for _, line := range strings.Split(stderr.String(), "\n") {
+			if strings.HasPrefix(line, prefix) {
+				progressLine = line
+				break
+			}
 		}
-		if strings.Contains(stdout.String(), line) {
+		if progressLine == "" || !strings.Contains(progressLine, "after=") || !strings.Contains(progressLine, "total=") {
+			t.Fatalf("timed progress missing for %q:\n%s", stage, stderr.String())
+		}
+		if strings.Contains(stdout.String(), prefix) {
 			t.Fatalf("progress leaked to JSON stdout: %s", stdout.String())
 		}
 	}

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -4902,7 +4902,12 @@ func TestPortableExportCommandCreatesCurrentStateGenerationFromLiveWAL(t *testin
 		"canonical shaping: fingerprints and summaries",
 		"canonical shaping: discarded tables and failure ledger",
 		"canonical shaping: canonical schema finalization",
-		"foreign key proof", "index removal", "final vacuum", "validation", "manifest", "artifact commit", "complete",
+		"canonical shaping: threads rebuild: preflight",
+		"canonical shaping: threads rebuild: foreign key proof",
+		"canonical shaping: threads rebuild: compact copy",
+		"canonical shaping: threads rebuild: schema swap",
+		"canonical shaping: threads rebuild: schema restore",
+		"index removal", "final vacuum", "validation", "manifest", "artifact commit", "complete",
 	} {
 		prefix := "gitcrawl: portable export: stage=" + stage + " "
 		var progressLine string

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -4823,8 +4823,9 @@ func TestPortableExportCommandCreatesCurrentStateGenerationFromLiveWAL(t *testin
 
 	outputDir := filepath.Join(dir, "artifact.next")
 	app := New()
-	var stdout bytes.Buffer
+	var stdout, stderr bytes.Buffer
 	app.Stdout = &stdout
+	app.Stderr = &stderr
 	if err := app.Run(ctx, []string{
 		"--config", configPath,
 		"portable", "export",
@@ -4890,6 +4891,18 @@ func TestPortableExportCommandCreatesCurrentStateGenerationFromLiveWAL(t *testin
 	}
 	if _, err := os.Stat(payload.ManifestPath); err != nil {
 		t.Fatalf("manifest missing: %v", err)
+	}
+	for _, stage := range []string{
+		"snapshot", "repository scope", "profile omissions", "canonical shaping",
+		"foreign key proof", "index removal", "final vacuum", "validation", "manifest", "artifact commit",
+	} {
+		line := "gitcrawl: portable export: " + stage
+		if !strings.Contains(stderr.String(), line) {
+			t.Fatalf("progress missing %q:\n%s", line, stderr.String())
+		}
+		if strings.Contains(stdout.String(), line) {
+			t.Fatalf("progress leaked to JSON stdout: %s", stdout.String())
+		}
 	}
 }
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -4833,19 +4833,26 @@ func TestPortableExportCommandCreatesCurrentStateGenerationFromLiveWAL(t *testin
 		"--output-dir", outputDir,
 		"--database-name", "openclaw__openclaw.sync.db",
 		"--public-path", "data/openclaw__openclaw.sync.db",
+		"--repository", "openclaw/openclaw",
 		"--max-bytes", "99999999",
 		"--json",
 	}); err != nil {
 		t.Fatalf("portable export: %v", err)
 	}
 	var payload struct {
-		Profile              string `json:"profile"`
-		PortableSchema       string `json:"portable_schema"`
-		SourceDBPath         string `json:"source_db_path"`
-		OutputDir            string `json:"output_dir"`
-		DatabasePath         string `json:"database_path"`
-		ManifestPath         string `json:"manifest_path"`
-		PublicPath           string `json:"public_path"`
+		Profile        string `json:"profile"`
+		PortableSchema string `json:"portable_schema"`
+		SourceDBPath   string `json:"source_db_path"`
+		OutputDir      string `json:"output_dir"`
+		DatabasePath   string `json:"database_path"`
+		ManifestPath   string `json:"manifest_path"`
+		PublicPath     string `json:"public_path"`
+		Repository     struct {
+			ID       int64  `json:"id"`
+			Owner    string `json:"owner"`
+			Name     string `json:"name"`
+			FullName string `json:"fullName"`
+		} `json:"repository"`
 		BodyChars            int    `json:"body_chars"`
 		BytesAfter           int64  `json:"bytes_after"`
 		MaxBytes             int64  `json:"max_bytes"`
@@ -4861,6 +4868,7 @@ func TestPortableExportCommandCreatesCurrentStateGenerationFromLiveWAL(t *testin
 	}
 	if payload.Profile != "current-state-v1" || payload.PortableSchema != "gitcrawl-portable-sync-v2" ||
 		payload.SourceDBPath != dbPath || payload.OutputDir != outputDir || payload.PublicPath != "data/openclaw__openclaw.sync.db" ||
+		payload.Repository.Owner != "openclaw" || payload.Repository.Name != "openclaw" || payload.Repository.FullName != "openclaw/openclaw" ||
 		payload.BodyChars != 32 || payload.MaxBytes != 99999999 || payload.BytesAfter <= 0 || payload.ArtifactID != payload.SHA256 ||
 		payload.QuickCheck != "ok" || payload.IntegrityCheck != "ok" || payload.ForeignKeyViolations != 0 || !payload.ArtifactCommitted {
 		t.Fatalf("portable export payload = %+v", payload)
@@ -4893,6 +4901,20 @@ func TestPortableExportCommandValidatesProfileBeforeOpeningSource(t *testing.T) 
 	})
 	if err == nil || !strings.Contains(err.Error(), `unsupported portable export profile "future-v2"`) {
 		t.Fatalf("unknown profile error = %v", err)
+	}
+	err = app.Run(context.Background(), []string{
+		"--config", filepath.Join(t.TempDir(), "missing.toml"),
+		"portable", "export", "--profile", "current-state-v1", "--output-dir", filepath.Join(t.TempDir(), "out"), "--repository", "openclaw",
+	})
+	if err == nil || !strings.Contains(err.Error(), `repository: expected owner/repo, got "openclaw"`) {
+		t.Fatalf("invalid repository error = %v", err)
+	}
+	err = app.Run(context.Background(), []string{
+		"--config", filepath.Join(t.TempDir(), "missing.toml"),
+		"portable", "export", "--profile", "current-state-v1", "--output-dir", filepath.Join(t.TempDir(), "out"), "--repository", "openclaw /gitcrawl",
+	})
+	if err == nil || !strings.Contains(err.Error(), `repository: expected owner/repo, got "openclaw /gitcrawl"`) {
+		t.Fatalf("non-canonical repository error = %v", err)
 	}
 }
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -4863,6 +4863,7 @@ func TestPortableExportCommandCreatesCurrentStateGenerationFromLiveWAL(t *testin
 		IntegrityCheck       string `json:"integrity_check"`
 		ForeignKeyViolations int    `json:"foreign_key_violations"`
 		ArtifactCommitted    bool   `json:"artifact_committed"`
+		ColumnProfile        string `json:"column_profile"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
 		t.Fatalf("parse portable export JSON: %v\n%s", err, stdout.String())
@@ -4871,7 +4872,8 @@ func TestPortableExportCommandCreatesCurrentStateGenerationFromLiveWAL(t *testin
 		payload.SourceDBPath != dbPath || payload.OutputDir != outputDir || payload.PublicPath != "data/openclaw__openclaw.sync.db" ||
 		payload.Repository.Owner != "openclaw" || payload.Repository.Name != "openclaw" || payload.Repository.FullName != "openclaw/openclaw" ||
 		payload.BodyChars != 32 || payload.MaxBytes != 99999999 || payload.BytesAfter <= 0 || payload.ArtifactID != payload.SHA256 ||
-		payload.QuickCheck != "ok" || payload.IntegrityCheck != "ok" || payload.ForeignKeyViolations != 0 || !payload.ArtifactCommitted {
+		payload.QuickCheck != "ok" || payload.IntegrityCheck != "ok" || payload.ForeignKeyViolations != 0 || !payload.ArtifactCommitted ||
+		payload.ColumnProfile != store.PortableColumnProfileSanitizedCompatibility {
 		t.Fatalf("portable export payload = %+v", payload)
 	}
 	artifact, err := sql.Open("sqlite", payload.DatabasePath)
@@ -4899,7 +4901,7 @@ func TestPortableExportCommandCreatesCurrentStateGenerationFromLiveWAL(t *testin
 		"canonical shaping: metadata and raw payload cleanup",
 		"canonical shaping: fingerprints and summaries",
 		"canonical shaping: discarded tables and failure ledger",
-		"canonical shaping: canonical schema drops",
+		"canonical shaping: canonical schema finalization",
 		"foreign key proof", "index removal", "final vacuum", "validation", "manifest", "artifact commit", "complete",
 	} {
 		prefix := "gitcrawl: portable export: stage=" + stage + " "

--- a/internal/cli/portable_export_failure_paths_test.go
+++ b/internal/cli/portable_export_failure_paths_test.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openclaw/gitcrawl/internal/store"
+)
+
+func TestPortableExportArgumentsFailBeforeOpeningRuntime(t *testing.T) {
+	missingConfig := filepath.Join(t.TempDir(), "missing.toml")
+	tests := []struct {
+		name      string
+		args      []string
+		wantError string
+	}{
+		{name: "unknown flag", args: []string{"--unknown"}, wantError: "flag provided but not defined"},
+		{name: "positional argument", args: []string{"--profile", "current-state-v1", "--output-dir", "out", "extra"}, wantError: "does not take positional arguments"},
+		{name: "missing profile", args: []string{"--output-dir", "out"}, wantError: "--profile is required"},
+		{name: "missing output", args: []string{"--profile", "current-state-v1"}, wantError: "--output-dir is required"},
+		{name: "invalid body chars", args: []string{"--profile", "current-state-v1", "--output-dir", "out", "--body-chars", "nope"}, wantError: "positive integer"},
+		{name: "invalid max bytes", args: []string{"--profile", "current-state-v1", "--output-dir", "out", "--max-bytes", "0"}, wantError: "--max-bytes must be a positive integer"},
+		{name: "unsafe database name", args: []string{"--profile", "current-state-v1", "--output-dir", "out", "--database-name", "../archive.db"}, wantError: "database-name must be a safe basename"},
+		{name: "unsafe public path", args: []string{"--profile", "current-state-v1", "--output-dir", "out", "--public-path", "../archive.db"}, wantError: "public-path must be a clean relative slash path"},
+		{name: "zero body chars", args: []string{"--profile", "current-state-v1", "--output-dir", "out", "--body-chars", "0"}, wantError: "positive integer"},
+		{name: "default body and public path reach runtime", args: []string{"--profile", "current-state-v1", "--output-dir", "out", "--body-chars="}, wantError: "no such file"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			app := New()
+			app.configPath = missingConfig
+			err := app.runPortableExport(context.Background(), test.args)
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("portable export argument error = %v, want %q", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestPortableCommandHelpAndDurationFormatting(t *testing.T) {
+	app := New()
+	app.Stdout = io.Discard
+	app.Stderr = io.Discard
+	if err := app.runPortable(context.Background(), []string{"help"}); err != nil {
+		t.Fatalf("portable help: %v", err)
+	}
+	if got := formatPortableProgressDuration(-time.Second); got != "0s" {
+		t.Fatalf("negative portable duration = %q", got)
+	}
+	if got := formatPortableProgressDuration(149 * time.Millisecond); got != "100ms" {
+		t.Fatalf("rounded portable duration = %q", got)
+	}
+}
+
+func TestPortableManifestWriterRejectsUnsafePaths(t *testing.T) {
+	if _, _, err := writePortableDBManifest(store.PortablePruneStats{DBPath: filepath.Join(t.TempDir(), "missing.db")}); err == nil || !strings.Contains(err.Error(), "stat portable db") {
+		t.Fatalf("missing portable DB manifest error = %v", err)
+	}
+
+	dirPath := t.TempDir()
+	if _, _, err := writePortableDBManifest(store.PortablePruneStats{DBPath: dirPath}); err == nil || !strings.Contains(err.Error(), "hash portable db") {
+		t.Fatalf("directory portable DB manifest error = %v", err)
+	}
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "portable.db")
+	if err := os.WriteFile(dbPath, []byte("portable bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := portableDBManifestPath(dbPath)
+	if err := os.Mkdir(manifestPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := writePortableDBManifest(store.PortablePruneStats{DBPath: dbPath}); err == nil || !strings.Contains(err.Error(), "write portable db manifest") {
+		t.Fatalf("occupied portable manifest path error = %v", err)
+	}
+}
+
+func TestPortableStorePathSanitization(t *testing.T) {
+	if got := safePathName(".Repo Name_42."); got != "repo-name_42" {
+		t.Fatalf("safe portable path = %q", got)
+	}
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if got := defaultPortableStoreDir(configPath, "/"); got != filepath.Join(filepath.Dir(configPath), "stores", "portable-store") {
+		t.Fatalf("fallback portable store path = %q", got)
+	}
+}
+
+func TestPortablePruneArgumentsFailBeforeMutation(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantError string
+	}{
+		{name: "unknown flag", args: []string{"--unknown"}, wantError: "flag provided but not defined"},
+		{name: "positional", args: []string{"extra"}, wantError: "does not take positional arguments"},
+		{name: "invalid body chars", args: []string{"--body-chars", "nope"}, wantError: "positive integer"},
+		{name: "default body reaches runtime", args: []string{"--body-chars="}, wantError: "no such file"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			app := New()
+			app.configPath = filepath.Join(t.TempDir(), "missing.toml")
+			err := app.runPortablePrune(context.Background(), test.args)
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("portable prune argument error = %v, want %q", err, test.wantError)
+			}
+		})
+	}
+}

--- a/internal/portable/export.go
+++ b/internal/portable/export.go
@@ -73,6 +73,7 @@ var currentStateProfile = Profile{
 	},
 	Excluded: []string{
 		"raw_json",
+		"pull_request_file_patches",
 		"documents",
 		"fts",
 		"vectors",

--- a/internal/portable/export.go
+++ b/internal/portable/export.go
@@ -21,7 +21,7 @@ import (
 	"unicode"
 
 	"github.com/openclaw/gitcrawl/internal/store"
-	_ "modernc.org/sqlite"
+	moderncsqlite "modernc.org/sqlite"
 )
 
 const (
@@ -29,6 +29,8 @@ const (
 	portableSchema        = "gitcrawl-portable-sync-v2"
 	currentProfileVersion = 1
 	defaultBodyChars      = 256
+	onlineBackupPageChunk = int32(1024)
+	onlineBackupBusyRetry = 50 * time.Millisecond
 )
 
 // Profile defines a portable artifact's semantic policy independently of CLI
@@ -125,9 +127,19 @@ const (
 	StageValidation       Stage = "validation"
 	StageManifest         Stage = "manifest"
 	StageArtifactCommit   Stage = "artifact commit"
+	StageComplete         Stage = "complete"
 )
 
 type ProgressFunc func(Stage)
+
+type onlineBackupOptions struct {
+	PagesPerStep int32
+	AfterStep    func(remaining, pageCount int)
+}
+
+type backupCreator interface {
+	NewBackup(string) (*moderncsqlite.Backup, error)
+}
 
 type Repository struct {
 	ID       int64  `json:"id"`
@@ -373,42 +385,60 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 	if err := reportProgress(ctx, options.Progress, StageFinalVacuum); err != nil {
 		return result, err
 	}
-	if err := finalVacuum(ctx, st.DB()); err != nil {
+	compactPath, err := createCompactDatabase(ctx, st.DB(), dbPath)
+	if err != nil {
+		return result, err
+	}
+	if err := st.Close(); err != nil {
+		return result, fmt.Errorf("close uncompact portable snapshot: %w", err)
+	}
+	closed = true
+	if err := replaceWithCompactDatabase(ctx, dbPath, compactPath); err != nil {
 		return result, err
 	}
 	result.Vacuumed = true
 	if err := reportProgress(ctx, options.Progress, StageValidation); err != nil {
 		return result, err
 	}
-	quickCheck, err := checkPragma(ctx, st.DB(), "quick_check")
+	finalDB, err := sql.Open("sqlite", dbPath)
 	if err != nil {
+		return result, fmt.Errorf("open compact portable database: %w", err)
+	}
+	finalDB.SetMaxOpenConns(1)
+	quickCheck, err := checkPragma(ctx, finalDB, "quick_check")
+	if err != nil {
+		_ = finalDB.Close()
 		return result, err
 	}
-	integrityCheck, err := checkPragma(ctx, st.DB(), "integrity_check")
+	integrityCheck, err := checkPragma(ctx, finalDB, "integrity_check")
 	if err != nil {
+		_ = finalDB.Close()
 		return result, err
 	}
 	result.QuickCheck = quickCheck
 	result.IntegrityCheck = integrityCheck
 	if quickCheck != "ok" || integrityCheck != "ok" {
+		_ = finalDB.Close()
 		return result, fmt.Errorf("portable database validation failed: quick_check=%q integrity_check=%q", quickCheck, integrityCheck)
 	}
 	if result.Repository == nil {
-		result.Repository, err = singleRepository(ctx, st.DB())
+		result.Repository, err = singleRepository(ctx, finalDB)
 		if err != nil {
+			_ = finalDB.Close()
 			return result, err
 		}
-	} else if err := verifyRepository(ctx, st.DB(), *result.Repository); err != nil {
+	} else if err := verifyRepository(ctx, finalDB, *result.Repository); err != nil {
+		_ = finalDB.Close()
 		return result, err
 	}
-	tables, err := databaseTableStats(ctx, st.DB())
+	tables, err := databaseTableStats(ctx, finalDB)
 	if err != nil {
+		_ = finalDB.Close()
 		return result, err
 	}
-	if err := st.Close(); err != nil {
-		return result, fmt.Errorf("close portable snapshot: %w", err)
+	if err := finalDB.Close(); err != nil {
+		return result, fmt.Errorf("close compact portable database: %w", err)
 	}
-	closed = true
 	if err := removeSQLiteSidecars(dbPath); err != nil {
 		return result, err
 	}
@@ -503,6 +533,9 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 	}
 	bestEffortSyncDir(filepath.Dir(outputDir))
 	result.ArtifactCommitted = true
+	if options.Progress != nil {
+		options.Progress(StageComplete)
+	}
 	return result, nil
 }
 
@@ -580,6 +613,18 @@ func ValidatePublicPath(value string) error {
 }
 
 func snapshotSQLite(ctx context.Context, sourcePath, targetPath string) error {
+	return snapshotSQLiteWithOptions(ctx, sourcePath, targetPath, onlineBackupOptions{PagesPerStep: onlineBackupPageChunk})
+}
+
+func snapshotSQLiteWithOptions(ctx context.Context, sourcePath, targetPath string, options onlineBackupOptions) (retErr error) {
+	if options.PagesPerStep <= 0 {
+		return fmt.Errorf("online backup pages per step must be positive")
+	}
+	if _, err := os.Lstat(targetPath); err == nil {
+		return fmt.Errorf("snapshot target already exists: %s", targetPath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect snapshot target: %w", err)
+	}
 	abs, err := filepath.Abs(sourcePath)
 	if err != nil {
 		return fmt.Errorf("resolve snapshot source: %w", err)
@@ -600,9 +645,85 @@ func snapshotSQLite(ctx context.Context, sourcePath, targetPath string) error {
 		return fmt.Errorf("open source database for snapshot: %w", err)
 	}
 	defer db.Close()
-	if _, err := db.ExecContext(ctx, `vacuum into ?`, targetPath); err != nil {
+	db.SetMaxOpenConns(1)
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("open source backup connection: %w", err)
+	}
+	defer conn.Close()
+	complete := false
+	defer func() {
+		if complete {
+			return
+		}
+		if err := os.Remove(targetPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			retErr = errors.Join(retErr, fmt.Errorf("remove partial snapshot: %w", err))
+		}
+		for _, suffix := range []string{"-wal", "-shm"} {
+			if err := os.Remove(targetPath + suffix); err != nil && !errors.Is(err, os.ErrNotExist) {
+				retErr = errors.Join(retErr, fmt.Errorf("remove partial snapshot sidecar: %w", err))
+			}
+		}
+	}()
+	if err := conn.Raw(func(driverConn any) (rawErr error) {
+		creator, ok := driverConn.(backupCreator)
+		if !ok {
+			return fmt.Errorf("SQLite driver connection does not support online backup")
+		}
+		backup, err := creator.NewBackup(targetPath)
+		if err != nil {
+			return fmt.Errorf("start online backup: %w", err)
+		}
+		finished := false
+		defer func() {
+			if finished {
+				return
+			}
+			if err := backup.Finish(); err != nil {
+				rawErr = errors.Join(rawErr, fmt.Errorf("finish online backup after failure: %w", err))
+			}
+		}()
+		for {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			more, err := backup.Step(options.PagesPerStep)
+			if err != nil {
+				if store.IsTransientSQLiteBusy(err) {
+					timer := time.NewTimer(onlineBackupBusyRetry)
+					select {
+					case <-ctx.Done():
+						timer.Stop()
+						return ctx.Err()
+					case <-timer.C:
+					}
+					continue
+				}
+				return fmt.Errorf("step online backup: %w", err)
+			}
+			if options.AfterStep != nil {
+				options.AfterStep(backup.Remaining(), backup.PageCount())
+			}
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if !more {
+				break
+			}
+		}
+		if err := backup.Finish(); err != nil {
+			finished = true
+			return fmt.Errorf("finish online backup: %w", err)
+		}
+		finished = true
+		return nil
+	}); err != nil {
 		return fmt.Errorf("snapshot source database: %w", err)
 	}
+	if _, err := os.Stat(targetPath); err != nil {
+		return fmt.Errorf("stat completed snapshot: %w", err)
+	}
+	complete = true
 	return nil
 }
 
@@ -738,16 +859,71 @@ func writeMetadata(ctx context.Context, db *sql.DB, metadata map[string]string) 
 	return nil
 }
 
-func finalVacuum(ctx context.Context, db *sql.DB) error {
-	var busy, logFrames, checkpointedFrames int
-	if err := db.QueryRowContext(ctx, `pragma wal_checkpoint(TRUNCATE)`).Scan(&busy, &logFrames, &checkpointedFrames); err != nil {
-		return fmt.Errorf("checkpoint portable snapshot: %w", err)
+func createCompactDatabase(ctx context.Context, db *sql.DB, workingPath string) (_ string, retErr error) {
+	placeholder, err := os.CreateTemp(filepath.Dir(workingPath), "."+filepath.Base(workingPath)+".compact-*")
+	if err != nil {
+		return "", fmt.Errorf("reserve compact portable database path: %w", err)
 	}
-	if busy != 0 {
-		return fmt.Errorf("checkpoint portable snapshot: busy with %d of %d frames checkpointed", checkpointedFrames, logFrames)
+	compactPath := placeholder.Name()
+	if err := placeholder.Close(); err != nil {
+		_ = os.Remove(compactPath)
+		return "", fmt.Errorf("close compact portable database placeholder: %w", err)
 	}
-	if _, err := db.ExecContext(ctx, `vacuum`); err != nil {
-		return fmt.Errorf("vacuum portable snapshot: %w", err)
+	if err := os.Remove(compactPath); err != nil {
+		return "", fmt.Errorf("prepare compact portable database path: %w", err)
+	}
+	complete := false
+	defer func() {
+		if complete {
+			return
+		}
+		if err := os.Remove(compactPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			retErr = errors.Join(retErr, fmt.Errorf("remove partial compact database: %w", err))
+		}
+		for _, suffix := range []string{"-wal", "-shm"} {
+			if err := os.Remove(compactPath + suffix); err != nil && !errors.Is(err, os.ErrNotExist) {
+				retErr = errors.Join(retErr, fmt.Errorf("remove partial compact sidecar: %w", err))
+			}
+		}
+	}()
+	if _, err := db.ExecContext(ctx, `vacuum into ?`, compactPath); err != nil {
+		return "", fmt.Errorf("create compact portable database: %w", err)
+	}
+	if _, err := os.Stat(compactPath); err != nil {
+		return "", fmt.Errorf("stat compact portable database: %w", err)
+	}
+	complete = true
+	return compactPath, nil
+}
+
+func replaceWithCompactDatabase(ctx context.Context, workingPath, compactPath string) error {
+	db, err := sql.Open("sqlite", compactPath)
+	if err != nil {
+		return fmt.Errorf("open compact database candidate: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	quickCheck, checkErr := checkPragma(ctx, db, "quick_check")
+	closeErr := db.Close()
+	if checkErr != nil {
+		return fmt.Errorf("validate compact database candidate: %w", checkErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close compact database candidate: %w", closeErr)
+	}
+	if quickCheck != "ok" {
+		return fmt.Errorf("compact database candidate quick_check = %q", quickCheck)
+	}
+	if err := removeSQLiteSidecars(compactPath); err != nil {
+		return err
+	}
+	if err := removeSQLiteSidecars(workingPath); err != nil {
+		return err
+	}
+	if err := os.Remove(workingPath); err != nil {
+		return fmt.Errorf("remove uncompact portable database: %w", err)
+	}
+	if err := os.Rename(compactPath, workingPath); err != nil {
+		return fmt.Errorf("promote compact portable database: %w", err)
 	}
 	return nil
 }

--- a/internal/portable/export.go
+++ b/internal/portable/export.go
@@ -123,7 +123,6 @@ const (
 	StageRepositoryScope  Stage = "repository scope"
 	StageProfileOmissions Stage = "profile omissions"
 	StageCanonicalShaping Stage = "canonical shaping"
-	StageForeignKeyProof  Stage = "foreign key proof"
 	StageIndexRemoval     Stage = "index removal"
 	StageFinalVacuum      Stage = "final vacuum"
 	StageValidation       Stage = "validation"
@@ -307,7 +306,7 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 		return result, err
 	}
 	if options.Repository != "" {
-		scope, err := st.RestrictPortableRepository(ctx, options.Repository)
+		scope, err := st.RestrictPortableRepositoryWithOptions(ctx, options.Repository, store.PortableRepositoryScopeOptions{DeferForeignKeyValidation: true})
 		if err != nil {
 			return result, fmt.Errorf("restrict portable repository: %w", err)
 		}
@@ -349,18 +348,15 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 	for _, table := range pruneStats.DroppedTables {
 		droppedTables = appendUnique(droppedTables, table)
 	}
-	// Prove row relationships while schema indexes still exist. Everything
-	// after this point is transport shaping or metadata and cannot change them.
-	if err := reportProgress(ctx, options.Progress, StageForeignKeyProof); err != nil {
-		return result, err
+	// Current-state shaping proves foreign keys once, immediately before its
+	// threads rebuild while the original table and ordinary indexes still exist.
+	if !pruneStats.ForeignKeyValidated {
+		return result, fmt.Errorf("canonical portable shaping did not validate foreign keys")
 	}
-	foreignKeyViolations, err := foreignKeyCheck(ctx, st.DB())
-	if err != nil {
-		return result, err
-	}
+	foreignKeyViolations := pruneStats.ForeignKeyViolations
 	result.ForeignKeyViolations = foreignKeyViolations
 	if foreignKeyViolations != 0 {
-		return result, fmt.Errorf("portable database foreign_key_check failed with %d violations", foreignKeyViolations)
+		return result, fmt.Errorf("canonical portable shaping found %d foreign-key violations", foreignKeyViolations)
 	}
 	if err := reportProgress(ctx, options.Progress, StageIndexRemoval); err != nil {
 		return result, err
@@ -985,22 +981,6 @@ func checkPragma(ctx context.Context, db *sql.DB, pragma string) (string, error)
 		return "", fmt.Errorf("read SQLite %s: %w", pragma, err)
 	}
 	return strings.Join(messages, "; "), nil
-}
-
-func foreignKeyCheck(ctx context.Context, db *sql.DB) (int, error) {
-	rows, err := db.QueryContext(ctx, `pragma foreign_key_check`)
-	if err != nil {
-		return 0, fmt.Errorf("run SQLite foreign_key_check: %w", err)
-	}
-	defer rows.Close()
-	count := 0
-	for rows.Next() {
-		count++
-	}
-	if err := rows.Err(); err != nil {
-		return 0, fmt.Errorf("read SQLite foreign_key_check: %w", err)
-	}
-	return count, nil
 }
 
 func fileSHA256(filePath string) (string, error) {

--- a/internal/portable/export.go
+++ b/internal/portable/export.go
@@ -42,6 +42,7 @@ type Profile struct {
 	Capabilities  []string
 	Excluded      []string
 	IndexProfile  string
+	ColumnProfile string
 }
 
 var currentStateProfile = Profile{
@@ -92,7 +93,8 @@ var currentStateProfile = Profile{
 		"sync_attempt_failures",
 		"ordinary_indexes",
 	},
-	IndexProfile: "constraints-only",
+	IndexProfile:  "constraints-only",
+	ColumnProfile: store.PortableColumnProfileSanitizedCompatibility,
 }
 
 func ResolveProfile(name string) (Profile, error) {
@@ -175,6 +177,7 @@ type Manifest struct {
 	DroppedTables        []string    `json:"droppedTables"`
 	DroppedIndexes       []string    `json:"droppedIndexes"`
 	IndexProfile         string      `json:"indexProfile"`
+	ColumnProfile        string      `json:"columnProfile,omitempty"`
 }
 
 type ExportResult struct {
@@ -201,6 +204,7 @@ type ExportResult struct {
 	DroppedTables        []string    `json:"dropped_tables"`
 	DroppedIndexes       []string    `json:"dropped_indexes"`
 	ArtifactCommitted    bool        `json:"artifact_committed"`
+	ColumnProfile        string      `json:"column_profile,omitempty"`
 }
 
 type exporter struct {
@@ -276,6 +280,7 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 		BytesBefore:    sourceInfo.Size(),
 		MaxBytes:       options.MaxBytes,
 		ByteBudgetOK:   true,
+		ColumnProfile:  profile.ColumnProfile,
 	}
 	if err := reportProgress(ctx, options.Progress, StageSnapshot); err != nil {
 		return result, err
@@ -329,11 +334,12 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 		}
 	}
 	pruneStats, err := st.PrunePortablePayloads(ctx, store.PortablePruneOptions{
-		BodyChars:           options.BodyChars,
-		Vacuum:              false,
-		IncludeSyncFailures: false,
-		DeferSecureRewrite:  true,
-		Progress:            pruneProgress,
+		BodyChars:                     options.BodyChars,
+		Vacuum:                        false,
+		IncludeSyncFailures:           false,
+		DeferSecureRewrite:            true,
+		RetainSanitizedPayloadColumns: true,
+		Progress:                      pruneProgress,
 	})
 	if err != nil {
 		return result, fmt.Errorf("apply canonical portable shaping: %w", err)
@@ -382,6 +388,7 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 		"exported_at":     exportedAt,
 		"source_path":     options.PublicPath,
 		"index_profile":   profile.IndexProfile,
+		"column_profile":  profile.ColumnProfile,
 	}
 	if err := writeMetadata(ctx, st.DB(), metadata); err != nil {
 		return result, err
@@ -491,6 +498,7 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 		DroppedTables:        droppedTables,
 		DroppedIndexes:       droppedIndexes,
 		IndexProfile:         profile.IndexProfile,
+		ColumnProfile:        profile.ColumnProfile,
 	}
 	if e.beforeManifest != nil {
 		if err := e.beforeManifest(); err != nil {
@@ -1129,6 +1137,7 @@ func validateManifestPair(ctx context.Context, dbPath, manifestPath string, expe
 		"profile_version": fmt.Sprintf("%d", actual.ProfileVersion),
 		"source_path":     actual.OutputPath,
 		"index_profile":   actual.IndexProfile,
+		"column_profile":  actual.ColumnProfile,
 	} {
 		var got string
 		if err := db.QueryRowContext(ctx, `select value from portable_metadata where key = ?`, key).Scan(&got); err != nil {

--- a/internal/portable/export.go
+++ b/internal/portable/export.go
@@ -109,7 +109,25 @@ type ExportOptions struct {
 	Repository   string
 	BodyChars    int
 	MaxBytes     *int64
+	Progress     ProgressFunc
 }
+
+type Stage string
+
+const (
+	StageSnapshot         Stage = "snapshot"
+	StageRepositoryScope  Stage = "repository scope"
+	StageProfileOmissions Stage = "profile omissions"
+	StageCanonicalShaping Stage = "canonical shaping"
+	StageForeignKeyProof  Stage = "foreign key proof"
+	StageIndexRemoval     Stage = "index removal"
+	StageFinalVacuum      Stage = "final vacuum"
+	StageValidation       Stage = "validation"
+	StageManifest         Stage = "manifest"
+	StageArtifactCommit   Stage = "artifact commit"
+)
+
+type ProgressFunc func(Stage)
 
 type Repository struct {
 	ID       int64  `json:"id"`
@@ -247,6 +265,9 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 		MaxBytes:       options.MaxBytes,
 		ByteBudgetOK:   true,
 	}
+	if err := reportProgress(ctx, options.Progress, StageSnapshot); err != nil {
+		return result, err
+	}
 	if err := snapshotSQLite(ctx, sourcePath, dbPath); err != nil {
 		return result, err
 	}
@@ -260,12 +281,34 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 			_ = st.Close()
 		}
 	}()
+	if err := configureDisposableStore(ctx, st.DB()); err != nil {
+		return result, err
+	}
+	if err := reportProgress(ctx, options.Progress, StageRepositoryScope); err != nil {
+		return result, err
+	}
 	if options.Repository != "" {
 		scope, err := st.RestrictPortableRepository(ctx, options.Repository)
 		if err != nil {
 			return result, fmt.Errorf("restrict portable repository: %w", err)
 		}
 		result.Repository = repositoryFromStore(scope.Repository)
+	}
+	if err := reportProgress(ctx, options.Progress, StageProfileOmissions); err != nil {
+		return result, err
+	}
+	var droppedTables []string
+	for _, table := range profile.DroppedTables {
+		dropped, err := dropTableIfPresent(ctx, st.DB(), table)
+		if err != nil {
+			return result, err
+		}
+		if dropped {
+			droppedTables = appendUnique(droppedTables, table)
+		}
+	}
+	if err := reportProgress(ctx, options.Progress, StageCanonicalShaping); err != nil {
+		return result, err
 	}
 	pruneStats, err := st.PrunePortablePayloads(ctx, store.PortablePruneOptions{
 		BodyChars:           options.BodyChars,
@@ -276,15 +319,24 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 	if err != nil {
 		return result, fmt.Errorf("apply canonical portable shaping: %w", err)
 	}
-	droppedTables := append([]string(nil), pruneStats.DroppedTables...)
-	for _, table := range profile.DroppedTables {
-		dropped, err := dropTableIfPresent(ctx, st.DB(), table)
-		if err != nil {
-			return result, err
-		}
-		if dropped {
-			droppedTables = append(droppedTables, table)
-		}
+	for _, table := range pruneStats.DroppedTables {
+		droppedTables = appendUnique(droppedTables, table)
+	}
+	// Prove row relationships while schema indexes still exist. Everything
+	// after this point is transport shaping or metadata and cannot change them.
+	if err := reportProgress(ctx, options.Progress, StageForeignKeyProof); err != nil {
+		return result, err
+	}
+	foreignKeyViolations, err := foreignKeyCheck(ctx, st.DB())
+	if err != nil {
+		return result, err
+	}
+	result.ForeignKeyViolations = foreignKeyViolations
+	if foreignKeyViolations != 0 {
+		return result, fmt.Errorf("portable database foreign_key_check failed with %d violations", foreignKeyViolations)
+	}
+	if err := reportProgress(ctx, options.Progress, StageIndexRemoval); err != nil {
+		return result, err
 	}
 	droppedIndexes, err := ordinaryNonUniqueIndexes(ctx, st.DB())
 	if err != nil {
@@ -318,10 +370,16 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 	if _, err := st.DB().ExecContext(ctx, `delete from portable_metadata where key = 'sync_failure_scrub_pending'`); err != nil {
 		return result, fmt.Errorf("clear portable scrub marker: %w", err)
 	}
+	if err := reportProgress(ctx, options.Progress, StageFinalVacuum); err != nil {
+		return result, err
+	}
 	if err := finalVacuum(ctx, st.DB()); err != nil {
 		return result, err
 	}
 	result.Vacuumed = true
+	if err := reportProgress(ctx, options.Progress, StageValidation); err != nil {
+		return result, err
+	}
 	quickCheck, err := checkPragma(ctx, st.DB(), "quick_check")
 	if err != nil {
 		return result, err
@@ -330,15 +388,10 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 	if err != nil {
 		return result, err
 	}
-	foreignKeyViolations, err := foreignKeyCheck(ctx, st.DB())
-	if err != nil {
-		return result, err
-	}
 	result.QuickCheck = quickCheck
 	result.IntegrityCheck = integrityCheck
-	result.ForeignKeyViolations = foreignKeyViolations
-	if quickCheck != "ok" || integrityCheck != "ok" || foreignKeyViolations != 0 {
-		return result, fmt.Errorf("portable database validation failed: quick_check=%q integrity_check=%q foreign_key_violations=%d", quickCheck, integrityCheck, foreignKeyViolations)
+	if quickCheck != "ok" || integrityCheck != "ok" {
+		return result, fmt.Errorf("portable database validation failed: quick_check=%q integrity_check=%q", quickCheck, integrityCheck)
 	}
 	if result.Repository == nil {
 		result.Repository, err = singleRepository(ctx, st.DB())
@@ -376,6 +429,9 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 	result.ArtifactID = sha
 	result.DroppedTables = droppedTables
 	result.DroppedIndexes = droppedIndexes
+	if err := reportProgress(ctx, options.Progress, StageManifest); err != nil {
+		return result, err
+	}
 	manifest := Manifest{
 		Schema:               portableSchema,
 		PortableSchema:       portableSchema,
@@ -436,6 +492,9 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return result, fmt.Errorf("inspect output directory before commit: %w", err)
 	}
+	if err := reportProgress(ctx, options.Progress, StageArtifactCommit); err != nil {
+		return result, err
+	}
 	// The portable artifact contract deliberately uses a sibling rename and
 	// portable Go filesystem APIs, so recheck the nonexistent target at the
 	// last possible point before committing the directory.
@@ -445,6 +504,46 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 	bestEffortSyncDir(filepath.Dir(outputDir))
 	result.ArtifactCommitted = true
 	return result, nil
+}
+
+func reportProgress(ctx context.Context, progress ProgressFunc, stage Stage) error {
+	if progress != nil {
+		progress(stage)
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("portable export canceled during %s: %w", stage, err)
+	}
+	return nil
+}
+
+func appendUnique(values []string, value string) []string {
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}
+
+func configureDisposableStore(ctx context.Context, db *sql.DB) error {
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	var mode string
+	if err := db.QueryRowContext(ctx, `pragma journal_mode = delete`).Scan(&mode); err != nil {
+		return fmt.Errorf("configure disposable journal mode: %w", err)
+	}
+	if !strings.EqualFold(strings.TrimSpace(mode), "delete") {
+		return fmt.Errorf("configure disposable journal mode: got %q, want delete", mode)
+	}
+	// Staging is private and discarded on error. Final integrity checks and
+	// explicit file/directory fsyncs remain the durability boundary.
+	if _, err := db.ExecContext(ctx, `pragma synchronous = off`); err != nil {
+		return fmt.Errorf("configure disposable synchronous mode: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `pragma temp_store = memory`); err != nil {
+		return fmt.Errorf("configure disposable temp store: %w", err)
+	}
+	return nil
 }
 
 func ValidateDatabaseName(name string) error {
@@ -804,12 +903,11 @@ func validateManifestPair(ctx context.Context, dbPath, manifestPath string, expe
 	if integrity != actual.IntegrityCheck || integrity != "ok" {
 		return fmt.Errorf("portable manifest integrityCheck does not match database")
 	}
-	violations, err := foreignKeyCheck(ctx, db)
-	if err != nil {
-		return err
-	}
-	if violations != actual.ForeignKeyViolations || violations != 0 {
-		return fmt.Errorf("portable manifest foreignKeyViolations does not match database")
+	// The semantic pipeline proves foreign keys before dropping transport-only
+	// indexes. Repeating foreign_key_check here would turn manifest validation
+	// into a pathological unindexed scan on large archives.
+	if actual.ForeignKeyViolations != 0 {
+		return fmt.Errorf("portable manifest records %d foreign-key violations", actual.ForeignKeyViolations)
 	}
 	tables, err := databaseTableStats(ctx, db)
 	if err != nil {

--- a/internal/portable/export.go
+++ b/internal/portable/export.go
@@ -322,11 +322,18 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 	if err := reportProgress(ctx, options.Progress, StageCanonicalShaping); err != nil {
 		return result, err
 	}
+	var pruneProgress store.PortablePruneProgressFunc
+	if options.Progress != nil {
+		pruneProgress = func(stage store.PortablePruneStage) {
+			options.Progress(Stage("canonical shaping: " + string(stage)))
+		}
+	}
 	pruneStats, err := st.PrunePortablePayloads(ctx, store.PortablePruneOptions{
 		BodyChars:           options.BodyChars,
 		Vacuum:              false,
 		IncludeSyncFailures: false,
 		DeferSecureRewrite:  true,
+		Progress:            pruneProgress,
 	})
 	if err != nil {
 		return result, fmt.Errorf("apply canonical portable shaping: %w", err)
@@ -562,19 +569,36 @@ func configureDisposableStore(ctx context.Context, db *sql.DB) error {
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
 	var mode string
-	if err := db.QueryRowContext(ctx, `pragma journal_mode = delete`).Scan(&mode); err != nil {
+	if err := db.QueryRowContext(ctx, `pragma journal_mode = off`).Scan(&mode); err != nil {
 		return fmt.Errorf("configure disposable journal mode: %w", err)
 	}
-	if !strings.EqualFold(strings.TrimSpace(mode), "delete") {
-		return fmt.Errorf("configure disposable journal mode: got %q, want delete", mode)
+	if !strings.EqualFold(strings.TrimSpace(mode), "off") {
+		return fmt.Errorf("configure disposable journal mode: got %q, want off", mode)
 	}
-	// Staging is private and discarded on error. Final integrity checks and
-	// explicit file/directory fsyncs remain the durability boundary.
+	// The working generation is private and deleted on any error, so it needs no
+	// rollback journal. The mandatory compact generation restores privacy and is
+	// fully validated, hashed, fsynced, and atomically committed for durability.
 	if _, err := db.ExecContext(ctx, `pragma synchronous = off`); err != nil {
 		return fmt.Errorf("configure disposable synchronous mode: %w", err)
 	}
+	if _, err := db.ExecContext(ctx, `pragma secure_delete = off`); err != nil {
+		return fmt.Errorf("configure disposable secure-delete mode: %w", err)
+	}
 	if _, err := db.ExecContext(ctx, `pragma temp_store = memory`); err != nil {
 		return fmt.Errorf("configure disposable temp store: %w", err)
+	}
+	var synchronous, secureDelete, tempStore int
+	if err := db.QueryRowContext(ctx, `pragma synchronous`).Scan(&synchronous); err != nil {
+		return fmt.Errorf("verify disposable synchronous mode: %w", err)
+	}
+	if err := db.QueryRowContext(ctx, `pragma secure_delete`).Scan(&secureDelete); err != nil {
+		return fmt.Errorf("verify disposable secure-delete mode: %w", err)
+	}
+	if err := db.QueryRowContext(ctx, `pragma temp_store`).Scan(&tempStore); err != nil {
+		return fmt.Errorf("verify disposable temp store: %w", err)
+	}
+	if synchronous != 0 || secureDelete != 0 || tempStore != 2 {
+		return fmt.Errorf("configure disposable settings: synchronous=%d secure_delete=%d temp_store=%d, want 0/0/2", synchronous, secureDelete, tempStore)
 	}
 	return nil
 }

--- a/internal/portable/export.go
+++ b/internal/portable/export.go
@@ -288,6 +288,8 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 	if err := snapshotSQLite(ctx, sourcePath, dbPath); err != nil {
 		return result, err
 	}
+	// Opening the disposable snapshot migrates valid older/physically-pruned
+	// portable schemas back to the current writable schema before shaping.
 	st, err := store.Open(ctx, dbPath)
 	if err != nil {
 		return result, fmt.Errorf("open disposable portable snapshot: %w", err)
@@ -363,15 +365,20 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 	if err := reportProgress(ctx, options.Progress, StageIndexRemoval); err != nil {
 		return result, err
 	}
-	droppedIndexes, err := ordinaryNonUniqueIndexes(ctx, st.DB())
+	remainingIndexes, err := ordinaryNonUniqueIndexes(ctx, st.DB())
 	if err != nil {
 		return result, err
 	}
-	for _, index := range droppedIndexes {
+	for _, index := range remainingIndexes {
 		if _, err := st.DB().ExecContext(ctx, `drop index if exists `+quoteIdentifier(index)); err != nil {
 			return result, fmt.Errorf("drop portable index %s: %w", index, err)
 		}
 	}
+	var droppedIndexes []string
+	for _, index := range append(pruneStats.DroppedIndexes, remainingIndexes...) {
+		droppedIndexes = appendUnique(droppedIndexes, index)
+	}
+	sort.Strings(droppedIndexes)
 	tableNames, err := databaseTableNames(ctx, st.DB())
 	if err != nil {
 		return result, err

--- a/internal/portable/export.go
+++ b/internal/portable/export.go
@@ -1,0 +1,748 @@
+package portable
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/openclaw/gitcrawl/internal/store"
+	_ "modernc.org/sqlite"
+)
+
+const (
+	CurrentStateV1        = "current-state-v1"
+	portableSchema        = "gitcrawl-portable-sync-v2"
+	currentProfileVersion = 1
+	defaultBodyChars      = 256
+)
+
+// Profile defines a portable artifact's semantic policy independently of CLI
+// parsing and publication concerns.
+type Profile struct {
+	Name          string
+	Version       int
+	DroppedTables []string
+	Capabilities  []string
+	Excluded      []string
+	IndexProfile  string
+}
+
+var currentStateProfile = Profile{
+	Name:    CurrentStateV1,
+	Version: currentProfileVersion,
+	DroppedTables: []string{
+		"comment_revisions",
+		"thread_key_summaries",
+		"cluster_closures",
+		"cluster_overrides",
+		"cluster_aliases",
+		"cluster_memberships",
+		"cluster_groups",
+	},
+	Capabilities: []string{
+		"body_excerpts",
+		"comment_excerpts",
+		"author_association",
+		"current_comments",
+		"thread_revisions",
+		"thread_fingerprints",
+		"pr_details",
+		"pr_files",
+		"pr_commits",
+		"pr_checks",
+		"pr_review_threads",
+		"workflow_runs",
+		"family_tombstones",
+		"thread_child_observation_memberships",
+		"raw_json_stripped",
+	},
+	Excluded: []string{
+		"raw_json",
+		"documents",
+		"fts",
+		"vectors",
+		"code_snapshots",
+		"code_documents",
+		"comment_revision_history",
+		"thread_key_summaries",
+		"cluster_governance",
+		"cluster_lineage",
+		"cluster_state",
+		"run_history",
+		"similarity_edges",
+		"blobs",
+		"sync_attempt_failures",
+		"ordinary_indexes",
+	},
+	IndexProfile: "constraints-only",
+}
+
+func ResolveProfile(name string) (Profile, error) {
+	if name != CurrentStateV1 {
+		return Profile{}, fmt.Errorf("unsupported portable export profile %q; supported profile: %s", name, CurrentStateV1)
+	}
+	return currentStateProfile, nil
+}
+
+type ExportOptions struct {
+	SourceDBPath string
+	OutputDir    string
+	DatabaseName string
+	PublicPath   string
+	Profile      string
+	BodyChars    int
+	MaxBytes     *int64
+}
+
+type Manifest struct {
+	Schema               string   `json:"schema"`
+	PortableSchema       string   `json:"portableSchema"`
+	Profile              string   `json:"profile"`
+	ProfileVersion       int      `json:"profileVersion"`
+	ExportedAt           string   `json:"exportedAt"`
+	OutputPath           string   `json:"outputPath"`
+	OutputBytes          int64    `json:"outputBytes"`
+	SHA256               string   `json:"sha256"`
+	ArtifactID           string   `json:"artifactId"`
+	BodyChars            int      `json:"bodyChars"`
+	MaxBytes             *int64   `json:"maxBytes,omitempty"`
+	Tables               []string `json:"tables"`
+	Excluded             []string `json:"excluded"`
+	ValidationOK         bool     `json:"validationOk"`
+	QuickCheck           string   `json:"quickCheck"`
+	IntegrityCheck       string   `json:"integrityCheck"`
+	ForeignKeyViolations int      `json:"foreignKeyViolations"`
+	DroppedTables        []string `json:"droppedTables"`
+	DroppedIndexes       []string `json:"droppedIndexes"`
+	IndexProfile         string   `json:"indexProfile"`
+}
+
+type ExportResult struct {
+	Profile              string   `json:"profile"`
+	PortableSchema       string   `json:"portable_schema"`
+	Schema               string   `json:"schema"`
+	SourceDBPath         string   `json:"source_db_path"`
+	OutputDir            string   `json:"output_dir"`
+	DatabasePath         string   `json:"database_path"`
+	ManifestPath         string   `json:"manifest_path"`
+	PublicPath           string   `json:"public_path"`
+	BodyChars            int      `json:"body_chars"`
+	BytesBefore          int64    `json:"bytes_before"`
+	BytesAfter           int64    `json:"bytes_after"`
+	MaxBytes             *int64   `json:"max_bytes,omitempty"`
+	ByteBudgetOK         bool     `json:"byte_budget_ok"`
+	ArtifactID           string   `json:"artifact_id"`
+	SHA256               string   `json:"sha256"`
+	QuickCheck           string   `json:"quick_check"`
+	IntegrityCheck       string   `json:"integrity_check"`
+	ForeignKeyViolations int      `json:"foreign_key_violations"`
+	Vacuumed             bool     `json:"vacuumed"`
+	DroppedTables        []string `json:"dropped_tables"`
+	DroppedIndexes       []string `json:"dropped_indexes"`
+	ArtifactCommitted    bool     `json:"artifact_committed"`
+}
+
+type exporter struct {
+	beforeManifest func() error
+	beforeCommit   func() error
+}
+
+func Export(ctx context.Context, options ExportOptions) (ExportResult, error) {
+	return exporter{}.export(ctx, options)
+}
+
+func (e exporter) export(ctx context.Context, options ExportOptions) (result ExportResult, err error) {
+	profile, err := ResolveProfile(options.Profile)
+	if err != nil {
+		return result, err
+	}
+	if options.BodyChars <= 0 {
+		options.BodyChars = defaultBodyChars
+	}
+	if err := ValidateDatabaseName(options.DatabaseName); err != nil {
+		return result, err
+	}
+	if err := ValidatePublicPath(options.PublicPath); err != nil {
+		return result, err
+	}
+	if options.MaxBytes != nil && *options.MaxBytes <= 0 {
+		return result, fmt.Errorf("max-bytes must be a positive integer")
+	}
+	sourcePath, err := filepath.Abs(options.SourceDBPath)
+	if err != nil {
+		return result, fmt.Errorf("resolve source database path: %w", err)
+	}
+	outputDir, err := filepath.Abs(options.OutputDir)
+	if err != nil {
+		return result, fmt.Errorf("resolve output directory: %w", err)
+	}
+	if _, err := os.Lstat(outputDir); err == nil {
+		return result, fmt.Errorf("output directory already exists: %s", outputDir)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return result, fmt.Errorf("inspect output directory: %w", err)
+	}
+	sourceInfo, err := os.Stat(sourcePath)
+	if err != nil {
+		return result, fmt.Errorf("stat source database: %w", err)
+	}
+	if !sourceInfo.Mode().IsRegular() {
+		return result, fmt.Errorf("source database is not a regular file: %s", sourcePath)
+	}
+	if err := os.MkdirAll(filepath.Dir(outputDir), 0o755); err != nil {
+		return result, fmt.Errorf("create output parent: %w", err)
+	}
+	stageDir, err := os.MkdirTemp(filepath.Dir(outputDir), ".gitcrawl-portable-export-*")
+	if err != nil {
+		return result, fmt.Errorf("create portable export staging directory: %w", err)
+	}
+	defer func() {
+		if !result.ArtifactCommitted {
+			_ = os.RemoveAll(stageDir)
+		}
+	}()
+	dbPath := filepath.Join(stageDir, options.DatabaseName)
+	manifestPath := dbPath + ".manifest.json"
+	result = ExportResult{
+		Profile:        profile.Name,
+		PortableSchema: portableSchema,
+		Schema:         portableSchema,
+		SourceDBPath:   sourcePath,
+		OutputDir:      outputDir,
+		DatabasePath:   filepath.Join(outputDir, options.DatabaseName),
+		ManifestPath:   filepath.Join(outputDir, options.DatabaseName+".manifest.json"),
+		PublicPath:     options.PublicPath,
+		BodyChars:      options.BodyChars,
+		BytesBefore:    sourceInfo.Size(),
+		MaxBytes:       options.MaxBytes,
+		ByteBudgetOK:   true,
+	}
+	if err := snapshotSQLite(ctx, sourcePath, dbPath); err != nil {
+		return result, err
+	}
+	st, err := store.Open(ctx, dbPath)
+	if err != nil {
+		return result, fmt.Errorf("open disposable portable snapshot: %w", err)
+	}
+	closed := false
+	defer func() {
+		if !closed {
+			_ = st.Close()
+		}
+	}()
+	droppedIndexes, err := ordinaryNonUniqueIndexes(ctx, st.DB())
+	if err != nil {
+		return result, err
+	}
+	pruneStats, err := st.PrunePortablePayloads(ctx, store.PortablePruneOptions{
+		BodyChars:           options.BodyChars,
+		Vacuum:              false,
+		IncludeSyncFailures: false,
+		DeferSecureRewrite:  true,
+	})
+	if err != nil {
+		return result, fmt.Errorf("apply canonical portable shaping: %w", err)
+	}
+	droppedTables := append([]string(nil), pruneStats.DroppedTables...)
+	for _, table := range profile.DroppedTables {
+		dropped, err := dropTableIfPresent(ctx, st.DB(), table)
+		if err != nil {
+			return result, err
+		}
+		if dropped {
+			droppedTables = append(droppedTables, table)
+		}
+	}
+	for _, index := range droppedIndexes {
+		if _, err := st.DB().ExecContext(ctx, `drop index if exists `+quoteIdentifier(index)); err != nil {
+			return result, fmt.Errorf("drop portable index %s: %w", index, err)
+		}
+	}
+	tables, err := databaseTables(ctx, st.DB())
+	if err != nil {
+		return result, err
+	}
+	exportedAt := time.Now().UTC().Format(time.RFC3339Nano)
+	metadata := map[string]string{
+		"schema":          portableSchema,
+		"profile":         profile.Name,
+		"profile_version": fmt.Sprintf("%d", profile.Version),
+		"body_chars":      fmt.Sprintf("%d", options.BodyChars),
+		"capabilities":    strings.Join(profile.Capabilities, ","),
+		"includes":        strings.Join(tables, ","),
+		"excluded":        strings.Join(profile.Excluded, ","),
+		"exported_at":     exportedAt,
+		"source_path":     options.PublicPath,
+		"index_profile":   profile.IndexProfile,
+	}
+	if err := writeMetadata(ctx, st.DB(), metadata); err != nil {
+		return result, err
+	}
+	if _, err := st.DB().ExecContext(ctx, `delete from portable_metadata where key = 'sync_failure_scrub_pending'`); err != nil {
+		return result, fmt.Errorf("clear portable scrub marker: %w", err)
+	}
+	if err := finalVacuum(ctx, st.DB()); err != nil {
+		return result, err
+	}
+	result.Vacuumed = true
+	quickCheck, err := checkPragma(ctx, st.DB(), "quick_check")
+	if err != nil {
+		return result, err
+	}
+	integrityCheck, err := checkPragma(ctx, st.DB(), "integrity_check")
+	if err != nil {
+		return result, err
+	}
+	foreignKeyViolations, err := foreignKeyCheck(ctx, st.DB())
+	if err != nil {
+		return result, err
+	}
+	result.QuickCheck = quickCheck
+	result.IntegrityCheck = integrityCheck
+	result.ForeignKeyViolations = foreignKeyViolations
+	if quickCheck != "ok" || integrityCheck != "ok" || foreignKeyViolations != 0 {
+		return result, fmt.Errorf("portable database validation failed: quick_check=%q integrity_check=%q foreign_key_violations=%d", quickCheck, integrityCheck, foreignKeyViolations)
+	}
+	if err := st.Close(); err != nil {
+		return result, fmt.Errorf("close portable snapshot: %w", err)
+	}
+	closed = true
+	if err := removeSQLiteSidecars(dbPath); err != nil {
+		return result, err
+	}
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		return result, fmt.Errorf("stat finalized portable database: %w", err)
+	}
+	result.BytesAfter = info.Size()
+	if options.MaxBytes != nil && info.Size() > *options.MaxBytes {
+		result.ByteBudgetOK = false
+		return result, fmt.Errorf("portable database size %d exceeds max-bytes %d", info.Size(), *options.MaxBytes)
+	}
+	sha, err := fileSHA256(dbPath)
+	if err != nil {
+		return result, fmt.Errorf("hash portable database: %w", err)
+	}
+	result.SHA256 = sha
+	result.ArtifactID = sha
+	result.DroppedTables = droppedTables
+	result.DroppedIndexes = droppedIndexes
+	manifest := Manifest{
+		Schema:               portableSchema,
+		PortableSchema:       portableSchema,
+		Profile:              profile.Name,
+		ProfileVersion:       profile.Version,
+		ExportedAt:           exportedAt,
+		OutputPath:           options.PublicPath,
+		OutputBytes:          info.Size(),
+		SHA256:               sha,
+		ArtifactID:           sha,
+		BodyChars:            options.BodyChars,
+		MaxBytes:             options.MaxBytes,
+		Tables:               tables,
+		Excluded:             append([]string(nil), profile.Excluded...),
+		ValidationOK:         true,
+		QuickCheck:           quickCheck,
+		IntegrityCheck:       integrityCheck,
+		ForeignKeyViolations: foreignKeyViolations,
+		DroppedTables:        droppedTables,
+		DroppedIndexes:       droppedIndexes,
+		IndexProfile:         profile.IndexProfile,
+	}
+	if e.beforeManifest != nil {
+		if err := e.beforeManifest(); err != nil {
+			return result, err
+		}
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return result, fmt.Errorf("marshal portable manifest: %w", err)
+	}
+	if err := writeSyncedFile(manifestPath, append(data, '\n'), 0o644); err != nil {
+		return result, fmt.Errorf("write portable manifest: %w", err)
+	}
+	if err := syncRegularFile(dbPath); err != nil {
+		return result, fmt.Errorf("sync portable database: %w", err)
+	}
+	if err := validateManifestPair(ctx, dbPath, manifestPath, manifest); err != nil {
+		return result, err
+	}
+	if err := removeSQLiteSidecars(dbPath); err != nil {
+		return result, err
+	}
+	if finalSHA, err := fileSHA256(dbPath); err != nil {
+		return result, fmt.Errorf("re-hash portable database after validation: %w", err)
+	} else if finalSHA != sha {
+		return result, fmt.Errorf("portable database changed during manifest validation")
+	}
+	bestEffortSyncDir(stageDir)
+	if e.beforeCommit != nil {
+		if err := e.beforeCommit(); err != nil {
+			return result, err
+		}
+	}
+	if _, err := os.Lstat(outputDir); err == nil {
+		return result, fmt.Errorf("output directory already exists: %s", outputDir)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return result, fmt.Errorf("inspect output directory before commit: %w", err)
+	}
+	// The portable artifact contract deliberately uses a sibling rename and
+	// portable Go filesystem APIs, so recheck the nonexistent target at the
+	// last possible point before committing the directory.
+	if err := os.Rename(stageDir, outputDir); err != nil {
+		return result, fmt.Errorf("commit portable artifact: %w", err)
+	}
+	bestEffortSyncDir(filepath.Dir(outputDir))
+	result.ArtifactCommitted = true
+	return result, nil
+}
+
+func ValidateDatabaseName(name string) error {
+	if name == "" || name == "." || name == ".." || strings.TrimSpace(name) != name ||
+		strings.ContainsAny(name, "/\\\x00") || filepath.Base(name) != name {
+		return fmt.Errorf("database-name must be a safe basename")
+	}
+	lower := strings.ToLower(name)
+	if strings.HasSuffix(lower, "-wal") || strings.HasSuffix(lower, "-shm") || strings.HasSuffix(lower, ".manifest.json") {
+		return fmt.Errorf("database-name must not use a SQLite sidecar or manifest suffix")
+	}
+	for _, r := range name {
+		if !unicode.IsLetter(r) && !unicode.IsNumber(r) && r != '.' && r != '-' && r != '_' {
+			return fmt.Errorf("database-name must contain only letters, numbers, dots, dashes, or underscores")
+		}
+	}
+	return nil
+}
+
+func ValidatePublicPath(value string) error {
+	if value == "" || strings.TrimSpace(value) != value || strings.ContainsAny(value, "\\\x00") ||
+		strings.HasPrefix(value, "/") || path.Clean(value) != value || value == "." {
+		return fmt.Errorf("public-path must be a clean relative slash path")
+	}
+	for _, part := range strings.Split(value, "/") {
+		if part == "" || part == "." || part == ".." {
+			return fmt.Errorf("public-path must be a clean relative slash path without traversal")
+		}
+	}
+	if len(value) >= 2 && value[1] == ':' {
+		return fmt.Errorf("public-path must not be an absolute host path")
+	}
+	return nil
+}
+
+func snapshotSQLite(ctx context.Context, sourcePath, targetPath string) error {
+	abs, err := filepath.Abs(sourcePath)
+	if err != nil {
+		return fmt.Errorf("resolve snapshot source: %w", err)
+	}
+	if runtime.GOOS == "windows" {
+		abs = filepath.ToSlash(abs)
+		if filepath.VolumeName(abs) != "" && !strings.HasPrefix(abs, "/") {
+			abs = "/" + abs
+		}
+	}
+	u := url.URL{Scheme: "file", Path: abs}
+	query := u.Query()
+	query.Set("mode", "ro")
+	query.Add("_pragma", "busy_timeout(5000)")
+	u.RawQuery = query.Encode()
+	db, err := sql.Open("sqlite", u.String())
+	if err != nil {
+		return fmt.Errorf("open source database for snapshot: %w", err)
+	}
+	defer db.Close()
+	if _, err := db.ExecContext(ctx, `vacuum into ?`, targetPath); err != nil {
+		return fmt.Errorf("snapshot source database: %w", err)
+	}
+	return nil
+}
+
+func ordinaryNonUniqueIndexes(ctx context.Context, db *sql.DB) ([]string, error) {
+	tables, err := databaseTables(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{})
+	for _, table := range tables {
+		rows, err := db.QueryContext(ctx, `pragma index_list(`+quoteIdentifier(table)+`)`)
+		if err != nil {
+			return nil, fmt.Errorf("list indexes for %s: %w", table, err)
+		}
+		for rows.Next() {
+			var sequence, unique, partial int
+			var name, origin string
+			if err := rows.Scan(&sequence, &name, &unique, &origin, &partial); err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("scan indexes for %s: %w", table, err)
+			}
+			if origin == "c" && unique == 0 {
+				seen[name] = struct{}{}
+			}
+		}
+		if err := rows.Close(); err != nil {
+			return nil, fmt.Errorf("close indexes for %s: %w", table, err)
+		}
+	}
+	indexes := make([]string, 0, len(seen))
+	for name := range seen {
+		indexes = append(indexes, name)
+	}
+	sort.Strings(indexes)
+	return indexes, nil
+}
+
+func databaseTables(ctx context.Context, db *sql.DB) ([]string, error) {
+	rows, err := db.QueryContext(ctx, `select name from sqlite_schema where type = 'table' and name not like 'sqlite_%' order by name`)
+	if err != nil {
+		return nil, fmt.Errorf("list portable tables: %w", err)
+	}
+	defer rows.Close()
+	var tables []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan portable table: %w", err)
+		}
+		tables = append(tables, name)
+	}
+	return tables, rows.Err()
+}
+
+func dropTableIfPresent(ctx context.Context, db *sql.DB, table string) (bool, error) {
+	var exists int
+	if err := db.QueryRowContext(ctx, `select exists(select 1 from sqlite_schema where type = 'table' and name = ?)`, table).Scan(&exists); err != nil {
+		return false, fmt.Errorf("inspect portable table %s: %w", table, err)
+	}
+	if exists == 0 {
+		return false, nil
+	}
+	if _, err := db.ExecContext(ctx, `drop table `+quoteIdentifier(table)); err != nil {
+		return false, fmt.Errorf("drop portable table %s: %w", table, err)
+	}
+	return true, nil
+}
+
+func quoteIdentifier(value string) string {
+	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`
+}
+
+func writeMetadata(ctx context.Context, db *sql.DB, metadata map[string]string) error {
+	keys := make([]string, 0, len(metadata))
+	for key := range metadata {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if _, err := db.ExecContext(ctx, `
+			insert into portable_metadata(key, value) values(?, ?)
+			on conflict(key) do update set value = excluded.value
+		`, key, metadata[key]); err != nil {
+			return fmt.Errorf("write portable metadata %s: %w", key, err)
+		}
+	}
+	return nil
+}
+
+func finalVacuum(ctx context.Context, db *sql.DB) error {
+	var busy, logFrames, checkpointedFrames int
+	if err := db.QueryRowContext(ctx, `pragma wal_checkpoint(TRUNCATE)`).Scan(&busy, &logFrames, &checkpointedFrames); err != nil {
+		return fmt.Errorf("checkpoint portable snapshot: %w", err)
+	}
+	if busy != 0 {
+		return fmt.Errorf("checkpoint portable snapshot: busy with %d of %d frames checkpointed", checkpointedFrames, logFrames)
+	}
+	if _, err := db.ExecContext(ctx, `vacuum`); err != nil {
+		return fmt.Errorf("vacuum portable snapshot: %w", err)
+	}
+	return nil
+}
+
+func checkPragma(ctx context.Context, db *sql.DB, pragma string) (string, error) {
+	rows, err := db.QueryContext(ctx, `pragma `+pragma)
+	if err != nil {
+		return "", fmt.Errorf("run SQLite %s: %w", pragma, err)
+	}
+	defer rows.Close()
+	var messages []string
+	for rows.Next() {
+		var message string
+		if err := rows.Scan(&message); err != nil {
+			return "", fmt.Errorf("scan SQLite %s: %w", pragma, err)
+		}
+		messages = append(messages, strings.TrimSpace(message))
+	}
+	if err := rows.Err(); err != nil {
+		return "", fmt.Errorf("read SQLite %s: %w", pragma, err)
+	}
+	return strings.Join(messages, "; "), nil
+}
+
+func foreignKeyCheck(ctx context.Context, db *sql.DB) (int, error) {
+	rows, err := db.QueryContext(ctx, `pragma foreign_key_check`)
+	if err != nil {
+		return 0, fmt.Errorf("run SQLite foreign_key_check: %w", err)
+	}
+	defer rows.Close()
+	count := 0
+	for rows.Next() {
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("read SQLite foreign_key_check: %w", err)
+	}
+	return count, nil
+}
+
+func fileSHA256(filePath string) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func writeSyncedFile(filePath string, data []byte, mode os.FileMode) error {
+	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
+	if err != nil {
+		return err
+	}
+	ok := false
+	defer func() {
+		_ = file.Close()
+		if !ok {
+			_ = os.Remove(filePath)
+		}
+	}()
+	if _, err := file.Write(data); err != nil {
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	ok = true
+	return nil
+}
+
+func syncRegularFile(filePath string) error {
+	file, err := os.OpenFile(filePath, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	return file.Sync()
+}
+
+func bestEffortSyncDir(dir string) {
+	file, err := os.Open(dir)
+	if err == nil {
+		_ = file.Sync()
+		_ = file.Close()
+	}
+}
+
+func removeSQLiteSidecars(dbPath string) error {
+	for _, suffix := range []string{"-wal", "-shm"} {
+		sidecar := dbPath + suffix
+		if err := os.Remove(sidecar); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove portable SQLite sidecar %s: %w", sidecar, err)
+		}
+		if _, err := os.Lstat(sidecar); err == nil {
+			return fmt.Errorf("portable SQLite sidecar remains after removal: %s", sidecar)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("verify portable SQLite sidecar removal %s: %w", sidecar, err)
+		}
+	}
+	return nil
+}
+
+func validateManifestPair(ctx context.Context, dbPath, manifestPath string, expected Manifest) error {
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("re-read portable manifest: %w", err)
+	}
+	var actual Manifest
+	if err := json.Unmarshal(data, &actual); err != nil {
+		return fmt.Errorf("re-read portable manifest: %w", err)
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		return fmt.Errorf("portable manifest changed during finalization")
+	}
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		return fmt.Errorf("re-stat portable database: %w", err)
+	}
+	if info.Size() != actual.OutputBytes {
+		return fmt.Errorf("portable manifest size %d does not match database size %d", actual.OutputBytes, info.Size())
+	}
+	sha, err := fileSHA256(dbPath)
+	if err != nil {
+		return fmt.Errorf("re-hash portable database: %w", err)
+	}
+	if sha != actual.SHA256 || sha != actual.ArtifactID {
+		return fmt.Errorf("portable manifest digest does not match database")
+	}
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		return fmt.Errorf("reopen portable database for manifest validation: %w", err)
+	}
+	defer db.Close()
+	quick, err := checkPragma(ctx, db, "quick_check")
+	if err != nil {
+		return err
+	}
+	if quick != actual.QuickCheck || quick != "ok" {
+		return fmt.Errorf("portable manifest quickCheck does not match database")
+	}
+	integrity, err := checkPragma(ctx, db, "integrity_check")
+	if err != nil {
+		return err
+	}
+	if integrity != actual.IntegrityCheck || integrity != "ok" {
+		return fmt.Errorf("portable manifest integrityCheck does not match database")
+	}
+	violations, err := foreignKeyCheck(ctx, db)
+	if err != nil {
+		return err
+	}
+	if violations != actual.ForeignKeyViolations || violations != 0 {
+		return fmt.Errorf("portable manifest foreignKeyViolations does not match database")
+	}
+	for key, want := range map[string]string{
+		"schema":          actual.Schema,
+		"profile":         actual.Profile,
+		"profile_version": fmt.Sprintf("%d", actual.ProfileVersion),
+		"source_path":     actual.OutputPath,
+		"index_profile":   actual.IndexProfile,
+	} {
+		var got string
+		if err := db.QueryRowContext(ctx, `select value from portable_metadata where key = ?`, key).Scan(&got); err != nil {
+			return fmt.Errorf("validate portable metadata %s: %w", key, err)
+		}
+		if got != want {
+			return fmt.Errorf("portable metadata %s %q does not match manifest %q", key, got, want)
+		}
+	}
+	return nil
+}

--- a/internal/portable/export.go
+++ b/internal/portable/export.go
@@ -105,56 +105,71 @@ type ExportOptions struct {
 	DatabaseName string
 	PublicPath   string
 	Profile      string
+	Repository   string
 	BodyChars    int
 	MaxBytes     *int64
 }
 
+type Repository struct {
+	ID       int64  `json:"id"`
+	Owner    string `json:"owner"`
+	Name     string `json:"name"`
+	FullName string `json:"fullName"`
+}
+
+type Table struct {
+	Name string `json:"name"`
+	Rows int64  `json:"rows"`
+}
+
 type Manifest struct {
-	Schema               string   `json:"schema"`
-	PortableSchema       string   `json:"portableSchema"`
-	Profile              string   `json:"profile"`
-	ProfileVersion       int      `json:"profileVersion"`
-	ExportedAt           string   `json:"exportedAt"`
-	OutputPath           string   `json:"outputPath"`
-	OutputBytes          int64    `json:"outputBytes"`
-	SHA256               string   `json:"sha256"`
-	ArtifactID           string   `json:"artifactId"`
-	BodyChars            int      `json:"bodyChars"`
-	MaxBytes             *int64   `json:"maxBytes,omitempty"`
-	Tables               []string `json:"tables"`
-	Excluded             []string `json:"excluded"`
-	ValidationOK         bool     `json:"validationOk"`
-	QuickCheck           string   `json:"quickCheck"`
-	IntegrityCheck       string   `json:"integrityCheck"`
-	ForeignKeyViolations int      `json:"foreignKeyViolations"`
-	DroppedTables        []string `json:"droppedTables"`
-	DroppedIndexes       []string `json:"droppedIndexes"`
-	IndexProfile         string   `json:"indexProfile"`
+	Schema               string      `json:"schema"`
+	PortableSchema       string      `json:"portableSchema"`
+	Profile              string      `json:"profile"`
+	ProfileVersion       int         `json:"profileVersion"`
+	ExportedAt           string      `json:"exportedAt"`
+	OutputPath           string      `json:"outputPath"`
+	OutputBytes          int64       `json:"outputBytes"`
+	SHA256               string      `json:"sha256"`
+	ArtifactID           string      `json:"artifactId"`
+	Repository           *Repository `json:"repository,omitempty"`
+	BodyChars            int         `json:"bodyChars"`
+	MaxBytes             *int64      `json:"maxBytes,omitempty"`
+	Tables               []Table     `json:"tables"`
+	Excluded             []string    `json:"excluded"`
+	ValidationOK         bool        `json:"validationOk"`
+	QuickCheck           string      `json:"quickCheck"`
+	IntegrityCheck       string      `json:"integrityCheck"`
+	ForeignKeyViolations int         `json:"foreignKeyViolations"`
+	DroppedTables        []string    `json:"droppedTables"`
+	DroppedIndexes       []string    `json:"droppedIndexes"`
+	IndexProfile         string      `json:"indexProfile"`
 }
 
 type ExportResult struct {
-	Profile              string   `json:"profile"`
-	PortableSchema       string   `json:"portable_schema"`
-	Schema               string   `json:"schema"`
-	SourceDBPath         string   `json:"source_db_path"`
-	OutputDir            string   `json:"output_dir"`
-	DatabasePath         string   `json:"database_path"`
-	ManifestPath         string   `json:"manifest_path"`
-	PublicPath           string   `json:"public_path"`
-	BodyChars            int      `json:"body_chars"`
-	BytesBefore          int64    `json:"bytes_before"`
-	BytesAfter           int64    `json:"bytes_after"`
-	MaxBytes             *int64   `json:"max_bytes,omitempty"`
-	ByteBudgetOK         bool     `json:"byte_budget_ok"`
-	ArtifactID           string   `json:"artifact_id"`
-	SHA256               string   `json:"sha256"`
-	QuickCheck           string   `json:"quick_check"`
-	IntegrityCheck       string   `json:"integrity_check"`
-	ForeignKeyViolations int      `json:"foreign_key_violations"`
-	Vacuumed             bool     `json:"vacuumed"`
-	DroppedTables        []string `json:"dropped_tables"`
-	DroppedIndexes       []string `json:"dropped_indexes"`
-	ArtifactCommitted    bool     `json:"artifact_committed"`
+	Profile              string      `json:"profile"`
+	PortableSchema       string      `json:"portable_schema"`
+	Schema               string      `json:"schema"`
+	SourceDBPath         string      `json:"source_db_path"`
+	OutputDir            string      `json:"output_dir"`
+	DatabasePath         string      `json:"database_path"`
+	ManifestPath         string      `json:"manifest_path"`
+	PublicPath           string      `json:"public_path"`
+	Repository           *Repository `json:"repository,omitempty"`
+	BodyChars            int         `json:"body_chars"`
+	BytesBefore          int64       `json:"bytes_before"`
+	BytesAfter           int64       `json:"bytes_after"`
+	MaxBytes             *int64      `json:"max_bytes,omitempty"`
+	ByteBudgetOK         bool        `json:"byte_budget_ok"`
+	ArtifactID           string      `json:"artifact_id"`
+	SHA256               string      `json:"sha256"`
+	QuickCheck           string      `json:"quick_check"`
+	IntegrityCheck       string      `json:"integrity_check"`
+	ForeignKeyViolations int         `json:"foreign_key_violations"`
+	Vacuumed             bool        `json:"vacuumed"`
+	DroppedTables        []string    `json:"dropped_tables"`
+	DroppedIndexes       []string    `json:"dropped_indexes"`
+	ArtifactCommitted    bool        `json:"artifact_committed"`
 }
 
 type exporter struct {
@@ -244,9 +259,12 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 			_ = st.Close()
 		}
 	}()
-	droppedIndexes, err := ordinaryNonUniqueIndexes(ctx, st.DB())
-	if err != nil {
-		return result, err
+	if options.Repository != "" {
+		scope, err := st.RestrictPortableRepository(ctx, options.Repository)
+		if err != nil {
+			return result, fmt.Errorf("restrict portable repository: %w", err)
+		}
+		result.Repository = repositoryFromStore(scope.Repository)
 	}
 	pruneStats, err := st.PrunePortablePayloads(ctx, store.PortablePruneOptions{
 		BodyChars:           options.BodyChars,
@@ -267,12 +285,16 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 			droppedTables = append(droppedTables, table)
 		}
 	}
+	droppedIndexes, err := ordinaryNonUniqueIndexes(ctx, st.DB())
+	if err != nil {
+		return result, err
+	}
 	for _, index := range droppedIndexes {
 		if _, err := st.DB().ExecContext(ctx, `drop index if exists `+quoteIdentifier(index)); err != nil {
 			return result, fmt.Errorf("drop portable index %s: %w", index, err)
 		}
 	}
-	tables, err := databaseTables(ctx, st.DB())
+	tableNames, err := databaseTableNames(ctx, st.DB())
 	if err != nil {
 		return result, err
 	}
@@ -283,7 +305,7 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 		"profile_version": fmt.Sprintf("%d", profile.Version),
 		"body_chars":      fmt.Sprintf("%d", options.BodyChars),
 		"capabilities":    strings.Join(profile.Capabilities, ","),
-		"includes":        strings.Join(tables, ","),
+		"includes":        strings.Join(tableNames, ","),
 		"excluded":        strings.Join(profile.Excluded, ","),
 		"exported_at":     exportedAt,
 		"source_path":     options.PublicPath,
@@ -316,6 +338,18 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 	result.ForeignKeyViolations = foreignKeyViolations
 	if quickCheck != "ok" || integrityCheck != "ok" || foreignKeyViolations != 0 {
 		return result, fmt.Errorf("portable database validation failed: quick_check=%q integrity_check=%q foreign_key_violations=%d", quickCheck, integrityCheck, foreignKeyViolations)
+	}
+	if result.Repository == nil {
+		result.Repository, err = singleRepository(ctx, st.DB())
+		if err != nil {
+			return result, err
+		}
+	} else if err := verifyRepository(ctx, st.DB(), *result.Repository); err != nil {
+		return result, err
+	}
+	tables, err := databaseTableStats(ctx, st.DB())
+	if err != nil {
+		return result, err
 	}
 	if err := st.Close(); err != nil {
 		return result, fmt.Errorf("close portable snapshot: %w", err)
@@ -351,6 +385,7 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 		OutputBytes:          info.Size(),
 		SHA256:               sha,
 		ArtifactID:           sha,
+		Repository:           result.Repository,
 		BodyChars:            options.BodyChars,
 		MaxBytes:             options.MaxBytes,
 		Tables:               tables,
@@ -472,7 +507,7 @@ func snapshotSQLite(ctx context.Context, sourcePath, targetPath string) error {
 }
 
 func ordinaryNonUniqueIndexes(ctx context.Context, db *sql.DB) ([]string, error) {
-	tables, err := databaseTables(ctx, db)
+	tables, err := databaseTableNames(ctx, db)
 	if err != nil {
 		return nil, err
 	}
@@ -505,7 +540,7 @@ func ordinaryNonUniqueIndexes(ctx context.Context, db *sql.DB) ([]string, error)
 	return indexes, nil
 }
 
-func databaseTables(ctx context.Context, db *sql.DB) ([]string, error) {
+func databaseTableNames(ctx context.Context, db *sql.DB) ([]string, error) {
 	rows, err := db.QueryContext(ctx, `select name from sqlite_schema where type = 'table' and name not like 'sqlite_%' order by name`)
 	if err != nil {
 		return nil, fmt.Errorf("list portable tables: %w", err)
@@ -520,6 +555,52 @@ func databaseTables(ctx context.Context, db *sql.DB) ([]string, error) {
 		tables = append(tables, name)
 	}
 	return tables, rows.Err()
+}
+
+func databaseTableStats(ctx context.Context, db *sql.DB) ([]Table, error) {
+	names, err := databaseTableNames(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	tables := make([]Table, 0, len(names))
+	for _, name := range names {
+		var rows int64
+		if err := db.QueryRowContext(ctx, `select count(*) from `+quoteIdentifier(name)).Scan(&rows); err != nil {
+			return nil, fmt.Errorf("count portable table %s: %w", name, err)
+		}
+		tables = append(tables, Table{Name: name, Rows: rows})
+	}
+	return tables, nil
+}
+
+func repositoryFromStore(repo store.Repository) *Repository {
+	return &Repository{ID: repo.ID, Owner: repo.Owner, Name: repo.Name, FullName: repo.FullName}
+}
+
+func singleRepository(ctx context.Context, db *sql.DB) (*Repository, error) {
+	var count int64
+	if err := db.QueryRowContext(ctx, `select count(*) from repositories`).Scan(&count); err != nil {
+		return nil, fmt.Errorf("count portable repositories: %w", err)
+	}
+	if count != 1 {
+		return nil, nil
+	}
+	var repo Repository
+	if err := db.QueryRowContext(ctx, `select id, owner, name, full_name from repositories`).Scan(&repo.ID, &repo.Owner, &repo.Name, &repo.FullName); err != nil {
+		return nil, fmt.Errorf("read portable repository metadata: %w", err)
+	}
+	return &repo, nil
+}
+
+func verifyRepository(ctx context.Context, db *sql.DB, expected Repository) error {
+	actual, err := singleRepository(ctx, db)
+	if err != nil {
+		return err
+	}
+	if actual == nil || *actual != expected {
+		return fmt.Errorf("portable repository restriction did not preserve exactly %s", expected.FullName)
+	}
+	return nil
 }
 
 func dropTableIfPresent(ctx context.Context, db *sql.DB, table string) (bool, error) {
@@ -728,6 +809,20 @@ func validateManifestPair(ctx context.Context, dbPath, manifestPath string, expe
 	}
 	if violations != actual.ForeignKeyViolations || violations != 0 {
 		return fmt.Errorf("portable manifest foreignKeyViolations does not match database")
+	}
+	tables, err := databaseTableStats(ctx, db)
+	if err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(tables, actual.Tables) {
+		return fmt.Errorf("portable manifest table counts do not match database")
+	}
+	repository, err := singleRepository(ctx, db)
+	if err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(repository, actual.Repository) {
+		return fmt.Errorf("portable manifest repository does not match database scope")
 	}
 	for key, want := range map[string]string{
 		"schema":          actual.Schema,

--- a/internal/portable/export_failure_paths_test.go
+++ b/internal/portable/export_failure_paths_test.go
@@ -1,0 +1,882 @@
+package portable
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestValidateManifestPairRejectsInconsistentArtifacts(t *testing.T) {
+	tests := []struct {
+		name      string
+		wantError string
+		mutate    func(t *testing.T, dbPath, manifestPath string, manifest *Manifest)
+	}{
+		{
+			name:      "manifest missing",
+			wantError: "re-read portable manifest",
+			mutate: func(t *testing.T, _, manifestPath string, _ *Manifest) {
+				t.Helper()
+				if err := os.Remove(manifestPath); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name:      "malformed manifest",
+			wantError: "re-read portable manifest",
+			mutate: func(t *testing.T, _, manifestPath string, _ *Manifest) {
+				t.Helper()
+				if err := os.WriteFile(manifestPath, []byte("{"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name:      "manifest changed",
+			wantError: "changed during finalization",
+			mutate: func(t *testing.T, _, manifestPath string, manifest *Manifest) {
+				t.Helper()
+				actual := *manifest
+				actual.Profile = "changed-profile"
+				writeTestManifest(t, manifestPath, actual)
+			},
+		},
+		{
+			name:      "database missing",
+			wantError: "re-stat portable database",
+			mutate: func(t *testing.T, dbPath, _ string, _ *Manifest) {
+				t.Helper()
+				if err := os.Remove(dbPath); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name:      "size mismatch",
+			wantError: "does not match database size",
+			mutate: func(t *testing.T, _, manifestPath string, manifest *Manifest) {
+				manifest.OutputBytes++
+				writeTestManifest(t, manifestPath, *manifest)
+			},
+		},
+		{
+			name:      "digest mismatch",
+			wantError: "digest does not match",
+			mutate: func(t *testing.T, _, manifestPath string, manifest *Manifest) {
+				manifest.SHA256 = strings.Repeat("0", 64)
+				manifest.ArtifactID = manifest.SHA256
+				writeTestManifest(t, manifestPath, *manifest)
+			},
+		},
+		{
+			name:      "database is not SQLite",
+			wantError: "file is not a database",
+			mutate: func(t *testing.T, dbPath, manifestPath string, manifest *Manifest) {
+				if err := os.WriteFile(dbPath, []byte("not a sqlite database"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				info, err := os.Stat(dbPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				manifest.OutputBytes = info.Size()
+				manifest.SHA256 = hashFile(t, dbPath)
+				manifest.ArtifactID = manifest.SHA256
+				writeTestManifest(t, manifestPath, *manifest)
+			},
+		},
+		{
+			name:      "quick check mismatch",
+			wantError: "quickCheck does not match",
+			mutate: func(t *testing.T, _, manifestPath string, manifest *Manifest) {
+				manifest.QuickCheck = "not ok"
+				writeTestManifest(t, manifestPath, *manifest)
+			},
+		},
+		{
+			name:      "integrity check mismatch",
+			wantError: "integrityCheck does not match",
+			mutate: func(t *testing.T, _, manifestPath string, manifest *Manifest) {
+				manifest.IntegrityCheck = "not ok"
+				writeTestManifest(t, manifestPath, *manifest)
+			},
+		},
+		{
+			name:      "foreign key violations",
+			wantError: "records 1 foreign-key violations",
+			mutate: func(t *testing.T, _, manifestPath string, manifest *Manifest) {
+				manifest.ForeignKeyViolations = 1
+				writeTestManifest(t, manifestPath, *manifest)
+			},
+		},
+		{
+			name:      "table counts mismatch",
+			wantError: "table counts do not match",
+			mutate: func(t *testing.T, _, manifestPath string, manifest *Manifest) {
+				manifest.Tables[0].Rows++
+				writeTestManifest(t, manifestPath, *manifest)
+			},
+		},
+		{
+			name:      "repository mismatch",
+			wantError: "repository does not match",
+			mutate: func(t *testing.T, _, manifestPath string, manifest *Manifest) {
+				manifest.Repository.FullName = "openclaw/other"
+				writeTestManifest(t, manifestPath, *manifest)
+			},
+		},
+		{
+			name:      "metadata missing",
+			wantError: "validate portable metadata profile",
+			mutate: func(t *testing.T, dbPath, manifestPath string, manifest *Manifest) {
+				db := openRawDB(t, dbPath)
+				if _, err := db.Exec(`delete from portable_metadata where key = 'profile'`); err != nil {
+					t.Fatal(err)
+				}
+				if err := db.Close(); err != nil {
+					t.Fatal(err)
+				}
+				refreshTestManifest(t, dbPath, manifest)
+				writeTestManifest(t, manifestPath, *manifest)
+			},
+		},
+		{
+			name:      "metadata mismatch",
+			wantError: "does not match manifest",
+			mutate: func(t *testing.T, dbPath, manifestPath string, manifest *Manifest) {
+				db := openRawDB(t, dbPath)
+				if _, err := db.Exec(`update portable_metadata set value = 'other' where key = 'column_profile'`); err != nil {
+					t.Fatal(err)
+				}
+				if err := db.Close(); err != nil {
+					t.Fatal(err)
+				}
+				refreshTestManifest(t, dbPath, manifest)
+				writeTestManifest(t, manifestPath, *manifest)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dbPath, manifestPath, manifest := newTestManifestPair(t)
+			test.mutate(t, dbPath, manifestPath, &manifest)
+			err := validateManifestPair(context.Background(), dbPath, manifestPath, manifest)
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("validate manifest pair error = %v, want %q", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestValidateManifestPairReportsUnreadableDatabaseContent(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "artifact.db")
+	if err := os.Mkdir(dbPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := Manifest{OutputBytes: info.Size(), SHA256: strings.Repeat("0", 64), ArtifactID: strings.Repeat("0", 64)}
+	manifestPath := filepath.Join(dir, "artifact.db.manifest.json")
+	writeTestManifest(t, manifestPath, manifest)
+	err = validateManifestPair(context.Background(), dbPath, manifestPath, manifest)
+	if err == nil || !strings.Contains(err.Error(), "re-hash portable database") {
+		t.Fatalf("unreadable database content error = %v", err)
+	}
+}
+
+func TestSQLiteSnapshotAndCompactGenerationRejectUnsafeTargets(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	db := openRawDB(t, sourcePath)
+	if _, err := db.Exec(`create table payload(value text); insert into payload values('kept')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := snapshotSQLiteWithOptions(ctx, sourcePath, filepath.Join(dir, "zero.db"), onlineBackupOptions{}); err == nil || !strings.Contains(err.Error(), "must be positive") {
+		t.Fatalf("zero-page snapshot error = %v", err)
+	}
+	existing := filepath.Join(dir, "existing.db")
+	if err := os.WriteFile(existing, []byte("occupied"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := snapshotSQLite(ctx, sourcePath, existing); err == nil || !strings.Contains(err.Error(), "target already exists") {
+		t.Fatalf("existing snapshot target error = %v", err)
+	}
+	missingTarget := filepath.Join(dir, "missing", "snapshot.db")
+	if err := snapshotSQLite(ctx, sourcePath, missingTarget); err == nil || !strings.Contains(err.Error(), "start online backup") {
+		t.Fatalf("missing-parent snapshot error = %v", err)
+	}
+	if _, err := os.Stat(missingTarget); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("failed snapshot left target: %v", err)
+	}
+	if err := snapshotSQLite(ctx, filepath.Join(dir, "missing-source.db"), filepath.Join(dir, "missing-source-copy.db")); err == nil {
+		t.Fatal("missing snapshot source succeeded")
+	}
+
+	closed := openRawDB(t, sourcePath)
+	if err := closed.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := createCompactDatabase(ctx, closed, filepath.Join(dir, "working.db")); err == nil || !strings.Contains(err.Error(), "create compact portable database") {
+		t.Fatalf("closed compact source error = %v", err)
+	}
+	parentFile := filepath.Join(dir, "not-a-directory")
+	if err := os.WriteFile(parentFile, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	invalidParentDB := openRawDB(t, sourcePath)
+	defer invalidParentDB.Close()
+	if _, err := createCompactDatabase(ctx, invalidParentDB, filepath.Join(parentFile, "working.db")); err == nil || !strings.Contains(err.Error(), "reserve compact") {
+		t.Fatalf("invalid compact directory error = %v", err)
+	}
+}
+
+func TestSQLiteSnapshotCancellationCleansDatabaseAndReportsRetainedSidecars(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	db := openRawDB(t, sourcePath)
+	if _, err := db.Exec(`create table payload(value blob); insert into payload values(zeroblob(1048576))`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	targetPath := filepath.Join(dir, "target.db")
+	ctx, cancel := context.WithCancel(context.Background())
+	err := snapshotSQLiteWithOptions(ctx, sourcePath, targetPath, onlineBackupOptions{
+		PagesPerStep: 1,
+		AfterStep: func(_, _ int) {
+			for _, suffix := range []string{"-wal", "-shm"} {
+				sidecar := targetPath + suffix
+				if mkdirErr := os.Mkdir(sidecar, 0o700); mkdirErr != nil {
+					t.Errorf("create retained sidecar: %v", mkdirErr)
+					continue
+				}
+				if writeErr := os.WriteFile(filepath.Join(sidecar, "retained"), []byte("x"), 0o600); writeErr != nil {
+					t.Errorf("seed retained sidecar: %v", writeErr)
+				}
+			}
+			cancel()
+		},
+	})
+	if err == nil || !errors.Is(err, context.Canceled) || !strings.Contains(err.Error(), "remove partial snapshot sidecar") {
+		t.Fatalf("canceled snapshot cleanup error = %v", err)
+	}
+	if _, statErr := os.Stat(targetPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("canceled snapshot left database: %v", statErr)
+	}
+}
+
+func TestSQLiteSnapshotPreCanceledContextLeavesNoTarget(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	db := openRawDB(t, sourcePath)
+	if _, err := db.Exec(`create table payload(value text)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	targetPath := filepath.Join(dir, "target.db")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := snapshotSQLiteWithOptions(ctx, sourcePath, targetPath, onlineBackupOptions{PagesPerStep: 1})
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("pre-canceled snapshot error = %v", err)
+	}
+	if _, statErr := os.Stat(targetPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("pre-canceled snapshot left target: %v", statErr)
+	}
+}
+
+func TestSQLiteSnapshotReportsPartialTargetCleanupFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("replacing an open SQLite file exercises Unix unlink cleanup semantics")
+	}
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	db := openRawDB(t, sourcePath)
+	if _, err := db.Exec(`create table payload(value blob); insert into payload values(zeroblob(1048576))`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	targetPath := filepath.Join(dir, "target.db")
+	ctx, cancel := context.WithCancel(context.Background())
+	err := snapshotSQLiteWithOptions(ctx, sourcePath, targetPath, onlineBackupOptions{
+		PagesPerStep: 1,
+		AfterStep: func(_, _ int) {
+			if removeErr := os.Remove(targetPath); removeErr != nil {
+				t.Errorf("unlink partial target: %v", removeErr)
+				cancel()
+				return
+			}
+			if mkdirErr := os.Mkdir(targetPath, 0o700); mkdirErr != nil {
+				t.Errorf("replace partial target with directory: %v", mkdirErr)
+				cancel()
+				return
+			}
+			if writeErr := os.WriteFile(filepath.Join(targetPath, "retained"), []byte("x"), 0o600); writeErr != nil {
+				t.Errorf("seed retained partial target: %v", writeErr)
+			}
+			cancel()
+		},
+	})
+	if err == nil || !errors.Is(err, context.Canceled) || !strings.Contains(err.Error(), "remove partial snapshot") {
+		t.Fatalf("partial target cleanup error = %v", err)
+	}
+}
+
+func TestCompactReplacementFailsClosed(t *testing.T) {
+	ctx := context.Background()
+	t.Run("invalid candidate", func(t *testing.T) {
+		dir := t.TempDir()
+		working := filepath.Join(dir, "working.db")
+		candidate := filepath.Join(dir, "candidate.db")
+		if err := os.WriteFile(working, []byte("working"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(candidate, []byte("not sqlite"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		err := replaceWithCompactDatabase(ctx, working, candidate)
+		if err == nil || !strings.Contains(err.Error(), "validate compact database candidate") {
+			t.Fatalf("invalid compact candidate error = %v", err)
+		}
+		if got := string(readFile(t, working)); got != "working" {
+			t.Fatalf("invalid candidate changed working database to %q", got)
+		}
+	})
+
+	t.Run("missing working database", func(t *testing.T) {
+		dir := t.TempDir()
+		candidate := filepath.Join(dir, "candidate.db")
+		db := openRawDB(t, candidate)
+		if _, err := db.Exec(`create table payload(value text)`); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+		err := replaceWithCompactDatabase(ctx, filepath.Join(dir, "missing.db"), candidate)
+		if err == nil || !strings.Contains(err.Error(), "remove uncompact portable database") {
+			t.Fatalf("missing working database error = %v", err)
+		}
+		if _, statErr := os.Stat(candidate); statErr != nil {
+			t.Fatalf("failed replacement removed candidate: %v", statErr)
+		}
+	})
+
+	t.Run("aliased paths", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "same.db")
+		db := openRawDB(t, path)
+		if _, err := db.Exec(`create table payload(value text)`); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := replaceWithCompactDatabase(ctx, path, path); err == nil || !strings.Contains(err.Error(), "promote compact portable database") {
+			t.Fatalf("aliased replacement error = %v", err)
+		}
+	})
+}
+
+func TestPortableFileHelpersRejectUnsafeDestinations(t *testing.T) {
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "existing")
+	if err := os.WriteFile(existing, []byte("original"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSyncedFile(existing, []byte("replacement"), 0o600); err == nil {
+		t.Fatal("exclusive synced write replaced an existing file")
+	}
+	if got := string(readFile(t, existing)); got != "original" {
+		t.Fatalf("exclusive synced write changed existing file to %q", got)
+	}
+	if err := writeSyncedFile(filepath.Join(dir, "missing", "file"), []byte("data"), 0o600); err == nil {
+		t.Fatal("synced write into missing parent succeeded")
+	}
+	if err := syncRegularFile(filepath.Join(dir, "missing")); err == nil {
+		t.Fatal("sync of missing file succeeded")
+	}
+	if _, err := fileSHA256(filepath.Join(dir, "missing")); err == nil {
+		t.Fatal("hash of missing file succeeded")
+	}
+	if _, err := fileSHA256(dir); err == nil {
+		t.Fatal("hash of directory succeeded")
+	}
+}
+
+func TestPortableTableDropFailsClosedOnForeignKeyConstraint(t *testing.T) {
+	ctx := context.Background()
+	db := openRawDB(t, filepath.Join(t.TempDir(), "drop.db"))
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	if _, err := db.ExecContext(ctx, `
+		pragma foreign_keys = on;
+		create table parent(id integer primary key);
+		create table child(parent_id integer references parent(id));
+		insert into parent values(1);
+		insert into child values(1);
+	`); err != nil {
+		t.Fatal(err)
+	}
+	dropped, err := dropTableIfPresent(ctx, db, "parent")
+	if err == nil || dropped || !strings.Contains(err.Error(), "drop portable table parent") {
+		t.Fatalf("foreign-key constrained drop = %v, %v", dropped, err)
+	}
+	if !tableExists(t, db, "parent") {
+		t.Fatal("failed constrained drop removed parent table")
+	}
+	if dropped, err := dropTableIfPresent(ctx, db, "missing"); err != nil || dropped {
+		t.Fatalf("missing table drop = %v, %v", dropped, err)
+	}
+}
+
+func TestCompactReplacementRejectsRetainedSidecars(t *testing.T) {
+	ctx := context.Background()
+	for _, target := range []string{"candidate", "working"} {
+		t.Run(target, func(t *testing.T) {
+			dir := t.TempDir()
+			working := filepath.Join(dir, "working.db")
+			candidate := filepath.Join(dir, "candidate.db")
+			for _, path := range []string{working, candidate} {
+				db := openRawDB(t, path)
+				if _, err := db.Exec(`create table payload(value text)`); err != nil {
+					t.Fatal(err)
+				}
+				if err := db.Close(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			sidecarBase := working
+			if target == "candidate" {
+				sidecarBase = candidate
+			}
+			sidecar := sidecarBase + "-wal"
+			if err := os.Mkdir(sidecar, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(sidecar, "retained"), []byte("x"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			err := replaceWithCompactDatabase(ctx, working, candidate)
+			wantError := "remove portable SQLite sidecar"
+			if target == "candidate" {
+				wantError = "unable to open database file"
+			}
+			if err == nil || !strings.Contains(err.Error(), wantError) {
+				t.Fatalf("retained %s sidecar error = %v", target, err)
+			}
+			if _, statErr := os.Stat(working); statErr != nil {
+				t.Fatalf("retained sidecar removed working database: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestAppendUniquePreservesFirstOccurrence(t *testing.T) {
+	values := []string{"threads", "repositories"}
+	got := appendUnique(values, "threads")
+	if len(got) != 2 || got[0] != "threads" || got[1] != "repositories" {
+		t.Fatalf("duplicate append changed slice: %v", got)
+	}
+}
+
+func TestPortableDatabaseHelpersPropagateCancellation(t *testing.T) {
+	db := openRawDB(t, filepath.Join(t.TempDir(), "canceled.db"))
+	defer db.Close()
+	if _, err := db.Exec(`create table disposable(id integer)`); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	checks := []struct {
+		name string
+		run  func() error
+	}{
+		{name: "configure", run: func() error { return configureDisposableStore(ctx, db) }},
+		{name: "indexes", run: func() error { _, err := ordinaryNonUniqueIndexes(ctx, db); return err }},
+		{name: "tables", run: func() error { _, err := databaseTableNames(ctx, db); return err }},
+		{name: "table stats", run: func() error { _, err := databaseTableStats(ctx, db); return err }},
+		{name: "repository", run: func() error { _, err := singleRepository(ctx, db); return err }},
+		{name: "verify repository", run: func() error { return verifyRepository(ctx, db, Repository{FullName: "openclaw/gitcrawl"}) }},
+		{name: "drop table", run: func() error { _, err := dropTableIfPresent(ctx, db, "disposable"); return err }},
+		{name: "metadata", run: func() error { return writeMetadata(ctx, db, map[string]string{"schema": "portable-v1"}) }},
+		{name: "pragma", run: func() error { _, err := checkPragma(ctx, db, "quick_check"); return err }},
+	}
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			if err := check.run(); err == nil {
+				t.Fatal("canceled operation succeeded")
+			}
+		})
+	}
+}
+
+func TestExportCancellationAtSafetyBoundariesCleansStaging(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, context.Background(), sourcePath)
+	defer st.Close()
+	stages := []Stage{
+		StageSnapshot,
+		StageRepositoryScope,
+		StageProfileOmissions,
+		StageIndexRemoval,
+		StageFinalVacuum,
+		StageValidation,
+		StageManifest,
+		StageArtifactCommit,
+	}
+	for _, stage := range stages {
+		t.Run(string(stage), func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			outputDir := filepath.Join(dir, "cancel-"+strings.ReplaceAll(string(stage), " ", "-"))
+			options := testExportOptions(sourcePath, outputDir)
+			options.Progress = func(got Stage) {
+				if got == stage {
+					cancel()
+				}
+			}
+			_, err := Export(ctx, options)
+			if err == nil || !errors.Is(err, context.Canceled) || !strings.Contains(err.Error(), string(stage)) {
+				t.Fatalf("cancellation at %q error = %v", stage, err)
+			}
+			if _, statErr := os.Stat(outputDir); !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("cancellation at %q left output: %v", stage, statErr)
+			}
+			assertNoExportTemps(t, dir)
+		})
+	}
+}
+
+func TestExportRejectsInvalidSourcesBudgetsAndOutputParents(t *testing.T) {
+	dir := t.TempDir()
+	validSource := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, context.Background(), validSource)
+	defer st.Close()
+
+	tests := []struct {
+		name      string
+		options   ExportOptions
+		wantError string
+	}{
+		{
+			name: "default body budget",
+			options: func() ExportOptions {
+				options := testExportOptions(validSource, filepath.Join(dir, "default-body"))
+				options.BodyChars = 0
+				options.Progress = func(Stage) {}
+				return options
+			}(),
+			wantError: "portable export canceled during snapshot",
+		},
+		{
+			name:      "unknown profile",
+			options:   ExportOptions{Profile: "unknown"},
+			wantError: "unsupported portable export profile",
+		},
+		{
+			name: "unsafe database name",
+			options: func() ExportOptions {
+				options := testExportOptions(validSource, filepath.Join(dir, "unsafe-name"))
+				options.DatabaseName = "../unsafe.db"
+				return options
+			}(),
+			wantError: "database-name must be a safe basename",
+		},
+		{
+			name: "unsafe public path",
+			options: func() ExportOptions {
+				options := testExportOptions(validSource, filepath.Join(dir, "unsafe-public-path"))
+				options.PublicPath = "../unsafe.db"
+				return options
+			}(),
+			wantError: "public-path must be a clean relative slash path",
+		},
+		{
+			name: "zero budget",
+			options: func() ExportOptions {
+				options := testExportOptions(validSource, filepath.Join(dir, "zero-budget"))
+				zero := int64(0)
+				options.MaxBytes = &zero
+				return options
+			}(),
+			wantError: "max-bytes must be a positive integer",
+		},
+		{
+			name:      "missing source",
+			options:   testExportOptions(filepath.Join(dir, "missing.db"), filepath.Join(dir, "missing-source")),
+			wantError: "stat source database",
+		},
+		{
+			name:      "source directory",
+			options:   testExportOptions(dir, filepath.Join(dir, "source-directory")),
+			wantError: "source database is not a regular file",
+		},
+		{
+			name: "output parent is file",
+			options: func() ExportOptions {
+				parent := filepath.Join(dir, "parent-file")
+				if err := os.WriteFile(parent, []byte("x"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				return testExportOptions(validSource, filepath.Join(parent, "artifact"))
+			}(),
+			wantError: "inspect output directory",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			if test.name == "default body budget" {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+			if _, err := Export(ctx, test.options); err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("export error = %v, want %q", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestExportCommitRacesFailWithoutPublishingPartialPair(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	defer st.Close()
+
+	t.Run("target appears before final inspection", func(t *testing.T) {
+		outputDir := filepath.Join(dir, "before-inspection")
+		e := exporter{beforeCommit: func() error { return os.Mkdir(outputDir, 0o700) }}
+		_, err := e.export(ctx, testExportOptions(sourcePath, outputDir))
+		if err == nil || !strings.Contains(err.Error(), "output directory already exists") {
+			t.Fatalf("pre-commit target race error = %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(outputDir, "gitcrawl.db")); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("pre-commit race published database: %v", err)
+		}
+		assertNoExportTemps(t, dir)
+	})
+
+	t.Run("target appears after final inspection", func(t *testing.T) {
+		outputDir := filepath.Join(dir, "after-inspection")
+		options := testExportOptions(sourcePath, outputDir)
+		options.Progress = func(stage Stage) {
+			if stage == StageArtifactCommit {
+				if err := os.Mkdir(outputDir, 0o700); err != nil {
+					t.Errorf("create racing output: %v", err)
+				}
+			}
+		}
+		_, err := Export(ctx, options)
+		if err == nil || !strings.Contains(err.Error(), "commit portable artifact") {
+			t.Fatalf("rename target race error = %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(outputDir, "gitcrawl.db")); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("rename race published database: %v", err)
+		}
+		assertNoExportTemps(t, dir)
+	})
+}
+
+func TestExportLateFileFailuresLeaveNoArtifact(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	defer st.Close()
+
+	t.Run("manifest already exists", func(t *testing.T) {
+		outputDir := filepath.Join(dir, "existing-manifest")
+		e := exporter{beforeManifest: func() error {
+			matches, err := filepath.Glob(filepath.Join(dir, ".gitcrawl-portable-export-*"))
+			if err != nil || len(matches) != 1 {
+				return errors.New("could not locate staging directory")
+			}
+			return os.WriteFile(filepath.Join(matches[0], "gitcrawl.db.manifest.json"), []byte("occupied"), 0o600)
+		}}
+		_, err := e.export(ctx, testExportOptions(sourcePath, outputDir))
+		if err == nil || !strings.Contains(err.Error(), "write portable manifest") {
+			t.Fatalf("existing manifest error = %v", err)
+		}
+		assertNoExportTemps(t, dir)
+	})
+
+	t.Run("database removed before sync", func(t *testing.T) {
+		outputDir := filepath.Join(dir, "missing-database")
+		e := exporter{beforeManifest: func() error {
+			matches, err := filepath.Glob(filepath.Join(dir, ".gitcrawl-portable-export-*", "gitcrawl.db"))
+			if err != nil || len(matches) != 1 {
+				return errors.New("could not locate staging database")
+			}
+			return os.Remove(matches[0])
+		}}
+		_, err := e.export(ctx, testExportOptions(sourcePath, outputDir))
+		if err == nil || !strings.Contains(err.Error(), "sync portable database") {
+			t.Fatalf("missing database sync error = %v", err)
+		}
+		assertNoExportTemps(t, dir)
+	})
+
+	t.Run("late retained sidecar", func(t *testing.T) {
+		outputDir := filepath.Join(dir, "retained-sidecar")
+		e := exporter{beforeManifest: func() error {
+			matches, err := filepath.Glob(filepath.Join(dir, ".gitcrawl-portable-export-*", "gitcrawl.db"))
+			if err != nil || len(matches) != 1 {
+				return errors.New("could not locate staging database")
+			}
+			sidecar := matches[0] + "-wal"
+			if err := os.Mkdir(sidecar, 0o700); err != nil {
+				return err
+			}
+			return os.WriteFile(filepath.Join(sidecar, "retained"), []byte("x"), 0o600)
+		}}
+		_, err := e.export(ctx, testExportOptions(sourcePath, outputDir))
+		if err == nil || (!strings.Contains(err.Error(), "remove portable SQLite sidecar") && !strings.Contains(err.Error(), "unable to open database file")) {
+			t.Fatalf("retained sidecar error = %v", err)
+		}
+		assertNoExportTemps(t, dir)
+	})
+}
+
+func TestExportRejectsInvalidSQLiteSourceWithoutPublishing(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "not-sqlite.db")
+	if err := os.WriteFile(sourcePath, []byte("not a SQLite database"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	outputDir := filepath.Join(dir, "artifact")
+	_, err := Export(context.Background(), testExportOptions(sourcePath, outputDir))
+	if err == nil || !strings.Contains(err.Error(), "snapshot source database") {
+		t.Fatalf("invalid SQLite source error = %v", err)
+	}
+	if _, statErr := os.Stat(outputDir); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("invalid SQLite source published output: %v", statErr)
+	}
+	assertNoExportTemps(t, dir)
+}
+
+func TestExportRejectsSnapshotSchemaLossDuringShaping(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	defer st.Close()
+	outputDir := filepath.Join(dir, "artifact")
+	options := testExportOptions(sourcePath, outputDir)
+	options.Progress = func(stage Stage) {
+		if stage != StageCanonicalShaping {
+			return
+		}
+		matches, err := filepath.Glob(filepath.Join(dir, ".gitcrawl-portable-export-*", "gitcrawl.db"))
+		if err != nil || len(matches) != 1 {
+			t.Errorf("locate shaping database: matches=%v err=%v", matches, err)
+			return
+		}
+		db := openRawDB(t, matches[0])
+		if _, err := db.ExecContext(ctx, `pragma foreign_keys = off; drop table threads`); err != nil {
+			t.Errorf("remove required shaping table: %v", err)
+		}
+		if err := db.Close(); err != nil {
+			t.Errorf("close shaping database: %v", err)
+		}
+	}
+	_, err := Export(ctx, options)
+	if err == nil || !strings.Contains(err.Error(), "canonical portable shaping") {
+		t.Fatalf("snapshot schema loss error = %v", err)
+	}
+	if _, statErr := os.Stat(outputDir); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("schema-loss export published output: %v", statErr)
+	}
+	assertNoExportTemps(t, dir)
+}
+
+func newTestManifestPair(t *testing.T) (string, string, Manifest) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "artifact.db")
+	db := openRawDB(t, dbPath)
+	if _, err := db.Exec(`
+		create table repositories(id integer primary key, owner text, name text, full_name text);
+		create table portable_metadata(key text primary key, value text not null);
+		insert into repositories values(1, 'openclaw', 'gitcrawl', 'openclaw/gitcrawl');
+		insert into portable_metadata values
+			('schema', 'portable-v1'),
+			('profile', 'current-state-v1'),
+			('profile_version', '1'),
+			('source_path', 'data/gitcrawl.db'),
+			('index_profile', 'unique-only'),
+			('column_profile', 'sanitized-compatibility');
+	`); err != nil {
+		t.Fatal(err)
+	}
+	tables, err := databaseTableStats(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	manifest := Manifest{
+		Schema: "portable-v1", PortableSchema: "portable-v1",
+		Profile: CurrentStateV1, ProfileVersion: 1,
+		OutputPath: "data/gitcrawl.db", Tables: tables,
+		Repository:   &Repository{ID: 1, Owner: "openclaw", Name: "gitcrawl", FullName: "openclaw/gitcrawl"},
+		ValidationOK: true, QuickCheck: "ok", IntegrityCheck: "ok",
+		IndexProfile: "unique-only", ColumnProfile: "sanitized-compatibility",
+	}
+	refreshTestManifest(t, dbPath, &manifest)
+	manifestPath := dbPath + ".manifest.json"
+	writeTestManifest(t, manifestPath, manifest)
+	return dbPath, manifestPath, manifest
+}
+
+func refreshTestManifest(t *testing.T, dbPath string, manifest *Manifest) {
+	t.Helper()
+	db := openRawDB(t, dbPath)
+	tables, err := databaseTableStats(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest.OutputBytes = info.Size()
+	manifest.SHA256 = hashFile(t, dbPath)
+	manifest.ArtifactID = manifest.SHA256
+	manifest.Tables = tables
+}
+
+func writeTestManifest(t *testing.T, path string, manifest Manifest) {
+	t.Helper()
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/portable/export_test.go
+++ b/internal/portable/export_test.go
@@ -62,7 +62,7 @@ func TestExportCurrentStateV1SnapshotsLiveWALWithoutMutatingSource(t *testing.T)
 	}
 	for _, table := range []string{
 		"repositories", "threads", "comments", "thread_revisions", "thread_fingerprints",
-		"pull_request_details", "pull_request_checks", "thread_child_observation_memberships",
+		"pull_request_details", "pull_request_files", "pull_request_checks", "thread_child_observation_memberships",
 	} {
 		if !tableExists(t, db, table) {
 			t.Fatalf("preserved table %s is missing", table)
@@ -95,7 +95,7 @@ func TestExportCurrentStateV1SnapshotsLiveWALWithoutMutatingSource(t *testing.T)
 		t.Fatalf("profile metadata = %q / %q", profileMetadata, indexProfile)
 	}
 	if !csvContains(includes, "comments") || !csvContains(includes, "thread_child_observation_memberships") ||
-		!csvContains(capabilities, "current_comments") || csvContains(excluded, "comments") {
+		!csvContains(capabilities, "current_comments") || !csvContains(excluded, "pull_request_file_patches") || csvContains(excluded, "comments") {
 		t.Fatalf("inaccurate metadata includes=%q capabilities=%q excluded=%q", includes, capabilities, excluded)
 	}
 	if indexExists(t, db, "custom_comments_author") || !indexExists(t, db, "unique_comments_github") {
@@ -115,6 +115,10 @@ func TestExportCurrentStateV1SnapshotsLiveWALWithoutMutatingSource(t *testing.T)
 	}
 	if got := hashFile(t, result.DatabasePath); got != result.SHA256 {
 		t.Fatalf("database hash = %s, want %s", got, result.SHA256)
+	}
+	assertPortablePRFilePatchStripped(t, db)
+	if !slices.Contains(manifest.Excluded, "pull_request_file_patches") {
+		t.Fatalf("manifest excluded = %v", manifest.Excluded)
 	}
 	if manifest.Repository == nil || manifest.Repository.FullName != "openclaw/gitcrawl" || result.Repository == nil || *manifest.Repository != *result.Repository {
 		t.Fatalf("single-repository metadata manifest=%+v result=%+v", manifest.Repository, result.Repository)
@@ -142,7 +146,7 @@ func TestExportScopedRepositoryKeepsOnlyRequestedDependentData(t *testing.T) {
 	defer db.Close()
 	for _, table := range []string{
 		"repositories", "threads", "comments", "thread_revisions", "thread_fingerprints",
-		"pull_request_details", "pull_request_checks", "thread_child_observation_memberships",
+		"pull_request_details", "pull_request_files", "pull_request_checks", "thread_child_observation_memberships",
 	} {
 		if got := rowCount(t, db, table); got != 1 {
 			t.Fatalf("scoped table %s rows = %d, want 1", table, got)
@@ -161,6 +165,7 @@ func TestExportScopedRepositoryKeepsOnlyRequestedDependentData(t *testing.T) {
 	if fullName != "openclaw/gitcrawl" || title != "portable export" || commentBody != "comment-current-body" {
 		t.Fatalf("scoped data = %q / %q / %q", fullName, title, commentBody)
 	}
+	assertPortablePRFilePatchStripped(t, db)
 	manifest := readManifest(t, result.ManifestPath)
 	if manifest.Repository == nil || *manifest.Repository != *result.Repository {
 		t.Fatalf("scoped manifest repository = %+v, result = %+v", manifest.Repository, result.Repository)
@@ -377,6 +382,7 @@ func seedExportSource(t *testing.T, ctx context.Context, dbPath string) *store.S
 		`insert into thread_fingerprints(id, thread_revision_id, algorithm_version, fingerprint_hash, fingerprint_slug, title_tokens_json, body_token_hash, linked_refs_json, file_set_hash, module_buckets_json, simhash64, feature_json, created_at) values(1, 1, 'v1', 'fingerprint', 'portable-export', '["portable"]', 'bodyhash', '[]', 'files', '[]', '1', '{}', '2026-08-08T00:00:00Z')`,
 		`insert into thread_key_summaries(id, thread_revision_id, summary_kind, prompt_version, provider, model, input_hash, output_hash, key_text, created_at) values(1, 1, 'llm_key', 'v1', 'openai', 'test', 'in', 'out', 'historical enrichment', '2026-08-08T00:00:00Z')`,
 		`insert into pull_request_details(thread_id, repo_id, number, raw_json, fetched_at, updated_at) values(1, 1, 7, '{}', '2026-08-08T00:00:00Z', '2026-08-08T00:00:00Z')`,
+		`insert into pull_request_files(thread_id, position, path, status, additions, deletions, changes, previous_path, patch, raw_json, fetched_at) values(1, 0, 'internal/portable/export.go', 'modified', 10, 2, 12, 'internal/export.go', '@@ retained repository patch', '{}', '2026-08-08T00:00:00Z')`,
 		`insert into pull_request_checks(id, thread_id, name, status, raw_json, fetched_at) values(1, 1, 'test', 'completed', '{}', '2026-08-08T00:00:00Z')`,
 		`insert into thread_child_observation_memberships(thread_id, family, observation_sequence, member_ids_json) values(1, 'comments', 1, '["C1"]')`,
 		`insert into cluster_groups(id, repo_id, stable_key, stable_slug, status, created_at, updated_at) values(1, 1, 'key', 'slug', 'open', '2026-08-08T00:00:00Z', '2026-08-08T00:00:00Z')`,
@@ -418,6 +424,7 @@ func seedSecondExportRepository(t *testing.T, ctx context.Context, st *store.Sto
 		`insert into thread_fingerprints(id, thread_revision_id, algorithm_version, fingerprint_hash, fingerprint_slug, title_tokens_json, body_token_hash, linked_refs_json, file_set_hash, module_buckets_json, simhash64, feature_json, created_at) values(2, 2, 'v1', 'other-fingerprint', 'other', '[]', 'other-bodyhash', '[]', 'other-files', '[]', '2', '{}', '2026-08-08T00:00:00Z')`,
 		`insert into thread_key_summaries(id, thread_revision_id, summary_kind, prompt_version, provider, model, input_hash, output_hash, key_text, created_at) values(2, 2, 'llm_key', 'v1', 'openai', 'test', 'other-in', 'other-out', 'other enrichment', '2026-08-08T00:00:00Z')`,
 		`insert into pull_request_details(thread_id, repo_id, number, raw_json, fetched_at, updated_at) values(2, 2, 8, '{}', '2026-08-08T00:00:00Z', '2026-08-08T00:00:00Z')`,
+		`insert into pull_request_files(thread_id, position, path, status, additions, deletions, changes, previous_path, patch, raw_json, fetched_at) values(2, 0, 'other.go', 'added', 4, 0, 4, null, '@@ other repository patch', '{}', '2026-08-08T00:00:00Z')`,
 		`insert into pull_request_checks(id, thread_id, name, status, raw_json, fetched_at) values(2, 2, 'test', 'completed', '{}', '2026-08-08T00:00:00Z')`,
 		`insert into thread_child_observation_memberships(thread_id, family, observation_sequence, member_ids_json) values(2, 'comments', 2, '["C2"]')`,
 		`insert into cluster_groups(id, repo_id, stable_key, stable_slug, status, created_at, updated_at) values(2, 2, 'other-key', 'other-slug', 'open', '2026-08-08T00:00:00Z', '2026-08-08T00:00:00Z')`,
@@ -530,6 +537,22 @@ func assertManifestTableCounts(t *testing.T, db *sql.DB, tables []Table) {
 			t.Fatalf("manifest table %s rows = %d, database = %d", table.Name, table.Rows, got)
 		}
 		previous = table.Name
+	}
+}
+
+func assertPortablePRFilePatchStripped(t *testing.T, db *sql.DB) {
+	t.Helper()
+	var path, status, previousPath string
+	var additions, deletions, changes int
+	var patch sql.NullString
+	if err := db.QueryRow(`
+		select path, status, additions, deletions, changes, previous_path, patch
+		from pull_request_files
+	`).Scan(&path, &status, &additions, &deletions, &changes, &previousPath, &patch); err != nil {
+		t.Fatalf("read portable PR file: %v", err)
+	}
+	if path != "internal/portable/export.go" || status != "modified" || additions != 10 || deletions != 2 || changes != 12 || previousPath != "internal/export.go" || patch.Valid {
+		t.Fatalf("portable PR file=%q/%q/%d/%d/%d/%q patch=%#v", path, status, additions, deletions, changes, previousPath, patch)
 	}
 }
 

--- a/internal/portable/export_test.go
+++ b/internal/portable/export_test.go
@@ -55,6 +55,13 @@ func TestExportCurrentStateV1SnapshotsLiveWALWithoutMutatingSource(t *testing.T)
 
 	db := openRawDB(t, result.DatabasePath)
 	defer db.Close()
+	var journalMode string
+	if err := db.QueryRow(`pragma journal_mode`).Scan(&journalMode); err != nil {
+		t.Fatalf("read artifact journal mode: %v", err)
+	}
+	if journalMode != "delete" {
+		t.Fatalf("artifact journal mode = %q, want delete", journalMode)
+	}
 	for _, table := range currentStateProfile.DroppedTables {
 		if tableExists(t, db, table) {
 			t.Fatalf("omitted table %s still exists", table)
@@ -106,6 +113,16 @@ func TestExportCurrentStateV1SnapshotsLiveWALWithoutMutatingSource(t *testing.T)
 	}
 	if slices.Contains(result.DroppedIndexes, "idx_comment_revisions_comment") || slices.Contains(result.DroppedIndexes, "custom_comment_revisions_body") {
 		t.Fatalf("implicitly removed indexes were reported as explicitly dropped: %v", result.DroppedIndexes)
+	}
+	if len(result.DroppedTables) < len(currentStateProfile.DroppedTables) || !slices.Equal(result.DroppedTables[:len(currentStateProfile.DroppedTables)], currentStateProfile.DroppedTables) {
+		t.Fatalf("profile tables were not dropped first: %v", result.DroppedTables)
+	}
+	seenDroppedTables := make(map[string]bool)
+	for _, table := range result.DroppedTables {
+		if seenDroppedTables[table] {
+			t.Fatalf("dropped table %s reported more than once: %v", table, result.DroppedTables)
+		}
+		seenDroppedTables[table] = true
 	}
 	manifest := readManifest(t, result.ManifestPath)
 	if manifest.OutputPath != result.PublicPath || manifest.OutputBytes != result.BytesAfter ||
@@ -307,6 +324,76 @@ func TestExportFailureHooksCleanStagingAndNeverCommitPartialPair(t *testing.T) {
 			}
 			assertNoExportTemps(t, dir)
 		})
+	}
+}
+
+func TestExportCancellationDuringStageCleansStaging(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, context.Background(), sourcePath)
+	defer st.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	outputDir := filepath.Join(dir, "canceled")
+	options := testExportOptions(sourcePath, outputDir)
+	options.Progress = func(stage Stage) {
+		if stage == StageCanonicalShaping {
+			cancel()
+		}
+	}
+	if _, err := Export(ctx, options); err == nil || !strings.Contains(err.Error(), "canceled during canonical shaping") {
+		t.Fatalf("canceled export error = %v", err)
+	}
+	if _, err := os.Stat(outputDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("canceled export left target: %v", err)
+	}
+	assertNoExportTemps(t, dir)
+}
+
+func TestExportRejectsForeignKeyViolationBeforeIndexRemoval(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	defer st.Close()
+	if _, err := st.DB().ExecContext(ctx, `pragma foreign_keys = off`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `insert into pull_request_checks(id, thread_id, name, status, raw_json, fetched_at) values(99, 999, 'orphan', 'completed', '{}', '2026-08-09T00:00:00Z')`); err != nil {
+		t.Fatalf("seed FK violation: %v", err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `pragma foreign_keys = on`); err != nil {
+		t.Fatal(err)
+	}
+	outputDir := filepath.Join(dir, "invalid-fk")
+	if _, err := Export(ctx, testExportOptions(sourcePath, outputDir)); err == nil || !strings.Contains(err.Error(), "foreign_key_check failed") {
+		t.Fatalf("foreign key export error = %v", err)
+	}
+	if _, err := os.Stat(outputDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("foreign key failure left target: %v", err)
+	}
+	assertNoExportTemps(t, dir)
+}
+
+func TestConfigureDisposableStoreUsesRollbackJournalAndReducedSync(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "staging.db"))
+	if err != nil {
+		t.Fatalf("open staging store: %v", err)
+	}
+	defer st.Close()
+	if err := configureDisposableStore(ctx, st.DB()); err != nil {
+		t.Fatalf("configure disposable store: %v", err)
+	}
+	var journalMode string
+	var synchronous int
+	if err := st.DB().QueryRowContext(ctx, `pragma journal_mode`).Scan(&journalMode); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.DB().QueryRowContext(ctx, `pragma synchronous`).Scan(&synchronous); err != nil {
+		t.Fatal(err)
+	}
+	if journalMode != "delete" || synchronous != 0 || st.DB().Stats().MaxOpenConnections != 1 {
+		t.Fatalf("disposable settings journal=%q synchronous=%d max_open=%d", journalMode, synchronous, st.DB().Stats().MaxOpenConnections)
 	}
 }
 

--- a/internal/portable/export_test.go
+++ b/internal/portable/export_test.go
@@ -104,6 +104,9 @@ func TestExportCurrentStateV1SnapshotsLiveWALWithoutMutatingSource(t *testing.T)
 	if !slices.Contains(result.DroppedIndexes, "custom_comments_author") || slices.Contains(result.DroppedIndexes, "unique_comments_github") {
 		t.Fatalf("dropped indexes = %v", result.DroppedIndexes)
 	}
+	if slices.Contains(result.DroppedIndexes, "idx_comment_revisions_comment") || slices.Contains(result.DroppedIndexes, "custom_comment_revisions_body") {
+		t.Fatalf("implicitly removed indexes were reported as explicitly dropped: %v", result.DroppedIndexes)
+	}
 	manifest := readManifest(t, result.ManifestPath)
 	if manifest.OutputPath != result.PublicPath || manifest.OutputBytes != result.BytesAfter ||
 		manifest.SHA256 != result.SHA256 || manifest.ArtifactID != result.ArtifactID ||
@@ -113,6 +116,100 @@ func TestExportCurrentStateV1SnapshotsLiveWALWithoutMutatingSource(t *testing.T)
 	if got := hashFile(t, result.DatabasePath); got != result.SHA256 {
 		t.Fatalf("database hash = %s, want %s", got, result.SHA256)
 	}
+	if manifest.Repository == nil || manifest.Repository.FullName != "openclaw/gitcrawl" || result.Repository == nil || *manifest.Repository != *result.Repository {
+		t.Fatalf("single-repository metadata manifest=%+v result=%+v", manifest.Repository, result.Repository)
+	}
+	assertManifestTableCounts(t, db, manifest.Tables)
+}
+
+func TestExportScopedRepositoryKeepsOnlyRequestedDependentData(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	defer st.Close()
+	seedSecondExportRepository(t, ctx, st)
+	options := testExportOptions(sourcePath, filepath.Join(dir, "scoped"))
+	options.Repository = "openclaw/gitcrawl"
+	result, err := Export(ctx, options)
+	if err != nil {
+		t.Fatalf("scoped export: %v", err)
+	}
+	if result.Repository == nil || *result.Repository != (Repository{ID: 1, Owner: "openclaw", Name: "gitcrawl", FullName: "openclaw/gitcrawl"}) {
+		t.Fatalf("scoped repository = %+v", result.Repository)
+	}
+	db := openRawDB(t, result.DatabasePath)
+	defer db.Close()
+	for _, table := range []string{
+		"repositories", "threads", "comments", "thread_revisions", "thread_fingerprints",
+		"pull_request_details", "pull_request_checks", "thread_child_observation_memberships",
+	} {
+		if got := rowCount(t, db, table); got != 1 {
+			t.Fatalf("scoped table %s rows = %d, want 1", table, got)
+		}
+	}
+	var fullName, title, commentBody string
+	if err := db.QueryRow(`select full_name from repositories`).Scan(&fullName); err != nil {
+		t.Fatalf("read scoped repository: %v", err)
+	}
+	if err := db.QueryRow(`select title from threads`).Scan(&title); err != nil {
+		t.Fatalf("read scoped thread: %v", err)
+	}
+	if err := db.QueryRow(`select body from comments`).Scan(&commentBody); err != nil {
+		t.Fatalf("read scoped comment: %v", err)
+	}
+	if fullName != "openclaw/gitcrawl" || title != "portable export" || commentBody != "comment-current-body" {
+		t.Fatalf("scoped data = %q / %q / %q", fullName, title, commentBody)
+	}
+	manifest := readManifest(t, result.ManifestPath)
+	if manifest.Repository == nil || *manifest.Repository != *result.Repository {
+		t.Fatalf("scoped manifest repository = %+v, result = %+v", manifest.Repository, result.Repository)
+	}
+	assertManifestTableCounts(t, db, manifest.Tables)
+	if slices.Contains(result.DroppedIndexes, "idx_comment_revisions_comment") || slices.Contains(result.DroppedIndexes, "custom_comment_revisions_body") {
+		t.Fatalf("dropped indexes include indexes removed with a table: %v", result.DroppedIndexes)
+	}
+}
+
+func TestExportMissingRepositoryCleansStaging(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	defer st.Close()
+	outputDir := filepath.Join(dir, "missing")
+	options := testExportOptions(sourcePath, outputDir)
+	options.Repository = "openclaw/missing"
+	if _, err := Export(ctx, options); err == nil || !strings.Contains(err.Error(), `target repository "openclaw/missing" count is 0`) {
+		t.Fatalf("missing repository error = %v", err)
+	}
+	if _, err := os.Stat(outputDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("missing repository left target: %v", err)
+	}
+	assertNoExportTemps(t, dir)
+}
+
+func TestExportUnscopedMultiRepositoryOmitsSingularMetadata(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	defer st.Close()
+	seedSecondExportRepository(t, ctx, st)
+	result, err := Export(ctx, testExportOptions(sourcePath, filepath.Join(dir, "multi")))
+	if err != nil {
+		t.Fatalf("unscoped multi-repository export: %v", err)
+	}
+	manifest := readManifest(t, result.ManifestPath)
+	if result.Repository != nil || manifest.Repository != nil {
+		t.Fatalf("multi-repository metadata result=%+v manifest=%+v", result.Repository, manifest.Repository)
+	}
+	db := openRawDB(t, result.DatabasePath)
+	defer db.Close()
+	if got := rowCount(t, db, "repositories"); got != 2 {
+		t.Fatalf("unscoped repositories = %d, want 2", got)
+	}
+	assertManifestTableCounts(t, db, manifest.Tables)
 }
 
 func TestExportByteBudgetExactAndOneByteOver(t *testing.T) {
@@ -288,6 +385,7 @@ func seedExportSource(t *testing.T, ctx context.Context, dbPath string) *store.S
 		`insert into cluster_aliases(cluster_id, alias_slug, reason, created_at) values(1, 'old-slug', 'lineage', '2026-08-08T00:00:00Z')`,
 		`insert into cluster_closures(cluster_id, reason, actor_kind, created_at, updated_at) values(1, 'local', 'human', '2026-08-08T00:00:00Z', '2026-08-08T00:00:00Z')`,
 		`create index custom_comments_author on comments(author_login)`,
+		`create index custom_comment_revisions_body on comment_revisions(body)`,
 		`create unique index unique_comments_github on comments(github_id)`,
 	}
 	tx, err := st.DB().BeginTx(ctx, nil)
@@ -307,6 +405,40 @@ func seedExportSource(t *testing.T, ctx context.Context, dbPath string) *store.S
 		t.Fatalf("source WAL missing: %v", err)
 	}
 	return st
+}
+
+func seedSecondExportRepository(t *testing.T, ctx context.Context, st *store.Store) {
+	t.Helper()
+	statements := []string{
+		`insert into repositories(id, owner, name, full_name, raw_json, updated_at) values(2, 'openclaw', 'other', 'openclaw/other', '{}', '2026-08-08T00:00:00Z')`,
+		`insert into threads(id, repo_id, github_id, number, kind, state, title, body, html_url, labels_json, assignees_json, raw_json, content_hash, updated_at) values(2, 2, 'T2', 8, 'pull_request', 'open', 'other repository', 'other body', 'https://github.com/openclaw/other/pull/8', '[]', '[]', '{}', 'other-hash', '2026-08-08T00:00:00Z')`,
+		`insert into comments(id, thread_id, github_id, comment_type, body, raw_json) values(2, 2, 'C2', 'issue_comment', 'other-comment', '{}')`,
+		`insert into comment_revisions(id, comment_id, body, raw_json, recorded_at) values(2, 2, 'other-history', '{}', '2026-08-08T00:00:00Z')`,
+		`insert into thread_revisions(id, thread_id, content_hash, title_hash, body_hash, labels_hash, created_at) values(2, 2, 'other-content', 'other-title', 'other-body', 'other-labels', '2026-08-08T00:00:00Z')`,
+		`insert into thread_fingerprints(id, thread_revision_id, algorithm_version, fingerprint_hash, fingerprint_slug, title_tokens_json, body_token_hash, linked_refs_json, file_set_hash, module_buckets_json, simhash64, feature_json, created_at) values(2, 2, 'v1', 'other-fingerprint', 'other', '[]', 'other-bodyhash', '[]', 'other-files', '[]', '2', '{}', '2026-08-08T00:00:00Z')`,
+		`insert into thread_key_summaries(id, thread_revision_id, summary_kind, prompt_version, provider, model, input_hash, output_hash, key_text, created_at) values(2, 2, 'llm_key', 'v1', 'openai', 'test', 'other-in', 'other-out', 'other enrichment', '2026-08-08T00:00:00Z')`,
+		`insert into pull_request_details(thread_id, repo_id, number, raw_json, fetched_at, updated_at) values(2, 2, 8, '{}', '2026-08-08T00:00:00Z', '2026-08-08T00:00:00Z')`,
+		`insert into pull_request_checks(id, thread_id, name, status, raw_json, fetched_at) values(2, 2, 'test', 'completed', '{}', '2026-08-08T00:00:00Z')`,
+		`insert into thread_child_observation_memberships(thread_id, family, observation_sequence, member_ids_json) values(2, 'comments', 2, '["C2"]')`,
+		`insert into cluster_groups(id, repo_id, stable_key, stable_slug, status, created_at, updated_at) values(2, 2, 'other-key', 'other-slug', 'open', '2026-08-08T00:00:00Z', '2026-08-08T00:00:00Z')`,
+		`insert into cluster_memberships(cluster_id, thread_id, role, state, added_by, added_reason_json, created_at, updated_at) values(2, 2, 'member', 'active', 'system', '{}', '2026-08-08T00:00:00Z', '2026-08-08T00:00:00Z')`,
+		`insert into cluster_overrides(id, repo_id, cluster_id, thread_id, action, created_at) values(2, 2, 2, 2, 'exclude', '2026-08-08T00:00:00Z')`,
+		`insert into cluster_aliases(cluster_id, alias_slug, reason, created_at) values(2, 'other-old-slug', 'lineage', '2026-08-08T00:00:00Z')`,
+		`insert into cluster_closures(cluster_id, reason, actor_kind, created_at, updated_at) values(2, 'local', 'human', '2026-08-08T00:00:00Z', '2026-08-08T00:00:00Z')`,
+	}
+	tx, err := st.DB().BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin second repository seed: %v", err)
+	}
+	for _, statement := range statements {
+		if _, err := tx.ExecContext(ctx, statement); err != nil {
+			_ = tx.Rollback()
+			t.Fatalf("seed second repository with %q: %v", statement, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit second repository seed: %v", err)
+	}
 }
 
 func testExportOptions(sourcePath, outputDir string) ExportOptions {
@@ -382,6 +514,23 @@ func readManifest(t *testing.T, path string) Manifest {
 		t.Fatalf("read manifest: %v", err)
 	}
 	return manifest
+}
+
+func assertManifestTableCounts(t *testing.T, db *sql.DB, tables []Table) {
+	t.Helper()
+	if len(tables) == 0 {
+		t.Fatal("manifest tables are empty")
+	}
+	previous := ""
+	for _, table := range tables {
+		if previous != "" && table.Name <= previous {
+			t.Fatalf("manifest tables not sorted: %q before %q", previous, table.Name)
+		}
+		if got := int64(rowCount(t, db, table.Name)); got != table.Rows {
+			t.Fatalf("manifest table %s rows = %d, database = %d", table.Name, table.Rows, got)
+		}
+		previous = table.Name
+	}
 }
 
 func assertNoExportTemps(t *testing.T, parent string) {

--- a/internal/portable/export_test.go
+++ b/internal/portable/export_test.go
@@ -1,0 +1,396 @@
+package portable
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/gitcrawl/internal/store"
+)
+
+func TestExportCurrentStateV1SnapshotsLiveWALWithoutMutatingSource(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	defer st.Close()
+
+	sourceBefore := readFile(t, sourcePath)
+	walBefore := readFile(t, sourcePath+"-wal")
+	outputDir := filepath.Join(dir, "artifact.next")
+	result, err := Export(ctx, ExportOptions{
+		SourceDBPath: sourcePath,
+		OutputDir:    outputDir,
+		DatabaseName: "openclaw__openclaw.sync.db",
+		PublicPath:   "data/openclaw__openclaw.sync.db",
+		Profile:      CurrentStateV1,
+		BodyChars:    8,
+	})
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	if !result.ArtifactCommitted || !result.ByteBudgetOK || result.QuickCheck != "ok" || result.IntegrityCheck != "ok" || result.ForeignKeyViolations != 0 {
+		t.Fatalf("export result = %+v", result)
+	}
+	if !bytes.Equal(sourceBefore, readFile(t, sourcePath)) {
+		t.Fatal("export changed source database bytes")
+	}
+	if !bytes.Equal(walBefore, readFile(t, sourcePath+"-wal")) {
+		t.Fatal("export changed source WAL bytes")
+	}
+	for _, suffix := range []string{"-wal", "-shm"} {
+		if _, err := os.Stat(result.DatabasePath + suffix); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("artifact sidecar %s exists: %v", suffix, err)
+		}
+	}
+
+	db := openRawDB(t, result.DatabasePath)
+	defer db.Close()
+	for _, table := range currentStateProfile.DroppedTables {
+		if tableExists(t, db, table) {
+			t.Fatalf("omitted table %s still exists", table)
+		}
+	}
+	for _, table := range []string{
+		"repositories", "threads", "comments", "thread_revisions", "thread_fingerprints",
+		"pull_request_details", "pull_request_checks", "thread_child_observation_memberships",
+	} {
+		if !tableExists(t, db, table) {
+			t.Fatalf("preserved table %s is missing", table)
+		}
+		if got := rowCount(t, db, table); got != 1 {
+			t.Fatalf("preserved table %s row count = %d, want 1", table, got)
+		}
+	}
+	var body, excerpt string
+	var bodyLength int
+	if err := db.QueryRow(`select body_excerpt, body_excerpt, body_length from threads where id = 1`).Scan(&body, &excerpt, &bodyLength); err != nil {
+		t.Fatalf("read compact thread: %v", err)
+	}
+	if body != "abcdefgh" || excerpt != "abcdefgh" || bodyLength != 26 {
+		t.Fatalf("compact thread = body %q excerpt %q length %d", body, excerpt, bodyLength)
+	}
+	var sourceMetadata, profileMetadata, includes, capabilities, excluded, indexProfile string
+	for key, target := range map[string]*string{
+		"source_path": &sourceMetadata, "profile": &profileMetadata, "includes": &includes,
+		"capabilities": &capabilities, "excluded": &excluded, "index_profile": &indexProfile,
+	} {
+		if err := db.QueryRow(`select value from portable_metadata where key = ?`, key).Scan(target); err != nil {
+			t.Fatalf("read metadata %s: %v", key, err)
+		}
+	}
+	if sourceMetadata != "data/openclaw__openclaw.sync.db" || strings.Contains(sourceMetadata, dir) {
+		t.Fatalf("portable source_path = %q", sourceMetadata)
+	}
+	if profileMetadata != CurrentStateV1 || indexProfile != "constraints-only" {
+		t.Fatalf("profile metadata = %q / %q", profileMetadata, indexProfile)
+	}
+	if !csvContains(includes, "comments") || !csvContains(includes, "thread_child_observation_memberships") ||
+		!csvContains(capabilities, "current_comments") || csvContains(excluded, "comments") {
+		t.Fatalf("inaccurate metadata includes=%q capabilities=%q excluded=%q", includes, capabilities, excluded)
+	}
+	if indexExists(t, db, "custom_comments_author") || !indexExists(t, db, "unique_comments_github") {
+		t.Fatalf("index policy not applied: dropped=%v unique=%v", indexExists(t, db, "custom_comments_author"), indexExists(t, db, "unique_comments_github"))
+	}
+	if !slices.Contains(result.DroppedIndexes, "custom_comments_author") || slices.Contains(result.DroppedIndexes, "unique_comments_github") {
+		t.Fatalf("dropped indexes = %v", result.DroppedIndexes)
+	}
+	manifest := readManifest(t, result.ManifestPath)
+	if manifest.OutputPath != result.PublicPath || manifest.OutputBytes != result.BytesAfter ||
+		manifest.SHA256 != result.SHA256 || manifest.ArtifactID != result.ArtifactID ||
+		manifest.ForeignKeyViolations != 0 || !manifest.ValidationOK {
+		t.Fatalf("manifest/result mismatch: manifest=%+v result=%+v", manifest, result)
+	}
+	if got := hashFile(t, result.DatabasePath); got != result.SHA256 {
+		t.Fatalf("database hash = %s, want %s", got, result.SHA256)
+	}
+}
+
+func TestExportByteBudgetExactAndOneByteOver(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	defer st.Close()
+	baseline, err := Export(ctx, testExportOptions(sourcePath, filepath.Join(dir, "baseline")))
+	if err != nil {
+		t.Fatalf("baseline export: %v", err)
+	}
+	exactOptions := testExportOptions(sourcePath, filepath.Join(dir, "exact"))
+	exactOptions.MaxBytes = &baseline.BytesAfter
+	exact, err := Export(ctx, exactOptions)
+	if err != nil {
+		t.Fatalf("exact byte budget: %v", err)
+	}
+	if exact.BytesAfter != baseline.BytesAfter || !exact.ByteBudgetOK {
+		t.Fatalf("exact result = %+v, baseline bytes = %d", exact, baseline.BytesAfter)
+	}
+	oneUnder := baseline.BytesAfter - 1
+	failingDir := filepath.Join(dir, "too-large")
+	failingOptions := testExportOptions(sourcePath, failingDir)
+	failingOptions.MaxBytes = &oneUnder
+	failed, err := Export(ctx, failingOptions)
+	if err == nil || !strings.Contains(err.Error(), "exceeds max-bytes") || failed.ByteBudgetOK {
+		t.Fatalf("one-byte-over result=%+v err=%v", failed, err)
+	}
+	if _, err := os.Stat(failingDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("failed budget left target: %v", err)
+	}
+	assertNoExportTemps(t, dir)
+}
+
+func TestExportRejectsUnsafeInputsAndExistingOutput(t *testing.T) {
+	for _, name := range []string{"", ".", "..", "a/b.db", `a\b.db`, "bad\x00.db", "gitcrawl.db-wal", "gitcrawl.db-shm", "gitcrawl.db.manifest.json"} {
+		if err := ValidateDatabaseName(name); err == nil {
+			t.Errorf("ValidateDatabaseName(%q) succeeded", name)
+		}
+	}
+	for _, publicPath := range []string{"", ".", "/data/a.db", "../a.db", "data/../a.db", "data//a.db", `data\a.db`, "data/bad\x00.db", "C:/a.db"} {
+		if err := ValidatePublicPath(publicPath); err == nil {
+			t.Errorf("ValidatePublicPath(%q) succeeded", publicPath)
+		}
+	}
+	if err := ValidateDatabaseName("export-2026.db"); err != nil {
+		t.Fatalf("valid database name rejected: %v", err)
+	}
+	if err := ValidatePublicPath("data/export-2026.db"); err != nil {
+		t.Fatalf("valid public path rejected: %v", err)
+	}
+	if _, err := ResolveProfile("current-state-v2"); err == nil || !strings.Contains(err.Error(), CurrentStateV1) {
+		t.Fatalf("unknown profile error = %v", err)
+	}
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	defer st.Close()
+	existing := filepath.Join(dir, "existing")
+	if err := os.Mkdir(existing, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Export(ctx, testExportOptions(sourcePath, existing)); err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("existing output error = %v", err)
+	}
+}
+
+func TestExportFailureHooksCleanStagingAndNeverCommitPartialPair(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	defer st.Close()
+	for _, tc := range []struct {
+		name     string
+		exporter exporter
+	}{
+		{name: "manifest", exporter: exporter{beforeManifest: func() error { return errors.New("manifest fault") }}},
+		{name: "commit", exporter: exporter{beforeCommit: func() error { return errors.New("commit fault") }}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			outputDir := filepath.Join(dir, tc.name)
+			if _, err := tc.exporter.export(ctx, testExportOptions(sourcePath, outputDir)); err == nil || !strings.Contains(err.Error(), "fault") {
+				t.Fatalf("fault error = %v", err)
+			}
+			if _, err := os.Stat(outputDir); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("fault left target: %v", err)
+			}
+			assertNoExportTemps(t, dir)
+		})
+	}
+}
+
+func TestRemoveSQLiteSidecarsFailsClosed(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "artifact.db")
+	walDir := dbPath + "-wal"
+	if err := os.Mkdir(walDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(walDir, "locked"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeSQLiteSidecars(dbPath); err == nil || !strings.Contains(err.Error(), "remove portable SQLite sidecar") {
+		t.Fatalf("sidecar cleanup error = %v", err)
+	}
+}
+
+func TestExportedDatabaseReopensWritableAndRecreatesOmittedSchema(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	defer st.Close()
+	result, err := Export(ctx, testExportOptions(sourcePath, filepath.Join(dir, "artifact")))
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	writable, err := store.Open(ctx, result.DatabasePath)
+	if err != nil {
+		t.Fatalf("writable reopen/migrate: %v", err)
+	}
+	defer writable.Close()
+	for _, table := range currentStateProfile.DroppedTables {
+		if !tableExists(t, writable.DB(), table) {
+			t.Fatalf("migration did not recreate %s", table)
+		}
+		if table != "comment_revisions" && rowCount(t, writable.DB(), table) != 0 {
+			got := rowCount(t, writable.DB(), table)
+			t.Fatalf("recreated history table %s has %d rows", table, got)
+		}
+	}
+	var historicalComments int
+	if err := writable.DB().QueryRow(`select count(*) from comment_revisions where body = 'historical-comment'`).Scan(&historicalComments); err != nil {
+		t.Fatalf("inspect recreated comment revisions: %v", err)
+	}
+	if historicalComments != 0 {
+		t.Fatal("migration restored omitted historical comment data")
+	}
+	if !indexExists(t, writable.DB(), "idx_comments_thread_type") {
+		t.Fatal("migration did not recreate ordinary schema indexes")
+	}
+}
+
+func seedExportSource(t *testing.T, ctx context.Context, dbPath string) *store.Store {
+	t.Helper()
+	st, err := store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open source: %v", err)
+	}
+	st.DB().SetMaxOpenConns(1)
+	if _, err := st.DB().ExecContext(ctx, `pragma wal_checkpoint(TRUNCATE)`); err != nil {
+		t.Fatalf("checkpoint source: %v", err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `pragma wal_autocheckpoint = 0`); err != nil {
+		t.Fatalf("disable WAL autocheckpoint: %v", err)
+	}
+	statements := []string{
+		`insert into repositories(id, owner, name, full_name, raw_json, updated_at) values(1, 'openclaw', 'gitcrawl', 'openclaw/gitcrawl', '{"private":"repo"}', '2026-08-08T00:00:00Z')`,
+		`insert into threads(id, repo_id, github_id, number, kind, state, title, body, html_url, labels_json, assignees_json, raw_json, content_hash, updated_at) values(1, 1, 'T1', 7, 'pull_request', 'open', 'portable export', 'abcdefghijklmnopqrstuvwxyz', 'https://github.com/openclaw/gitcrawl/pull/7', '[]', '[]', '{"private":"thread"}', 'hash', '2026-08-08T00:00:00Z')`,
+		`insert into comments(id, thread_id, github_id, comment_type, body, raw_json) values(1, 1, 'C1', 'issue_comment', 'comment-current-body', '{"private":"comment"}')`,
+		`insert into comment_revisions(id, comment_id, body, raw_json, recorded_at) values(1, 1, 'historical-comment', '{}', '2026-08-08T00:00:00Z')`,
+		`insert into thread_revisions(id, thread_id, content_hash, title_hash, body_hash, labels_hash, created_at) values(1, 1, 'content', 'title', 'body', 'labels', '2026-08-08T00:00:00Z')`,
+		`insert into thread_fingerprints(id, thread_revision_id, algorithm_version, fingerprint_hash, fingerprint_slug, title_tokens_json, body_token_hash, linked_refs_json, file_set_hash, module_buckets_json, simhash64, feature_json, created_at) values(1, 1, 'v1', 'fingerprint', 'portable-export', '["portable"]', 'bodyhash', '[]', 'files', '[]', '1', '{}', '2026-08-08T00:00:00Z')`,
+		`insert into thread_key_summaries(id, thread_revision_id, summary_kind, prompt_version, provider, model, input_hash, output_hash, key_text, created_at) values(1, 1, 'llm_key', 'v1', 'openai', 'test', 'in', 'out', 'historical enrichment', '2026-08-08T00:00:00Z')`,
+		`insert into pull_request_details(thread_id, repo_id, number, raw_json, fetched_at, updated_at) values(1, 1, 7, '{}', '2026-08-08T00:00:00Z', '2026-08-08T00:00:00Z')`,
+		`insert into pull_request_checks(id, thread_id, name, status, raw_json, fetched_at) values(1, 1, 'test', 'completed', '{}', '2026-08-08T00:00:00Z')`,
+		`insert into thread_child_observation_memberships(thread_id, family, observation_sequence, member_ids_json) values(1, 'comments', 1, '["C1"]')`,
+		`insert into cluster_groups(id, repo_id, stable_key, stable_slug, status, created_at, updated_at) values(1, 1, 'key', 'slug', 'open', '2026-08-08T00:00:00Z', '2026-08-08T00:00:00Z')`,
+		`insert into cluster_memberships(cluster_id, thread_id, role, state, added_by, added_reason_json, created_at, updated_at) values(1, 1, 'member', 'active', 'system', '{}', '2026-08-08T00:00:00Z', '2026-08-08T00:00:00Z')`,
+		`insert into cluster_overrides(id, repo_id, cluster_id, thread_id, action, created_at) values(1, 1, 1, 1, 'exclude', '2026-08-08T00:00:00Z')`,
+		`insert into cluster_aliases(cluster_id, alias_slug, reason, created_at) values(1, 'old-slug', 'lineage', '2026-08-08T00:00:00Z')`,
+		`insert into cluster_closures(cluster_id, reason, actor_kind, created_at, updated_at) values(1, 'local', 'human', '2026-08-08T00:00:00Z', '2026-08-08T00:00:00Z')`,
+		`create index custom_comments_author on comments(author_login)`,
+		`create unique index unique_comments_github on comments(github_id)`,
+	}
+	tx, err := st.DB().BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin seed: %v", err)
+	}
+	for _, statement := range statements {
+		if _, err := tx.ExecContext(ctx, statement); err != nil {
+			_ = tx.Rollback()
+			t.Fatalf("seed source with %q: %v", statement, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit seed: %v", err)
+	}
+	if _, err := os.Stat(dbPath + "-wal"); err != nil {
+		t.Fatalf("source WAL missing: %v", err)
+	}
+	return st
+}
+
+func testExportOptions(sourcePath, outputDir string) ExportOptions {
+	return ExportOptions{
+		SourceDBPath: sourcePath,
+		OutputDir:    outputDir,
+		DatabaseName: "gitcrawl.db",
+		PublicPath:   "data/gitcrawl.db",
+		Profile:      CurrentStateV1,
+		BodyChars:    32,
+	}
+}
+
+func openRawDB(t *testing.T, path string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open sqlite %s: %v", path, err)
+	}
+	return db
+}
+
+func tableExists(t *testing.T, db *sql.DB, name string) bool {
+	t.Helper()
+	var exists int
+	if err := db.QueryRow(`select exists(select 1 from sqlite_schema where type = 'table' and name = ?)`, name).Scan(&exists); err != nil {
+		t.Fatalf("inspect table %s: %v", name, err)
+	}
+	return exists == 1
+}
+
+func indexExists(t *testing.T, db *sql.DB, name string) bool {
+	t.Helper()
+	var exists int
+	if err := db.QueryRow(`select exists(select 1 from sqlite_schema where type = 'index' and name = ?)`, name).Scan(&exists); err != nil {
+		t.Fatalf("inspect index %s: %v", name, err)
+	}
+	return exists == 1
+}
+
+func rowCount(t *testing.T, db *sql.DB, table string) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`select count(*) from ` + quoteIdentifier(table)).Scan(&count); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	return count
+}
+
+func csvContains(csv, value string) bool {
+	return slices.Contains(strings.Split(csv, ","), value)
+}
+
+func readFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return data
+}
+
+func hashFile(t *testing.T, path string) string {
+	t.Helper()
+	sum := sha256.Sum256(readFile(t, path))
+	return hex.EncodeToString(sum[:])
+}
+
+func readManifest(t *testing.T, path string) Manifest {
+	t.Helper()
+	var manifest Manifest
+	if err := json.Unmarshal(readFile(t, path), &manifest); err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	return manifest
+}
+
+func assertNoExportTemps(t *testing.T, parent string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(parent, ".gitcrawl-portable-export-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary exports remain: %v", matches)
+	}
+}

--- a/internal/portable/export_test.go
+++ b/internal/portable/export_test.go
@@ -78,18 +78,21 @@ func TestExportCurrentStateV1SnapshotsLiveWALWithoutMutatingSource(t *testing.T)
 			t.Fatalf("preserved table %s row count = %d, want 1", table, got)
 		}
 	}
-	var body, excerpt string
+	var body, excerpt, threadRawJSON, repositoryRawJSON string
 	var bodyLength int
-	if err := db.QueryRow(`select body_excerpt, body_excerpt, body_length from threads where id = 1`).Scan(&body, &excerpt, &bodyLength); err != nil {
+	if err := db.QueryRow(`select body, body_excerpt, body_length, raw_json from threads where id = 1`).Scan(&body, &excerpt, &bodyLength, &threadRawJSON); err != nil {
 		t.Fatalf("read compact thread: %v", err)
 	}
-	if body != "abcdefgh" || excerpt != "abcdefgh" || bodyLength != 26 {
-		t.Fatalf("compact thread = body %q excerpt %q length %d", body, excerpt, bodyLength)
+	if err := db.QueryRow(`select raw_json from repositories where id = 1`).Scan(&repositoryRawJSON); err != nil {
+		t.Fatalf("read compact repository: %v", err)
 	}
-	var sourceMetadata, profileMetadata, includes, capabilities, excluded, indexProfile string
+	if body != "abcdefgh" || excerpt != "abcdefgh" || bodyLength != 26 || threadRawJSON != "" || repositoryRawJSON != "" {
+		t.Fatalf("compact thread = body %q excerpt %q length %d thread_raw=%q repository_raw=%q", body, excerpt, bodyLength, threadRawJSON, repositoryRawJSON)
+	}
+	var sourceMetadata, profileMetadata, includes, capabilities, excluded, indexProfile, columnProfile string
 	for key, target := range map[string]*string{
 		"source_path": &sourceMetadata, "profile": &profileMetadata, "includes": &includes,
-		"capabilities": &capabilities, "excluded": &excluded, "index_profile": &indexProfile,
+		"capabilities": &capabilities, "excluded": &excluded, "index_profile": &indexProfile, "column_profile": &columnProfile,
 	} {
 		if err := db.QueryRow(`select value from portable_metadata where key = ?`, key).Scan(target); err != nil {
 			t.Fatalf("read metadata %s: %v", key, err)
@@ -98,8 +101,8 @@ func TestExportCurrentStateV1SnapshotsLiveWALWithoutMutatingSource(t *testing.T)
 	if sourceMetadata != "data/openclaw__openclaw.sync.db" || strings.Contains(sourceMetadata, dir) {
 		t.Fatalf("portable source_path = %q", sourceMetadata)
 	}
-	if profileMetadata != CurrentStateV1 || indexProfile != "constraints-only" {
-		t.Fatalf("profile metadata = %q / %q", profileMetadata, indexProfile)
+	if profileMetadata != CurrentStateV1 || indexProfile != "constraints-only" || columnProfile != store.PortableColumnProfileSanitizedCompatibility {
+		t.Fatalf("profile metadata = %q / %q / %q", profileMetadata, indexProfile, columnProfile)
 	}
 	if !csvContains(includes, "comments") || !csvContains(includes, "thread_child_observation_memberships") ||
 		!csvContains(capabilities, "current_comments") || !csvContains(excluded, "pull_request_file_patches") || csvContains(excluded, "comments") {
@@ -127,7 +130,8 @@ func TestExportCurrentStateV1SnapshotsLiveWALWithoutMutatingSource(t *testing.T)
 	manifest := readManifest(t, result.ManifestPath)
 	if manifest.OutputPath != result.PublicPath || manifest.OutputBytes != result.BytesAfter ||
 		manifest.SHA256 != result.SHA256 || manifest.ArtifactID != result.ArtifactID ||
-		manifest.ForeignKeyViolations != 0 || !manifest.ValidationOK {
+		manifest.ForeignKeyViolations != 0 || !manifest.ValidationOK ||
+		manifest.ColumnProfile != store.PortableColumnProfileSanitizedCompatibility || result.ColumnProfile != manifest.ColumnProfile {
 		t.Fatalf("manifest/result mismatch: manifest=%+v result=%+v", manifest, result)
 	}
 	if got := hashFile(t, result.DatabasePath); got != result.SHA256 {
@@ -484,6 +488,7 @@ func TestFinalCompactArtifactExcludesDeletedPayloadSentinels(t *testing.T) {
 		"GITCRAWL_REMOVED_RAW_JSON_SENTINEL_" + strings.Repeat("r", 96),
 		"GITCRAWL_REMOVED_PR_PATCH_SENTINEL_" + strings.Repeat("p", 96),
 		"GITCRAWL_REMOVED_SYNC_FAILURE_SENTINEL_" + strings.Repeat("s", 96),
+		"GITCRAWL_REMOVED_FULL_THREAD_BODY_SENTINEL_" + strings.Repeat("b", 160),
 	}
 	if _, err := st.DB().ExecContext(ctx, `update comment_revisions set body = ? where id = 1`, sentinels[0]); err != nil {
 		t.Fatal(err)
@@ -503,6 +508,9 @@ func TestFinalCompactArtifactExcludesDeletedPayloadSentinels(t *testing.T) {
 	`, sentinels[3]); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := st.DB().ExecContext(ctx, `update threads set body = ? where id = 1`, sentinels[4]); err != nil {
+		t.Fatal(err)
+	}
 	result, err := Export(ctx, testExportOptions(sourcePath, filepath.Join(dir, "artifact")))
 	if err != nil {
 		t.Fatalf("export sentinel fixture: %v", err)
@@ -515,17 +523,22 @@ func TestFinalCompactArtifactExcludesDeletedPayloadSentinels(t *testing.T) {
 	}
 	db := openRawDB(t, result.DatabasePath)
 	defer db.Close()
-	var title, path, status string
+	var title, path, status, body, excerpt, rawJSON string
+	var bodyLength int
 	var additions int
 	var patch sql.NullString
 	if err := db.QueryRow(`select title from threads where id = 1`).Scan(&title); err != nil {
 		t.Fatal(err)
 	}
+	if err := db.QueryRow(`select body, body_excerpt, body_length, raw_json from threads where id = 1`).Scan(&body, &excerpt, &bodyLength, &rawJSON); err != nil {
+		t.Fatal(err)
+	}
 	if err := db.QueryRow(`select path, status, additions, patch from pull_request_files where thread_id = 1`).Scan(&path, &status, &additions, &patch); err != nil {
 		t.Fatal(err)
 	}
-	if title != "portable export" || path != "internal/portable/export.go" || status != "modified" || additions != 10 || patch.Valid {
-		t.Fatalf("retained metadata title=%q file=%q/%q/%d patch=%#v", title, path, status, additions, patch)
+	wantExcerpt := sentinels[4][:32]
+	if title != "portable export" || body != wantExcerpt || excerpt != wantExcerpt || bodyLength != len(sentinels[4]) || rawJSON != "" || path != "internal/portable/export.go" || status != "modified" || additions != 10 || patch.Valid {
+		t.Fatalf("retained metadata title=%q body=%q excerpt=%q length=%d raw=%q file=%q/%q/%d patch=%#v", title, body, excerpt, bodyLength, rawJSON, path, status, additions, patch)
 	}
 }
 
@@ -650,6 +663,22 @@ func TestExportedDatabaseReopensWritableAndRecreatesOmittedSchema(t *testing.T) 
 	}
 	if !indexExists(t, writable.DB(), "idx_comments_thread_type") {
 		t.Fatal("migration did not recreate ordinary schema indexes")
+	}
+	if _, err := writable.DB().ExecContext(ctx, `update threads set body = 'writable body', raw_json = '{"writable":true}' where id = 1`); err != nil {
+		t.Fatalf("write retained thread columns: %v", err)
+	}
+	if _, err := writable.DB().ExecContext(ctx, `update repositories set raw_json = '{"writable":true}' where id = 1`); err != nil {
+		t.Fatalf("write retained repository column: %v", err)
+	}
+	var body, threadRaw, repositoryRaw string
+	if err := writable.DB().QueryRowContext(ctx, `select body, raw_json from threads where id = 1`).Scan(&body, &threadRaw); err != nil {
+		t.Fatalf("read retained thread columns: %v", err)
+	}
+	if err := writable.DB().QueryRowContext(ctx, `select raw_json from repositories where id = 1`).Scan(&repositoryRaw); err != nil {
+		t.Fatalf("read retained repository column: %v", err)
+	}
+	if body != "writable body" || threadRaw != `{"writable":true}` || repositoryRaw != `{"writable":true}` {
+		t.Fatalf("retained writable columns body=%q thread_raw=%q repository_raw=%q", body, threadRaw, repositoryRaw)
 	}
 }
 

--- a/internal/portable/export_test.go
+++ b/internal/portable/export_test.go
@@ -444,7 +444,7 @@ func TestExportRejectsForeignKeyViolationBeforeIndexRemoval(t *testing.T) {
 	assertNoExportTemps(t, dir)
 }
 
-func TestConfigureDisposableStoreUsesRollbackJournalAndReducedSync(t *testing.T) {
+func TestConfigureDisposableStoreDisablesJournalDurabilityAndSecureDelete(t *testing.T) {
 	ctx := context.Background()
 	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "staging.db"))
 	if err != nil {
@@ -455,15 +455,77 @@ func TestConfigureDisposableStoreUsesRollbackJournalAndReducedSync(t *testing.T)
 		t.Fatalf("configure disposable store: %v", err)
 	}
 	var journalMode string
-	var synchronous int
+	var synchronous, secureDelete, tempStore int
 	if err := st.DB().QueryRowContext(ctx, `pragma journal_mode`).Scan(&journalMode); err != nil {
 		t.Fatal(err)
 	}
 	if err := st.DB().QueryRowContext(ctx, `pragma synchronous`).Scan(&synchronous); err != nil {
 		t.Fatal(err)
 	}
-	if journalMode != "delete" || synchronous != 0 || st.DB().Stats().MaxOpenConnections != 1 {
-		t.Fatalf("disposable settings journal=%q synchronous=%d max_open=%d", journalMode, synchronous, st.DB().Stats().MaxOpenConnections)
+	if err := st.DB().QueryRowContext(ctx, `pragma secure_delete`).Scan(&secureDelete); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.DB().QueryRowContext(ctx, `pragma temp_store`).Scan(&tempStore); err != nil {
+		t.Fatal(err)
+	}
+	if journalMode != "off" || synchronous != 0 || secureDelete != 0 || tempStore != 2 || st.DB().Stats().MaxOpenConnections != 1 {
+		t.Fatalf("disposable settings journal=%q synchronous=%d secure_delete=%d temp_store=%d max_open=%d", journalMode, synchronous, secureDelete, tempStore, st.DB().Stats().MaxOpenConnections)
+	}
+}
+
+func TestFinalCompactArtifactExcludesDeletedPayloadSentinels(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	defer st.Close()
+	sentinels := []string{
+		"GITCRAWL_REMOVED_HISTORY_SENTINEL_" + strings.Repeat("h", 96),
+		"GITCRAWL_REMOVED_RAW_JSON_SENTINEL_" + strings.Repeat("r", 96),
+		"GITCRAWL_REMOVED_PR_PATCH_SENTINEL_" + strings.Repeat("p", 96),
+		"GITCRAWL_REMOVED_SYNC_FAILURE_SENTINEL_" + strings.Repeat("s", 96),
+	}
+	if _, err := st.DB().ExecContext(ctx, `update comment_revisions set body = ? where id = 1`, sentinels[0]); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `update threads set raw_json = ? where id = 1`, sentinels[1]); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `update pull_request_files set patch = ? where thread_id = 1`, sentinels[2]); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `
+		insert into sync_attempt_failures(
+			id, repo_id, thread_id, number, operation, error_class, error_message,
+			first_seen_at, last_seen_at
+		) values(1, 1, 1, 7, 'pull_request_details', 'test', ?,
+			'2026-08-09T00:00:00Z', '2026-08-09T00:00:00Z')
+	`, sentinels[3]); err != nil {
+		t.Fatal(err)
+	}
+	result, err := Export(ctx, testExportOptions(sourcePath, filepath.Join(dir, "artifact")))
+	if err != nil {
+		t.Fatalf("export sentinel fixture: %v", err)
+	}
+	artifactBytes := readFile(t, result.DatabasePath)
+	for _, sentinel := range sentinels {
+		if bytes.Contains(artifactBytes, []byte(sentinel)) {
+			t.Fatalf("final compact artifact retained deleted sentinel %q", sentinel)
+		}
+	}
+	db := openRawDB(t, result.DatabasePath)
+	defer db.Close()
+	var title, path, status string
+	var additions int
+	var patch sql.NullString
+	if err := db.QueryRow(`select title from threads where id = 1`).Scan(&title); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.QueryRow(`select path, status, additions, patch from pull_request_files where thread_id = 1`).Scan(&path, &status, &additions, &patch); err != nil {
+		t.Fatal(err)
+	}
+	if title != "portable export" || path != "internal/portable/export.go" || status != "modified" || additions != 10 || patch.Valid {
+		t.Fatalf("retained metadata title=%q file=%q/%q/%d patch=%#v", title, path, status, additions, patch)
 	}
 }
 

--- a/internal/portable/export_test.go
+++ b/internal/portable/export_test.go
@@ -153,6 +153,9 @@ func TestExportCurrentStateV1SnapshotsLiveWALWithoutMutatingSource(t *testing.T)
 		t.Fatalf("single-repository metadata manifest=%+v result=%+v", manifest.Repository, result.Repository)
 	}
 	assertManifestTableCounts(t, db, manifest.Tables)
+	if violations, err := testForeignKeyViolationCount(ctx, db); err != nil || violations != 0 {
+		t.Fatalf("independent final artifact FK violations=%d err=%v", violations, err)
+	}
 }
 
 func TestOnlineBackupSnapshotsLiveWALInChunksWithoutSourceMutation(t *testing.T) {
@@ -827,6 +830,19 @@ func openRawDB(t *testing.T, path string) *sql.DB {
 		t.Fatalf("open sqlite %s: %v", path, err)
 	}
 	return db
+}
+
+func testForeignKeyViolationCount(ctx context.Context, db *sql.DB) (int, error) {
+	rows, err := db.QueryContext(ctx, `pragma foreign_key_check`)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+	count := 0
+	for rows.Next() {
+		count++
+	}
+	return count, rows.Err()
 }
 
 func tableExists(t *testing.T, db *sql.DB, name string) bool {

--- a/internal/portable/export_test.go
+++ b/internal/portable/export_test.go
@@ -390,7 +390,7 @@ func TestExportByteBudgetExactAndOneByteOver(t *testing.T) {
 }
 
 func TestExportRejectsUnsafeInputsAndExistingOutput(t *testing.T) {
-	for _, name := range []string{"", ".", "..", "a/b.db", `a\b.db`, "bad\x00.db", "gitcrawl.db-wal", "gitcrawl.db-shm", "gitcrawl.db.manifest.json"} {
+	for _, name := range []string{"", ".", "..", "a/b.db", `a\b.db`, "bad\x00.db", "bad?.db", "gitcrawl.db-wal", "gitcrawl.db-shm", "gitcrawl.db.manifest.json"} {
 		if err := ValidateDatabaseName(name); err == nil {
 			t.Errorf("ValidateDatabaseName(%q) succeeded", name)
 		}

--- a/internal/portable/export_test.go
+++ b/internal/portable/export_test.go
@@ -143,6 +143,76 @@ func TestExportCurrentStateV1SnapshotsLiveWALWithoutMutatingSource(t *testing.T)
 	assertManifestTableCounts(t, db, manifest.Tables)
 }
 
+func TestOnlineBackupSnapshotsLiveWALInChunksWithoutSourceMutation(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	defer st.Close()
+	sourceBefore := readFile(t, sourcePath)
+	walBefore := readFile(t, sourcePath+"-wal")
+	targetPath := filepath.Join(dir, "snapshot.db")
+	steps := 0
+	if err := snapshotSQLiteWithOptions(ctx, sourcePath, targetPath, onlineBackupOptions{
+		PagesPerStep: 1,
+		AfterStep: func(remaining, pageCount int) {
+			steps++
+			if pageCount <= 0 || remaining < 0 {
+				t.Errorf("backup progress remaining=%d page_count=%d", remaining, pageCount)
+			}
+		},
+	}); err != nil {
+		t.Fatalf("online backup: %v", err)
+	}
+	if steps <= 1 {
+		t.Fatalf("online backup steps = %d, want multiple bounded chunks", steps)
+	}
+	db := openRawDB(t, targetPath)
+	defer db.Close()
+	if got := rowCount(t, db, "threads"); got != 1 {
+		t.Fatalf("snapshot threads = %d, want committed WAL row", got)
+	}
+	if !bytes.Equal(sourceBefore, readFile(t, sourcePath)) || !bytes.Equal(walBefore, readFile(t, sourcePath+"-wal")) {
+		t.Fatal("online backup changed source database or WAL bytes")
+	}
+}
+
+func TestOnlineBackupCancellationRemovesPartialTarget(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, context.Background(), sourcePath)
+	defer st.Close()
+	sourceBefore := readFile(t, sourcePath)
+	walBefore := readFile(t, sourcePath+"-wal")
+	ctx, cancel := context.WithCancel(context.Background())
+	targetPath := filepath.Join(dir, "partial.db")
+	sawPartial := false
+	err := snapshotSQLiteWithOptions(ctx, sourcePath, targetPath, onlineBackupOptions{
+		PagesPerStep: 1,
+		AfterStep: func(remaining, pageCount int) {
+			if remaining > 0 {
+				_, statErr := os.Stat(targetPath)
+				sawPartial = statErr == nil
+				cancel()
+			}
+		},
+	})
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled online backup error = %v", err)
+	}
+	if !sawPartial {
+		t.Fatal("online backup cancellation did not occur after a partial target was created")
+	}
+	for _, path := range []string{targetPath, targetPath + "-wal", targetPath + "-shm"} {
+		if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("partial backup artifact remains at %s: %v", path, err)
+		}
+	}
+	if !bytes.Equal(sourceBefore, readFile(t, sourcePath)) || !bytes.Equal(walBefore, readFile(t, sourcePath+"-wal")) {
+		t.Fatal("canceled online backup changed source database or WAL bytes")
+	}
+}
+
 func TestExportScopedRepositoryKeepsOnlyRequestedDependentData(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
@@ -394,6 +464,80 @@ func TestConfigureDisposableStoreUsesRollbackJournalAndReducedSync(t *testing.T)
 	}
 	if journalMode != "delete" || synchronous != 0 || st.DB().Stats().MaxOpenConnections != 1 {
 		t.Fatalf("disposable settings journal=%q synchronous=%d max_open=%d", journalMode, synchronous, st.DB().Stats().MaxOpenConnections)
+	}
+}
+
+func TestCompactGenerationReplacesUncompactWorkingDatabase(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	workingPath := filepath.Join(dir, "working.db")
+	st, err := store.Open(ctx, workingPath)
+	if err != nil {
+		t.Fatalf("open working store: %v", err)
+	}
+	if err := configureDisposableStore(ctx, st.DB()); err != nil {
+		t.Fatalf("configure working store: %v", err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `create table compact_payload(value blob); insert into compact_payload values(zeroblob(2097152)); delete from compact_payload`); err != nil {
+		t.Fatalf("seed free space: %v", err)
+	}
+	workingInfo, err := os.Stat(workingPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compactPath, err := createCompactDatabase(ctx, st.DB(), workingPath)
+	if err != nil {
+		t.Fatalf("create compact generation: %v", err)
+	}
+	compactInfo, err := os.Stat(compactPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if compactInfo.Size() >= workingInfo.Size() {
+		t.Fatalf("compact bytes = %d, uncompact bytes = %d", compactInfo.Size(), workingInfo.Size())
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close working store: %v", err)
+	}
+	if err := replaceWithCompactDatabase(ctx, workingPath, compactPath); err != nil {
+		t.Fatalf("replace with compact generation: %v", err)
+	}
+	if _, err := os.Stat(compactPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("compact temp still exists: %v", err)
+	}
+	db := openRawDB(t, workingPath)
+	defer db.Close()
+	if check, err := checkPragma(ctx, db, "quick_check"); err != nil || check != "ok" {
+		t.Fatalf("promoted compact quick_check=%q err=%v", check, err)
+	}
+}
+
+func TestCompactGenerationCancellationCleansPartialFile(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	workingPath := filepath.Join(dir, "working.db")
+	st, err := store.Open(ctx, workingPath)
+	if err != nil {
+		t.Fatalf("open working store: %v", err)
+	}
+	defer st.Close()
+	if err := configureDisposableStore(ctx, st.DB()); err != nil {
+		t.Fatalf("configure working store: %v", err)
+	}
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+	if _, err := createCompactDatabase(canceled, st.DB(), workingPath); err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled compact generation error = %v", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, ".working.db.compact-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("partial compact files remain: %v", matches)
+	}
+	if _, err := os.Stat(workingPath); err != nil {
+		t.Fatalf("working database removed on compact cancellation: %v", err)
 	}
 }
 

--- a/internal/portable/export_test.go
+++ b/internal/portable/export_test.go
@@ -114,6 +114,14 @@ func TestExportCurrentStateV1SnapshotsLiveWALWithoutMutatingSource(t *testing.T)
 	if !slices.Contains(result.DroppedIndexes, "custom_comments_author") || slices.Contains(result.DroppedIndexes, "unique_comments_github") {
 		t.Fatalf("dropped indexes = %v", result.DroppedIndexes)
 	}
+	for _, index := range []string{"custom_threads_title", "idx_threads_repo_number", "idx_threads_repo_state_closed", "idx_threads_repo_updated"} {
+		if !slices.Contains(result.DroppedIndexes, index) {
+			t.Fatalf("dropped indexes = %v, missing rebuilt threads index %s", result.DroppedIndexes, index)
+		}
+	}
+	if slices.Contains(result.DroppedIndexes, "unique_threads_github_id") || !indexExists(t, db, "unique_threads_github_id") {
+		t.Fatalf("explicit unique threads index was not preserved: dropped=%v exists=%v", result.DroppedIndexes, indexExists(t, db, "unique_threads_github_id"))
+	}
 	if slices.Contains(result.DroppedIndexes, "idx_comment_revisions_comment") || slices.Contains(result.DroppedIndexes, "custom_comment_revisions_body") {
 		t.Fatalf("implicitly removed indexes were reported as explicitly dropped: %v", result.DroppedIndexes)
 	}
@@ -308,6 +316,35 @@ func TestExportUnscopedMultiRepositoryOmitsSingularMetadata(t *testing.T) {
 	assertManifestTableCounts(t, db, manifest.Tables)
 }
 
+func TestExportMigratesPhysicallyPrunedSourceBeforeSanitizedRebuild(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "physically-pruned.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	if _, err := st.PrunePortablePayloads(ctx, store.PortablePruneOptions{BodyChars: 16}); err != nil {
+		t.Fatalf("physically prune source: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close physically pruned source: %v", err)
+	}
+	result, err := Export(ctx, testExportOptions(sourcePath, filepath.Join(dir, "artifact")))
+	if err != nil {
+		t.Fatalf("export physically pruned source: %v", err)
+	}
+	db := openRawDB(t, result.DatabasePath)
+	defer db.Close()
+	var body, excerpt, rawJSON, columnProfile string
+	if err := db.QueryRow(`select body, body_excerpt, raw_json from threads where id = 1`).Scan(&body, &excerpt, &rawJSON); err != nil {
+		t.Fatalf("read migrated compatibility columns: %v", err)
+	}
+	if err := db.QueryRow(`select value from portable_metadata where key = 'column_profile'`).Scan(&columnProfile); err != nil {
+		t.Fatal(err)
+	}
+	if body != "abcdefghijklmnop" || excerpt != body || rawJSON != "" || columnProfile != store.PortableColumnProfileSanitizedCompatibility {
+		t.Fatalf("migrated physical source body=%q excerpt=%q raw=%q profile=%q", body, excerpt, rawJSON, columnProfile)
+	}
+}
+
 func TestExportByteBudgetExactAndOneByteOver(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
@@ -439,7 +476,7 @@ func TestExportRejectsForeignKeyViolationBeforeIndexRemoval(t *testing.T) {
 		t.Fatal(err)
 	}
 	outputDir := filepath.Join(dir, "invalid-fk")
-	if _, err := Export(ctx, testExportOptions(sourcePath, outputDir)); err == nil || !strings.Contains(err.Error(), "foreign_key_check failed") {
+	if _, err := Export(ctx, testExportOptions(sourcePath, outputDir)); err == nil || !strings.Contains(err.Error(), "foreign-key violations") {
 		t.Fatalf("foreign key export error = %v", err)
 	}
 	if _, err := os.Stat(outputDir); !errors.Is(err, os.ErrNotExist) {
@@ -485,10 +522,10 @@ func TestFinalCompactArtifactExcludesDeletedPayloadSentinels(t *testing.T) {
 	defer st.Close()
 	sentinels := []string{
 		"GITCRAWL_REMOVED_HISTORY_SENTINEL_" + strings.Repeat("h", 96),
-		"GITCRAWL_REMOVED_RAW_JSON_SENTINEL_" + strings.Repeat("r", 96),
+		"GITCRAWL_REMOVED_RAW_JSON_SENTINEL_" + strings.Repeat("r", 2<<20),
 		"GITCRAWL_REMOVED_PR_PATCH_SENTINEL_" + strings.Repeat("p", 96),
 		"GITCRAWL_REMOVED_SYNC_FAILURE_SENTINEL_" + strings.Repeat("s", 96),
-		"GITCRAWL_REMOVED_FULL_THREAD_BODY_SENTINEL_" + strings.Repeat("b", 160),
+		"GITCRAWL_REMOVED_FULL_THREAD_BODY_SENTINEL_" + strings.Repeat("b", 2<<20),
 	}
 	if _, err := st.DB().ExecContext(ctx, `update comment_revisions set body = ? where id = 1`, sentinels[0]); err != nil {
 		t.Fatal(err)
@@ -516,9 +553,9 @@ func TestFinalCompactArtifactExcludesDeletedPayloadSentinels(t *testing.T) {
 		t.Fatalf("export sentinel fixture: %v", err)
 	}
 	artifactBytes := readFile(t, result.DatabasePath)
-	for _, sentinel := range sentinels {
+	for index, sentinel := range sentinels {
 		if bytes.Contains(artifactBytes, []byte(sentinel)) {
-			t.Fatalf("final compact artifact retained deleted sentinel %q", sentinel)
+			t.Fatalf("final compact artifact retained deleted sentinel %d", index)
 		}
 	}
 	db := openRawDB(t, result.DatabasePath)
@@ -715,6 +752,8 @@ func seedExportSource(t *testing.T, ctx context.Context, dbPath string) *store.S
 		`create index custom_comments_author on comments(author_login)`,
 		`create index custom_comment_revisions_body on comment_revisions(body)`,
 		`create unique index unique_comments_github on comments(github_id)`,
+		`create index custom_threads_title on threads(title)`,
+		`create unique index unique_threads_github_id on threads(github_id)`,
 	}
 	tx, err := st.DB().BeginTx(ctx, nil)
 	if err != nil {

--- a/internal/portable/export_test.go
+++ b/internal/portable/export_test.go
@@ -55,6 +55,14 @@ func TestExportCurrentStateV1SnapshotsLiveWALWithoutMutatingSource(t *testing.T)
 
 	db := openRawDB(t, result.DatabasePath)
 	defer db.Close()
+	for _, column := range []struct{ table, name string }{
+		{table: "comments", name: "raw_json_blob_id"},
+		{table: "thread_revisions", name: "raw_json_blob_id"},
+	} {
+		if columnExists(t, db, column.table, column.name) {
+			t.Fatalf("derived artifact retained dangling column %s.%s", column.table, column.name)
+		}
+	}
 	var journalMode string
 	if err := db.QueryRow(`pragma journal_mode`).Scan(&journalMode); err != nil {
 		t.Fatalf("read artifact journal mode: %v", err)
@@ -488,6 +496,42 @@ func TestExportRejectsForeignKeyViolationBeforeIndexRemoval(t *testing.T) {
 	assertNoExportTemps(t, dir)
 }
 
+func TestExportRejectsRetainedForeignKeyToDisposableTable(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	defer st.Close()
+	if _, err := st.DB().ExecContext(ctx, `
+		insert into documents(id, thread_id, title, body, raw_text, dedupe_text, updated_at)
+		values(1, 1, 'derived', 'body', 'raw', 'dedupe', '2026-08-09T00:00:00Z');
+		create table retained_document_links(
+			id integer primary key,
+			document_id integer not null references documents(id)
+		);
+	`); err != nil {
+		t.Fatalf("seed retained FK to disposable table: %v", err)
+	}
+	outputDir := filepath.Join(dir, "invalid-retained-fk")
+	options := testExportOptions(sourcePath, outputDir)
+	var stages []Stage
+	options.Progress = func(stage Stage) { stages = append(stages, stage) }
+	_, err := Export(ctx, options)
+	if err == nil || !strings.Contains(err.Error(), "foreign") {
+		t.Fatalf("retained FK export error = %v", err)
+	}
+	if slices.Contains(stages, Stage("canonical shaping: threads rebuild: preflight")) {
+		t.Fatalf("retained FK reached threads rebuild preflight: %v", stages)
+	}
+	if slices.Contains(stages, Stage("canonical shaping: threads rebuild: compact copy")) {
+		t.Fatalf("retained FK reached threads copy: %v", stages)
+	}
+	if _, err := os.Stat(outputDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("retained FK failure left target: %v", err)
+	}
+	assertNoExportTemps(t, dir)
+}
+
 func TestConfigureDisposableStoreDisablesJournalDurabilityAndSecureDelete(t *testing.T) {
 	ctx := context.Background()
 	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "staging.db"))
@@ -685,6 +729,14 @@ func TestExportedDatabaseReopensWritableAndRecreatesOmittedSchema(t *testing.T) 
 		t.Fatalf("writable reopen/migrate: %v", err)
 	}
 	defer writable.Close()
+	for _, column := range []struct{ table, name string }{
+		{table: "comments", name: "raw_json_blob_id"},
+		{table: "thread_revisions", name: "raw_json_blob_id"},
+	} {
+		if !columnExists(t, writable.DB(), column.table, column.name) {
+			t.Fatalf("writable reopen did not restore %s.%s", column.table, column.name)
+		}
+	}
 	for _, table := range currentStateProfile.DroppedTables {
 		if !tableExists(t, writable.DB(), table) {
 			t.Fatalf("migration did not recreate %s", table)
@@ -861,6 +913,30 @@ func indexExists(t *testing.T, db *sql.DB, name string) bool {
 		t.Fatalf("inspect index %s: %v", name, err)
 	}
 	return exists == 1
+}
+
+func columnExists(t *testing.T, db *sql.DB, table, column string) bool {
+	t.Helper()
+	rows, err := db.Query(`pragma table_info(` + quoteIdentifier(table) + `)`)
+	if err != nil {
+		t.Fatalf("inspect columns for %s: %v", table, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid, notNull, primaryKey int
+		var name, columnType string
+		var defaultValue any
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			t.Fatalf("scan columns for %s: %v", table, err)
+		}
+		if name == column {
+			return true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read columns for %s: %v", table, err)
+	}
+	return false
 }
 
 func rowCount(t *testing.T, db *sql.DB, table string) int {

--- a/internal/store/portable.go
+++ b/internal/store/portable.go
@@ -3,13 +3,16 @@ package store
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -35,9 +38,22 @@ const (
 	PortablePruneStageFingerprintsSummaries       PortablePruneStage = "fingerprints and summaries"
 	PortablePruneStageDiscardedData               PortablePruneStage = "discarded tables and failure ledger"
 	PortablePruneStageCanonicalSchemaFinalization PortablePruneStage = "canonical schema finalization"
+	PortablePruneStageThreadsRebuildPreflight     PortablePruneStage = "threads rebuild: preflight"
+	PortablePruneStageThreadsRebuildForeignKeys   PortablePruneStage = "threads rebuild: foreign key proof"
+	PortablePruneStageThreadsRebuildCompactCopy   PortablePruneStage = "threads rebuild: compact copy"
+	PortablePruneStageThreadsRebuildSchemaSwap    PortablePruneStage = "threads rebuild: schema swap"
+	PortablePruneStageThreadsRebuildSchemaRestore PortablePruneStage = "threads rebuild: schema restore"
 )
 
 type PortablePruneProgressFunc func(PortablePruneStage)
+
+type portableForeignKeyCheckFunc func(context.Context, dbQueries) (int, error)
+
+type portableThreadsRebuildHookStage string
+
+const portableThreadsRebuildHookAfterCopy portableThreadsRebuildHookStage = "after-copy"
+
+type portableThreadsRebuildHookFunc func(portableThreadsRebuildHookStage, *sql.Tx, string) error
 
 type PortablePruneOptions struct {
 	BodyChars           int
@@ -50,6 +66,8 @@ type PortablePruneOptions struct {
 	DeferSecureRewrite            bool
 	RetainSanitizedPayloadColumns bool
 	Progress                      PortablePruneProgressFunc `json:"-"`
+	foreignKeyCheck               portableForeignKeyCheckFunc
+	threadsRebuildHook            portableThreadsRebuildHookFunc
 }
 
 type PortablePruneStats struct {
@@ -76,6 +94,8 @@ type PortablePruneStats struct {
 	DroppedTables             []string `json:"dropped_tables,omitempty"`
 	DroppedColumns            []string `json:"dropped_columns,omitempty"`
 	DroppedIndexes            []string `json:"dropped_indexes,omitempty"`
+	ForeignKeyValidated       bool     `json:"foreign_key_validated,omitempty"`
+	ForeignKeyViolations      int      `json:"foreign_key_violations,omitempty"`
 	Vacuumed                  bool     `json:"vacuumed"`
 }
 
@@ -85,10 +105,20 @@ type PortableRepositoryScope struct {
 	RepositoriesRemoved int64      `json:"repositories_removed"`
 }
 
+type PortableRepositoryScopeOptions struct {
+	// DeferForeignKeyValidation is reserved for disposable pipelines that run
+	// one equivalent proof after all remaining semantic mutations.
+	DeferForeignKeyValidation bool
+}
+
 // RestrictPortableRepository reduces a disposable portable snapshot to one
 // repository. It combines current foreign-key cascades with column-aware
 // deletion so repository-owned rows remain covered as the schema evolves.
 func (s *Store) RestrictPortableRepository(ctx context.Context, fullName string) (PortableRepositoryScope, error) {
+	return s.RestrictPortableRepositoryWithOptions(ctx, fullName, PortableRepositoryScopeOptions{})
+}
+
+func (s *Store) RestrictPortableRepositoryWithOptions(ctx context.Context, fullName string, options PortableRepositoryScopeOptions) (PortableRepositoryScope, error) {
 	var result PortableRepositoryScope
 	conn, err := s.db.Conn(ctx)
 	if err != nil {
@@ -204,12 +234,14 @@ func (s *Store) RestrictPortableRepository(ctx context.Context, fullName string)
 	if err := tx.Commit(); err != nil {
 		return result, fmt.Errorf("commit portable repository scope: %w", err)
 	}
-	violations, err := portableForeignKeyViolationCount(ctx, conn)
-	if err != nil {
-		return result, err
-	}
-	if violations != 0 {
-		return result, fmt.Errorf("portable repository restriction left %d foreign-key violations", violations)
+	if !options.DeferForeignKeyValidation {
+		violations, err := portableForeignKeyViolationCount(ctx, conn)
+		if err != nil {
+			return result, err
+		}
+		if violations != 0 {
+			return result, fmt.Errorf("portable repository restriction left %d foreign-key violations", violations)
+		}
 	}
 	result.RepositoriesRemoved = result.RepositoriesBefore - 1
 	return result, nil
@@ -388,7 +420,7 @@ func (s *Store) PrunePortablePayloads(ctx context.Context, options PortablePrune
 		}
 	}
 	reportPortablePruneProgress(options.Progress, PortablePruneStageCanonicalSchemaFinalization)
-	if err := s.canonicalizePortableSchema(ctx, options.BodyChars, options.IncludeSyncFailures, options.RetainSanitizedPayloadColumns, &stats); err != nil {
+	if err := s.canonicalizePortableSchema(ctx, options, &stats); err != nil {
 		return stats, err
 	}
 	if options.Vacuum {
@@ -581,7 +613,10 @@ func (s *Store) pruneEquivalentLegacyKeySummaries(ctx context.Context) (int64, e
 	return rowsAffected(result), nil
 }
 
-func (s *Store) canonicalizePortableSchema(ctx context.Context, bodyChars int, includeSyncFailures, retainSanitizedPayloadColumns bool, stats *PortablePruneStats) error {
+func (s *Store) canonicalizePortableSchema(ctx context.Context, options PortablePruneOptions, stats *PortablePruneStats) error {
+	bodyChars := options.BodyChars
+	includeSyncFailures := options.IncludeSyncFailures
+	retainSanitizedPayloadColumns := options.RetainSanitizedPayloadColumns
 	if s.hasColumn(ctx, "threads", "body") && !s.hasColumn(ctx, "threads", "body_excerpt") {
 		if _, err := s.db.ExecContext(ctx, `alter table threads add column body_excerpt text`); err != nil {
 			return fmt.Errorf("add portable threads.body_excerpt: %w", err)
@@ -600,7 +635,12 @@ func (s *Store) canonicalizePortableSchema(ctx context.Context, bodyChars int, i
 		}
 	}
 	if retainSanitizedPayloadColumns {
-		droppedIndexes, err := s.rebuildPortableCompatibilityThreads(ctx)
+		// Derived exports drop discarded relationship-bearing tables before the
+		// single indexed FK proof performed by the threads rebuild.
+		if err := s.dropCanonicalPortableTables(ctx, includeSyncFailures, stats); err != nil {
+			return err
+		}
+		droppedIndexes, err := s.rebuildPortableCompatibilityThreadsWithOptions(ctx, options, stats)
 		if err != nil {
 			return err
 		}
@@ -628,17 +668,10 @@ func (s *Store) canonicalizePortableSchema(ctx context.Context, bodyChars int, i
 		}
 		stats.DroppedColumns = append(stats.DroppedColumns, column.table+"."+column.name)
 	}
-	for _, table := range canonicalPortableDroppedTables() {
-		if table == "sync_attempt_failures" && includeSyncFailures {
-			continue
+	if !retainSanitizedPayloadColumns {
+		if err := s.dropCanonicalPortableTables(ctx, includeSyncFailures, stats); err != nil {
+			return err
 		}
-		if !s.tableExists(ctx, table) {
-			continue
-		}
-		if _, err := s.db.ExecContext(ctx, `drop table if exists `+sqliteIdentifier(table)); err != nil {
-			return fmt.Errorf("drop portable table %s: %w", table, err)
-		}
-		stats.DroppedTables = append(stats.DroppedTables, table)
 	}
 	if err := s.ensurePortableMetadata(ctx); err != nil {
 		return err
@@ -681,6 +714,22 @@ func (s *Store) canonicalizePortableSchema(ctx context.Context, bodyChars int, i
 	return nil
 }
 
+func (s *Store) dropCanonicalPortableTables(ctx context.Context, includeSyncFailures bool, stats *PortablePruneStats) error {
+	for _, table := range canonicalPortableDroppedTables() {
+		if table == "sync_attempt_failures" && includeSyncFailures {
+			continue
+		}
+		if !s.tableExists(ctx, table) {
+			continue
+		}
+		if _, err := s.db.ExecContext(ctx, `drop table if exists `+sqliteIdentifier(table)); err != nil {
+			return fmt.Errorf("drop portable table %s: %w", table, err)
+		}
+		stats.DroppedTables = append(stats.DroppedTables, table)
+	}
+	return nil
+}
+
 func (s *Store) sanitizePortableRepositoryCompatibilityColumn(ctx context.Context) error {
 	if s.hasColumn(ctx, "repositories", "raw_json") {
 		if _, err := s.db.ExecContext(ctx, `update repositories set raw_json = '' where raw_json != ''`); err != nil {
@@ -697,12 +746,21 @@ type portableSchemaObject struct {
 	sql  string
 }
 
-func (s *Store) rebuildPortableCompatibilityThreads(ctx context.Context) (_ []string, retErr error) {
+func (s *Store) rebuildPortableCompatibilityThreads(ctx context.Context) ([]string, error) {
+	stats := &PortablePruneStats{}
+	return s.rebuildPortableCompatibilityThreadsWithOptions(ctx, PortablePruneOptions{}, stats)
+}
+
+func (s *Store) rebuildPortableCompatibilityThreadsWithOptions(ctx context.Context, options PortablePruneOptions, stats *PortablePruneStats) (_ []string, retErr error) {
+	if stats == nil {
+		stats = &PortablePruneStats{}
+	}
 	conn, err := s.db.Conn(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("open portable threads rebuild connection: %w", err)
 	}
 	defer conn.Close()
+	reportPortablePruneProgress(options.Progress, PortablePruneStageThreadsRebuildPreflight)
 	var createSQL string
 	if err := conn.QueryRowContext(ctx, `select sql from sqlite_schema where type = 'table' and name = 'threads'`).Scan(&createSQL); err != nil {
 		return nil, fmt.Errorf("read portable threads schema: %w", err)
@@ -715,7 +773,7 @@ func (s *Store) rebuildPortableCompatibilityThreads(ctx context.Context) (_ []st
 	if err != nil {
 		return nil, err
 	}
-	columns, selectExpressions, err := portableThreadsRebuildColumns(ctx, conn)
+	columns, selectExpressions, verbatimColumns, err := portableThreadsRebuildColumns(ctx, conn)
 	if err != nil {
 		return nil, err
 	}
@@ -754,6 +812,38 @@ func (s *Store) rebuildPortableCompatibilityThreads(ctx context.Context) (_ []st
 	}
 	if originalSequence.Valid && !strings.Contains(strings.ToUpper(createSQL), "AUTOINCREMENT") {
 		return nil, fmt.Errorf("portable threads sqlite_sequence exists without AUTOINCREMENT schema")
+	}
+	originalIdentity, err := portableThreadsIdentityForTable(ctx, conn, "threads")
+	if err != nil {
+		return nil, err
+	}
+	originalThreadForeignKeys, err := portableForeignKeysForTable(ctx, conn, "threads")
+	if err != nil {
+		return nil, err
+	}
+	if err := validatePortableThreadsForeignKeyTransformSafety(originalThreadForeignKeys, verbatimColumns); err != nil {
+		return nil, err
+	}
+	originalChildForeignKeys, err := portableChildForeignKeysReferencingThreads(ctx, conn)
+	if err != nil {
+		return nil, err
+	}
+	if err := validatePortableChildForeignKeyIdentityTargets(originalChildForeignKeys); err != nil {
+		return nil, err
+	}
+	reportPortablePruneProgress(options.Progress, PortablePruneStageThreadsRebuildForeignKeys)
+	checker := options.foreignKeyCheck
+	if checker == nil {
+		checker = portableForeignKeyViolationCount
+	}
+	violations, err := checker(ctx, conn)
+	if err != nil {
+		return nil, err
+	}
+	stats.ForeignKeyValidated = true
+	stats.ForeignKeyViolations = violations
+	if violations != 0 {
+		return nil, fmt.Errorf("portable threads rebuild found %d foreign-key violations before rebuild", violations)
 	}
 	foreignKeysOff := false
 	legacyAlterChanged := false
@@ -802,6 +892,7 @@ func (s *Store) rebuildPortableCompatibilityThreads(ctx context.Context) (_ []st
 		return nil, fmt.Errorf("begin portable threads rebuild: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
+	reportPortablePruneProgress(options.Progress, PortablePruneStageThreadsRebuildCompactCopy)
 	if _, err := tx.ExecContext(ctx, siblingCreateSQL); err != nil {
 		return nil, fmt.Errorf("create portable threads sibling: %w", err)
 	}
@@ -809,12 +900,26 @@ func (s *Store) rebuildPortableCompatibilityThreads(ctx context.Context) (_ []st
 	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {
 		return nil, fmt.Errorf("copy compact portable threads: %w", err)
 	}
+	if options.threadsRebuildHook != nil {
+		if err := options.threadsRebuildHook(portableThreadsRebuildHookAfterCopy, tx, sibling); err != nil {
+			return nil, fmt.Errorf("portable threads rebuild test hook: %w", err)
+		}
+	}
+	rebuiltIdentity, err := portableThreadsIdentityForTable(ctx, tx, sibling)
+	if err != nil {
+		return nil, err
+	}
+	if rebuiltIdentity != originalIdentity {
+		return nil, fmt.Errorf("portable threads rebuild identity mismatch: copied %d of %d rows", rebuiltIdentity.count, originalIdentity.count)
+	}
+	reportPortablePruneProgress(options.Progress, PortablePruneStageThreadsRebuildSchemaSwap)
 	if _, err := tx.ExecContext(ctx, `drop table "threads"`); err != nil {
 		return nil, fmt.Errorf("drop uncompact portable threads: %w", err)
 	}
 	if _, err := tx.ExecContext(ctx, `alter table `+sqliteIdentifier(sibling)+` rename to "threads"`); err != nil {
 		return nil, fmt.Errorf("rename compact portable threads: %w", err)
 	}
+	reportPortablePruneProgress(options.Progress, PortablePruneStageThreadsRebuildSchemaRestore)
 	if originalSequence.Valid {
 		var rebuiltSequence sql.NullInt64
 		if err := tx.QueryRowContext(ctx, `select max(seq) from sqlite_sequence where name in ('threads', ?)`, sibling).Scan(&rebuiltSequence); err != nil {
@@ -853,12 +958,19 @@ func (s *Store) rebuildPortableCompatibilityThreads(ctx context.Context) (_ []st
 			return nil, fmt.Errorf("invalidate portable observation convergence after threads rebuild: %w", err)
 		}
 	}
-	violations, err := portableForeignKeyViolationCount(ctx, tx)
+	rebuiltThreadForeignKeys, err := portableForeignKeysForTable(ctx, tx, "threads")
 	if err != nil {
 		return nil, err
 	}
-	if violations != 0 {
-		return nil, fmt.Errorf("portable threads rebuild left %d foreign-key violations before commit", violations)
+	if !slices.Equal(originalThreadForeignKeys, rebuiltThreadForeignKeys) {
+		return nil, fmt.Errorf("portable threads rebuild changed threads foreign-key schema")
+	}
+	rebuiltChildForeignKeys, err := portableChildForeignKeysReferencingThreads(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	if !slices.Equal(originalChildForeignKeys, rebuiltChildForeignKeys) {
+		return nil, fmt.Errorf("portable threads rebuild changed child foreign-key schema")
 	}
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("commit portable threads rebuild: %w", err)
@@ -879,13 +991,9 @@ func (s *Store) rebuildPortableCompatibilityThreads(ctx context.Context) (_ []st
 	if foreignKeys != 1 {
 		return nil, fmt.Errorf("restore portable threads foreign keys: pragma remained %d", foreignKeys)
 	}
-	violations, err = portableForeignKeyViolationCount(ctx, conn)
-	if err != nil {
-		return nil, err
-	}
-	if violations != 0 {
-		return nil, fmt.Errorf("portable threads rebuild left %d foreign-key violations", violations)
-	}
+	// One indexed full FK proof ran before the rebuild. Child rows and outgoing
+	// FK source values are untouched, parent (id, repo_id) identity is exact,
+	// and both parent/child FK definitions are equivalent, so zero is preserved.
 	return ordinaryIndexes, nil
 }
 
@@ -1016,6 +1124,146 @@ func portableThreadsSequence(ctx context.Context, q dbQueries) (sql.NullInt64, e
 	return sequence, nil
 }
 
+type portableThreadsIdentity struct {
+	count  int64
+	digest [sha256.Size]byte
+}
+
+func portableThreadsIdentityForTable(ctx context.Context, q dbQueries, table string) (portableThreadsIdentity, error) {
+	rows, err := q.QueryContext(ctx, `select id, repo_id from `+sqliteIdentifier(table)+` order by id`)
+	if err != nil {
+		return portableThreadsIdentity{}, fmt.Errorf("read portable threads identity from %s: %w", table, err)
+	}
+	defer rows.Close()
+	hash := sha256.New()
+	var identity portableThreadsIdentity
+	var encoded [16]byte
+	for rows.Next() {
+		var id, repoID int64
+		if err := rows.Scan(&id, &repoID); err != nil {
+			return portableThreadsIdentity{}, fmt.Errorf("scan portable threads identity from %s: %w", table, err)
+		}
+		binary.BigEndian.PutUint64(encoded[:8], uint64(id))
+		binary.BigEndian.PutUint64(encoded[8:], uint64(repoID))
+		_, _ = hash.Write(encoded[:])
+		identity.count++
+	}
+	if err := rows.Err(); err != nil {
+		return portableThreadsIdentity{}, fmt.Errorf("read portable threads identity rows from %s: %w", table, err)
+	}
+	copy(identity.digest[:], hash.Sum(nil))
+	return identity, nil
+}
+
+type portableForeignKeyDefinition struct {
+	ownerTable      string
+	id              int
+	sequence        int
+	referencedTable string
+	fromColumn      string
+	toColumn        string
+	onUpdate        string
+	onDelete        string
+	match           string
+}
+
+func portableForeignKeysForTable(ctx context.Context, q dbQueries, table string) ([]portableForeignKeyDefinition, error) {
+	rows, err := q.QueryContext(ctx, `pragma foreign_key_list(`+sqliteIdentifier(table)+`)`)
+	if err != nil {
+		return nil, fmt.Errorf("inspect portable foreign keys for %s: %w", table, err)
+	}
+	defer rows.Close()
+	var definitions []portableForeignKeyDefinition
+	for rows.Next() {
+		var definition portableForeignKeyDefinition
+		var toColumn sql.NullString
+		definition.ownerTable = table
+		if err := rows.Scan(
+			&definition.id,
+			&definition.sequence,
+			&definition.referencedTable,
+			&definition.fromColumn,
+			&toColumn,
+			&definition.onUpdate,
+			&definition.onDelete,
+			&definition.match,
+		); err != nil {
+			return nil, fmt.Errorf("scan portable foreign keys for %s: %w", table, err)
+		}
+		definition.toColumn = toColumn.String
+		definitions = append(definitions, definition)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read portable foreign keys for %s: %w", table, err)
+	}
+	sortPortableForeignKeys(definitions)
+	return definitions, nil
+}
+
+func portableChildForeignKeysReferencingThreads(ctx context.Context, q dbQueries) ([]portableForeignKeyDefinition, error) {
+	tables, err := portableTableNames(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	var definitions []portableForeignKeyDefinition
+	for _, table := range tables {
+		if table == "threads" {
+			continue
+		}
+		tableDefinitions, err := portableForeignKeysForTable(ctx, q, table)
+		if err != nil {
+			return nil, err
+		}
+		for _, definition := range tableDefinitions {
+			if strings.EqualFold(definition.referencedTable, "threads") {
+				definitions = append(definitions, definition)
+			}
+		}
+	}
+	sortPortableForeignKeys(definitions)
+	return definitions, nil
+}
+
+func sortPortableForeignKeys(definitions []portableForeignKeyDefinition) {
+	sort.Slice(definitions, func(left, right int) bool {
+		leftKey := fmt.Sprintf("%s\x00%08d\x00%08d\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s", definitions[left].ownerTable, definitions[left].id, definitions[left].sequence, definitions[left].referencedTable, definitions[left].fromColumn, definitions[left].toColumn, definitions[left].onUpdate, definitions[left].onDelete, definitions[left].match)
+		rightKey := fmt.Sprintf("%s\x00%08d\x00%08d\x00%s\x00%s\x00%s\x00%s\x00%s\x00%s", definitions[right].ownerTable, definitions[right].id, definitions[right].sequence, definitions[right].referencedTable, definitions[right].fromColumn, definitions[right].toColumn, definitions[right].onUpdate, definitions[right].onDelete, definitions[right].match)
+		return leftKey < rightKey
+	})
+}
+
+func validatePortableChildForeignKeyIdentityTargets(definitions []portableForeignKeyDefinition) error {
+	for _, definition := range definitions {
+		toColumn := definition.toColumn
+		if toColumn == "" {
+			toColumn = "id"
+		}
+		if !strings.EqualFold(toColumn, "id") && !strings.EqualFold(toColumn, "repo_id") {
+			return fmt.Errorf("portable threads rebuild cannot preserve child foreign key %s.%s referencing mutable threads column %s", definition.ownerTable, definition.fromColumn, toColumn)
+		}
+	}
+	return nil
+}
+
+func validatePortableThreadsForeignKeyTransformSafety(definitions []portableForeignKeyDefinition, verbatimColumns map[string]bool) error {
+	for _, definition := range definitions {
+		if !verbatimColumns[strings.ToLower(definition.fromColumn)] {
+			return fmt.Errorf("portable threads rebuild cannot preserve foreign key from transformed threads column %s", definition.fromColumn)
+		}
+		if !strings.EqualFold(definition.referencedTable, "threads") {
+			continue
+		}
+		toColumn := definition.toColumn
+		if toColumn == "" {
+			toColumn = "id"
+		}
+		if !strings.EqualFold(toColumn, "id") && !strings.EqualFold(toColumn, "repo_id") {
+			return fmt.Errorf("portable threads rebuild cannot preserve self-referencing foreign key targeting transformed threads column %s", toColumn)
+		}
+	}
+	return nil
+}
+
 func portableThreadsSiblingName() (string, error) {
 	var value [8]byte
 	if _, err := rand.Read(value[:]); err != nil {
@@ -1032,20 +1280,21 @@ func rewritePortableThreadsCreateSQL(createSQL, sibling string) (string, error) 
 	return createSQL[:match[3]] + sqliteIdentifier(sibling) + createSQL[match[4]:], nil
 }
 
-func portableThreadsRebuildColumns(ctx context.Context, q dbQueries) ([]string, []string, error) {
+func portableThreadsRebuildColumns(ctx context.Context, q dbQueries) ([]string, []string, map[string]bool, error) {
 	rows, err := q.QueryContext(ctx, `pragma table_xinfo("threads")`)
 	if err != nil {
-		return nil, nil, fmt.Errorf("inspect portable threads columns: %w", err)
+		return nil, nil, nil, fmt.Errorf("inspect portable threads columns: %w", err)
 	}
 	defer rows.Close()
 	var columns, expressions []string
 	seen := make(map[string]bool)
+	verbatimColumns := make(map[string]bool)
 	for rows.Next() {
 		var cid, notNull, primaryKey, hidden int
 		var name, columnType string
 		var defaultValue any
 		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey, &hidden); err != nil {
-			return nil, nil, fmt.Errorf("scan portable threads columns: %w", err)
+			return nil, nil, nil, fmt.Errorf("scan portable threads columns: %w", err)
 		}
 		seen[name] = true
 		if hidden != 0 {
@@ -1059,17 +1308,18 @@ func portableThreadsRebuildColumns(ctx context.Context, q dbQueries) ([]string, 
 			expressions = append(expressions, `''`)
 		default:
 			expressions = append(expressions, sqliteIdentifier(name))
+			verbatimColumns[strings.ToLower(name)] = true
 		}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, nil, fmt.Errorf("read portable threads columns: %w", err)
+		return nil, nil, nil, fmt.Errorf("read portable threads columns: %w", err)
 	}
 	for _, required := range []string{"body", "body_excerpt", "raw_json"} {
 		if !seen[required] {
-			return nil, nil, fmt.Errorf("portable threads rebuild requires column %s", required)
+			return nil, nil, nil, fmt.Errorf("portable threads rebuild requires column %s", required)
 		}
 	}
-	return columns, expressions, nil
+	return columns, expressions, verbatimColumns, nil
 }
 
 func portableThreadsRebuildIndexes(ctx context.Context, q dbQueries) ([]string, []portableSchemaObject, error) {

--- a/internal/store/portable.go
+++ b/internal/store/portable.go
@@ -38,6 +38,7 @@ const (
 	PortablePruneStageFingerprintsSummaries       PortablePruneStage = "fingerprints and summaries"
 	PortablePruneStageDiscardedData               PortablePruneStage = "discarded tables and failure ledger"
 	PortablePruneStageCanonicalSchemaFinalization PortablePruneStage = "canonical schema finalization"
+	PortablePruneStageDisposableTableDrop         PortablePruneStage = "canonical schema finalization: disposable table drop"
 	PortablePruneStageThreadsRebuildPreflight     PortablePruneStage = "threads rebuild: preflight"
 	PortablePruneStageThreadsRebuildForeignKeys   PortablePruneStage = "threads rebuild: foreign key proof"
 	PortablePruneStageThreadsRebuildCompactCopy   PortablePruneStage = "threads rebuild: compact copy"
@@ -55,6 +56,8 @@ const portableThreadsRebuildHookAfterCopy portableThreadsRebuildHookStage = "aft
 
 type portableThreadsRebuildHookFunc func(portableThreadsRebuildHookStage, *sql.Tx, string) error
 
+type portableTableDropHookFunc func(context.Context, *sql.Tx, string) error
+
 type PortablePruneOptions struct {
 	BodyChars           int
 	Vacuum              bool
@@ -68,6 +71,7 @@ type PortablePruneOptions struct {
 	Progress                      PortablePruneProgressFunc `json:"-"`
 	foreignKeyCheck               portableForeignKeyCheckFunc
 	threadsRebuildHook            portableThreadsRebuildHookFunc
+	tableDropHook                 portableTableDropHookFunc
 }
 
 type PortablePruneStats struct {
@@ -637,7 +641,11 @@ func (s *Store) canonicalizePortableSchema(ctx context.Context, options Portable
 	if retainSanitizedPayloadColumns {
 		// Derived exports drop discarded relationship-bearing tables before the
 		// single indexed FK proof performed by the threads rebuild.
-		if err := s.dropCanonicalPortableTables(ctx, includeSyncFailures, stats); err != nil {
+		reportPortablePruneProgress(options.Progress, PortablePruneStageDisposableTableDrop)
+		if err := s.dropPortableDerivedBlobPointerColumns(ctx, stats); err != nil {
+			return err
+		}
+		if err := s.dropCanonicalPortableTablesBulk(ctx, includeSyncFailures, stats, options.tableDropHook); err != nil {
 			return err
 		}
 		droppedIndexes, err := s.rebuildPortableCompatibilityThreadsWithOptions(ctx, options, stats)
@@ -714,6 +722,28 @@ func (s *Store) canonicalizePortableSchema(ctx context.Context, options Portable
 	return nil
 }
 
+func (s *Store) dropPortableDerivedBlobPointerColumns(ctx context.Context, stats *PortablePruneStats) error {
+	for _, column := range []struct {
+		table string
+		name  string
+	}{
+		{table: "comments", name: "raw_json_blob_id"},
+		{table: "thread_revisions", name: "raw_json_blob_id"},
+	} {
+		if !s.hasColumn(ctx, column.table, column.name) {
+			continue
+		}
+		if _, err := s.db.ExecContext(ctx, `alter table `+sqliteIdentifier(column.table)+` drop column `+sqliteIdentifier(column.name)); err != nil {
+			return fmt.Errorf("drop derived portable column %s.%s: %w", column.table, column.name, err)
+		}
+		name := column.table + "." + column.name
+		if !slices.Contains(stats.DroppedColumns, name) {
+			stats.DroppedColumns = append(stats.DroppedColumns, name)
+		}
+	}
+	return nil
+}
+
 func (s *Store) dropCanonicalPortableTables(ctx context.Context, includeSyncFailures bool, stats *PortablePruneStats) error {
 	for _, table := range canonicalPortableDroppedTables() {
 		if table == "sync_attempt_failures" && includeSyncFailures {
@@ -728,6 +758,431 @@ func (s *Store) dropCanonicalPortableTables(ctx context.Context, includeSyncFail
 		stats.DroppedTables = append(stats.DroppedTables, table)
 	}
 	return nil
+}
+
+func (s *Store) dropCanonicalPortableTablesBulk(ctx context.Context, includeSyncFailures bool, stats *PortablePruneStats, hook portableTableDropHookFunc) (retErr error) {
+	if stats == nil {
+		stats = &PortablePruneStats{}
+	}
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("open portable disposable table drop connection: %w", err)
+	}
+	defer conn.Close()
+	var originalForeignKeys int
+	if err := conn.QueryRowContext(ctx, `pragma foreign_keys`).Scan(&originalForeignKeys); err != nil {
+		return fmt.Errorf("read portable disposable table foreign keys: %w", err)
+	}
+	var originalJournalMode string
+	if err := conn.QueryRowContext(ctx, `pragma journal_mode`).Scan(&originalJournalMode); err != nil {
+		return fmt.Errorf("read portable disposable table journal mode: %w", err)
+	}
+	restoreForeignKeys := false
+	restoreJournalMode := false
+	defer func() {
+		if restoreJournalMode {
+			if err := setPortableJournalMode(context.Background(), conn, originalJournalMode); err != nil {
+				retErr = errors.Join(retErr, err)
+			}
+		}
+		if restoreForeignKeys {
+			if err := setPortableForeignKeys(context.Background(), conn, originalForeignKeys); err != nil {
+				retErr = errors.Join(retErr, err)
+			}
+		}
+	}()
+	// The staging database normally uses journal_mode=OFF. MEMORY provides real
+	// rollback semantics for this one private DDL transaction without adding a
+	// durable journal that survives process failure.
+	restoreJournalMode = true
+	if err := setPortableJournalMode(ctx, conn, "memory"); err != nil {
+		return err
+	}
+	restoreForeignKeys = true
+	if err := setPortableForeignKeys(ctx, conn, 0); err != nil {
+		return err
+	}
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin portable disposable table drop: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	presentBefore := make(map[string]string)
+	for _, table := range canonicalPortableBulkDropOrder() {
+		if table == "sync_attempt_failures" && includeSyncFailures {
+			continue
+		}
+		actual, present, err := portableSchemaTableName(ctx, tx, table)
+		if err != nil {
+			return err
+		}
+		if present {
+			presentBefore[table] = actual
+		}
+	}
+	for _, table := range canonicalPortableBulkDropOrder() {
+		if presentBefore[table] == "" {
+			continue
+		}
+		actual, present, err := portableSchemaTableName(ctx, tx, table)
+		if err != nil {
+			return err
+		}
+		if !present {
+			continue
+		}
+		if hook != nil {
+			if err := hook(ctx, tx, actual); err != nil {
+				return fmt.Errorf("portable disposable table drop hook for %s: %w", actual, err)
+			}
+		}
+		if _, err := tx.ExecContext(ctx, `drop table `+sqliteIdentifier(actual)); err != nil {
+			return fmt.Errorf("drop portable disposable table %s: %w", actual, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit portable disposable table drop: %w", err)
+	}
+	if err := setPortableJournalMode(context.Background(), conn, originalJournalMode); err != nil {
+		return err
+	}
+	restoreJournalMode = false
+	if err := setPortableForeignKeys(context.Background(), conn, originalForeignKeys); err != nil {
+		return err
+	}
+	restoreForeignKeys = false
+	var removed []string
+	for _, table := range canonicalPortableBulkDropOrder() {
+		if table == "sync_attempt_failures" && includeSyncFailures {
+			continue
+		}
+		_, present, err := portableSchemaTableName(ctx, conn, table)
+		if err != nil {
+			return err
+		}
+		if present {
+			return fmt.Errorf("portable disposable table %s remains after bulk drop", table)
+		}
+		removed = append(removed, table)
+		actual := presentBefore[table]
+		if actual == "" {
+			continue
+		}
+		if !slices.Contains(stats.DroppedTables, actual) {
+			stats.DroppedTables = append(stats.DroppedTables, actual)
+		}
+	}
+	if err := validatePortableRetainedSchemaDependencies(ctx, conn, removed); err != nil {
+		return err
+	}
+	return nil
+}
+
+func setPortableForeignKeys(ctx context.Context, conn *sql.Conn, enabled int) error {
+	if enabled != 0 && enabled != 1 {
+		return fmt.Errorf("invalid portable foreign_keys setting %d", enabled)
+	}
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf(`pragma foreign_keys = %d`, enabled)); err != nil {
+		return fmt.Errorf("set portable disposable table foreign keys to %d: %w", enabled, err)
+	}
+	var actual int
+	if err := conn.QueryRowContext(ctx, `pragma foreign_keys`).Scan(&actual); err != nil {
+		return fmt.Errorf("verify portable disposable table foreign keys: %w", err)
+	}
+	if actual != enabled {
+		return fmt.Errorf("set portable disposable table foreign keys to %d: pragma remained %d", enabled, actual)
+	}
+	return nil
+}
+
+func setPortableJournalMode(ctx context.Context, conn *sql.Conn, mode string) error {
+	want := strings.ToLower(strings.TrimSpace(mode))
+	switch want {
+	case "delete", "truncate", "persist", "memory", "wal", "off":
+	default:
+		return fmt.Errorf("invalid portable journal_mode %q", mode)
+	}
+	var actual string
+	if err := conn.QueryRowContext(ctx, `pragma journal_mode = `+want).Scan(&actual); err != nil {
+		return fmt.Errorf("set portable disposable table journal mode to %s: %w", want, err)
+	}
+	if !strings.EqualFold(actual, want) {
+		return fmt.Errorf("set portable disposable table journal mode to %s: pragma remained %s", want, actual)
+	}
+	return nil
+}
+
+func portableSchemaTableName(ctx context.Context, q dbQueries, table string) (string, bool, error) {
+	var actual string
+	err := q.QueryRowContext(ctx, `
+		select name
+		from sqlite_schema
+		where type = 'table' and name collate nocase = ?
+	`, table).Scan(&actual)
+	if err == sql.ErrNoRows {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("inspect portable disposable table %s: %w", table, err)
+	}
+	return actual, true, nil
+}
+
+type portableRetainedSchemaObject struct {
+	kind string
+	name string
+	sql  string
+}
+
+func validatePortableRetainedSchemaDependencies(ctx context.Context, q dbQueries, dropped []string) error {
+	if len(dropped) == 0 {
+		return nil
+	}
+	droppedSet := make(map[string]bool, len(dropped))
+	for _, table := range dropped {
+		droppedSet[strings.ToLower(table)] = true
+	}
+	tables, err := portableTableNames(ctx, q)
+	if err != nil {
+		return err
+	}
+	for _, table := range tables {
+		definitions, err := portableForeignKeysForTable(ctx, q, table)
+		if err != nil {
+			return err
+		}
+		for _, definition := range definitions {
+			if droppedSet[strings.ToLower(definition.referencedTable)] {
+				return fmt.Errorf("retained portable table %s foreign key references dropped table %s", table, definition.referencedTable)
+			}
+		}
+	}
+	rows, err := q.QueryContext(ctx, `
+		select type, name, sql
+		from sqlite_schema
+		where type in ('view', 'trigger') and sql is not null
+		order by type, name
+	`)
+	if err != nil {
+		return fmt.Errorf("inspect retained portable schema dependencies: %w", err)
+	}
+	var objects []portableRetainedSchemaObject
+	for rows.Next() {
+		var object portableRetainedSchemaObject
+		if err := rows.Scan(&object.kind, &object.name, &object.sql); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan retained portable schema dependency: %w", err)
+		}
+		objects = append(objects, object)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("read retained portable schema dependencies: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close retained portable schema dependencies: %w", err)
+	}
+	for _, object := range objects {
+		switch object.kind {
+		case "view":
+			viewIdentifier, err := portableRuntimeIdentifier(object.name)
+			if err != nil {
+				return fmt.Errorf("quote retained portable view %s: %w", object.name, err)
+			}
+			viewRows, err := q.QueryContext(ctx, `select * from `+viewIdentifier+` limit 0`)
+			if err != nil {
+				return fmt.Errorf("retained portable view %s is invalid after disposable table drop: %w", object.name, err)
+			}
+			if _, err := viewRows.Columns(); err != nil {
+				_ = viewRows.Close()
+				return fmt.Errorf("retained portable view %s is invalid after disposable table drop: %w", object.name, err)
+			}
+			for viewRows.Next() {
+			}
+			if err := viewRows.Err(); err != nil {
+				_ = viewRows.Close()
+				return fmt.Errorf("retained portable view %s is invalid after disposable table drop: %w", object.name, err)
+			}
+			if err := viewRows.Close(); err != nil {
+				return fmt.Errorf("close retained portable view %s validation: %w", object.name, err)
+			}
+		case "trigger":
+			dependency, err := portableTriggerDroppedDependency(object.sql, droppedSet)
+			if err != nil {
+				return fmt.Errorf("inspect retained portable trigger %s: %w", object.name, err)
+			}
+			if dependency != "" {
+				return fmt.Errorf("retained portable trigger %s references dropped table %s", object.name, dependency)
+			}
+		}
+	}
+	return nil
+}
+
+func portableTriggerDroppedDependency(triggerSQL string, dropped map[string]bool) (string, error) {
+	tokens, err := tokenizePortableSQL(triggerSQL)
+	if err != nil {
+		return "", err
+	}
+	begin := -1
+	start := -1
+	for index, token := range tokens {
+		if !token.quoted && strings.EqualFold(token.value, "BEGIN") {
+			begin = index + 1
+			break
+		}
+		if !token.quoted && strings.EqualFold(token.value, "WHEN") {
+			start = index + 1
+		}
+	}
+	if begin < 0 {
+		return "", fmt.Errorf("unrecognized trigger body")
+	}
+	if start >= 0 {
+		if dependency := portableDroppedTableDependency(tokens[start:begin-1], dropped); dependency != "" {
+			return dependency, nil
+		}
+	}
+	for _, statement := range portableSQLStatements(tokens[begin:]) {
+		if dependency := portableDroppedTableDependency(statement, dropped); dependency != "" {
+			return dependency, nil
+		}
+	}
+	return "", nil
+}
+
+func portableDroppedTableDependency(tokens []portableSQLToken, dropped map[string]bool) string {
+	// CTE resolution is deliberately conservative: a removed-table name in a
+	// real table position is rejected even when a CTE might shadow it.
+	return portableDroppedTableDependencyInList(tokens, dropped, false)
+}
+
+func portableDroppedTableDependencyInList(tokens []portableSQLToken, dropped map[string]bool, initialFromList bool) string {
+	wantTable := initialFromList
+	fromList := initialFromList
+	deleteTarget := false
+	for index := 0; index < len(tokens); index++ {
+		token := tokens[index]
+		if wantTable {
+			if portableSQLKeyword(token, "OR") && index+1 < len(tokens) {
+				index++
+				continue
+			}
+			if token.value == "(" {
+				end := portableSQLMatchingParenthesis(tokens, index)
+				if dependency := portableDroppedTableDependencyInList(tokens[index+1:end], dropped, true); dependency != "" {
+					return dependency
+				}
+				wantTable = false
+				index = end
+				continue
+			}
+			name, consumed := portableSQLTableIdentifier(tokens[index:])
+			wantTable = false
+			if consumed > 0 {
+				index += consumed - 1
+			}
+			if dropped[strings.ToLower(name)] {
+				return name
+			}
+			continue
+		}
+		if token.value == "(" {
+			end := portableSQLMatchingParenthesis(tokens, index)
+			if dependency := portableDroppedTableDependencyInList(tokens[index+1:end], dropped, false); dependency != "" {
+				return dependency
+			}
+			index = end
+			continue
+		}
+		switch {
+		case portableSQLKeyword(token, "DELETE"):
+			deleteTarget = true
+			fromList = false
+		case portableSQLKeyword(token, "FROM"):
+			wantTable = true
+			fromList = !deleteTarget
+			deleteTarget = false
+		case portableSQLKeyword(token, "JOIN"):
+			wantTable = true
+		case portableSQLKeyword(token, "UPDATE"),
+			portableSQLKeyword(token, "INTO"),
+			portableSQLKeyword(token, "REFERENCES"):
+			wantTable = true
+		case fromList && token.value == ",":
+			wantTable = true
+		case portableSQLKeyword(token, "WHERE"),
+			portableSQLKeyword(token, "GROUP"),
+			portableSQLKeyword(token, "HAVING"),
+			portableSQLKeyword(token, "ORDER"),
+			portableSQLKeyword(token, "LIMIT"),
+			portableSQLKeyword(token, "RETURNING"),
+			portableSQLKeyword(token, "SET"),
+			portableSQLKeyword(token, "VALUES"),
+			portableSQLKeyword(token, "UNION"),
+			portableSQLKeyword(token, "EXCEPT"),
+			portableSQLKeyword(token, "INTERSECT"):
+			fromList = false
+		}
+	}
+	return ""
+}
+
+func portableSQLMatchingParenthesis(tokens []portableSQLToken, start int) int {
+	depth := 0
+	for index := start; index < len(tokens); index++ {
+		switch tokens[index].value {
+		case "(":
+			depth++
+		case ")":
+			depth--
+			if depth == 0 {
+				return index
+			}
+		}
+	}
+	return len(tokens) - 1
+}
+
+func portableSQLStatements(tokens []portableSQLToken) [][]portableSQLToken {
+	var statements [][]portableSQLToken
+	start := 0
+	depth := 0
+	for index, token := range tokens {
+		switch token.value {
+		case "(":
+			depth++
+		case ")":
+			if depth > 0 {
+				depth--
+			}
+		case ";":
+			if depth == 0 {
+				if index > start {
+					statements = append(statements, tokens[start:index])
+				}
+				start = index + 1
+			}
+		}
+	}
+	if start < len(tokens) {
+		statements = append(statements, tokens[start:])
+	}
+	return statements
+}
+
+func portableSQLTableIdentifier(tokens []portableSQLToken) (string, int) {
+	if len(tokens) == 0 || tokens[0].value == "(" {
+		return "", 0
+	}
+	if len(tokens) >= 3 && tokens[1].value == "." {
+		return tokens[2].value, 3
+	}
+	return tokens[0].value, 1
+}
+
+func portableSQLKeyword(token portableSQLToken, keyword string) bool {
+	return !token.quoted && strings.EqualFold(token.value, keyword)
 }
 
 func (s *Store) sanitizePortableRepositoryCompatibilityColumn(ctx context.Context) error {
@@ -998,8 +1453,9 @@ func (s *Store) rebuildPortableCompatibilityThreadsWithOptions(ctx context.Conte
 }
 
 type portableSQLToken struct {
-	value  string
-	quoted bool
+	value   string
+	quoted  bool
+	literal bool
 }
 
 func portableTriggerUpdatesThreads(triggerSQL string) (bool, error) {
@@ -1076,7 +1532,7 @@ func tokenizePortableSQL(value string) ([]portableSQLToken, error) {
 				}
 				index++
 			}
-			tokens = append(tokens, portableSQLToken{value: text.String(), quoted: true})
+			tokens = append(tokens, portableSQLToken{value: text.String(), quoted: true, literal: quote == '\''})
 		case value[index] == '[':
 			end := strings.IndexByte(value[index+1:], ']')
 			if end < 0 {
@@ -1692,11 +2148,52 @@ func canonicalPortableDroppedTables() []string {
 	}
 }
 
+func canonicalPortableBulkDropOrder() []string {
+	return []string{
+		"code_documents_fts",
+		"code_documents_fts_config",
+		"code_documents_fts_data",
+		"code_documents_fts_docsize",
+		"code_documents_fts_idx",
+		"code_documents",
+		"code_snapshots",
+		"documents_fts",
+		"documents_fts_config",
+		"documents_fts_data",
+		"documents_fts_docsize",
+		"documents_fts_idx",
+		"documents",
+		"document_embeddings",
+		"document_summaries",
+		"thread_vectors",
+		"thread_changed_files",
+		"thread_hunk_signatures",
+		"thread_code_snapshots",
+		"cluster_events",
+		"cluster_members",
+		"clusters",
+		"similarity_edges",
+		"sync_attempt_failures",
+		"sync_runs",
+		"summary_runs",
+		"embedding_runs",
+		"cluster_runs",
+		"blobs",
+	}
+}
+
 func sqliteIdentifier(value string) string {
 	if value == "" || strings.ContainsAny(value, "\"\x00") {
 		panic(fmt.Sprintf("unsafe SQLite identifier: %q", value))
 	}
 	return `"` + value + `"`
+}
+
+func portableRuntimeIdentifier(value string) (string, error) {
+	if value == "" || strings.ContainsRune(value, '\x00') {
+		return "", fmt.Errorf("unsafe SQLite identifier %q", value)
+	}
+	return `"` + strings.ReplaceAll(value, `"`, `""`) + `"`, nil
 }
 
 func (s *Store) tableExists(ctx context.Context, table string) bool {

--- a/internal/store/portable.go
+++ b/internal/store/portable.go
@@ -2,10 +2,15 @@ package store
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"regexp"
+	"sort"
 	"strings"
 	"time"
 )
@@ -70,6 +75,7 @@ type PortablePruneStats struct {
 	SyncFailureVacuumForced   bool     `json:"sync_failure_vacuum_forced"`
 	DroppedTables             []string `json:"dropped_tables,omitempty"`
 	DroppedColumns            []string `json:"dropped_columns,omitempty"`
+	DroppedIndexes            []string `json:"dropped_indexes,omitempty"`
 	Vacuumed                  bool     `json:"vacuumed"`
 }
 
@@ -594,7 +600,12 @@ func (s *Store) canonicalizePortableSchema(ctx context.Context, bodyChars int, i
 		}
 	}
 	if retainSanitizedPayloadColumns {
-		if err := s.sanitizePortableCompatibilityColumns(ctx); err != nil {
+		droppedIndexes, err := s.rebuildPortableCompatibilityThreads(ctx)
+		if err != nil {
+			return err
+		}
+		stats.DroppedIndexes = append(stats.DroppedIndexes, droppedIndexes...)
+		if err := s.sanitizePortableRepositoryCompatibilityColumn(ctx); err != nil {
 			return err
 		}
 	}
@@ -670,31 +681,465 @@ func (s *Store) canonicalizePortableSchema(ctx context.Context, bodyChars int, i
 	return nil
 }
 
-func (s *Store) sanitizePortableCompatibilityColumns(ctx context.Context) error {
-	var assignments, conditions []string
-	if s.hasColumns(ctx, "threads", "body", "body_excerpt") {
-		assignments = append(assignments, `body = body_excerpt`)
-		conditions = append(conditions, `body is not body_excerpt`)
-	}
-	if s.hasColumn(ctx, "threads", "raw_json") {
-		assignments = append(assignments, `raw_json = ''`)
-		conditions = append(conditions, `raw_json != ''`)
-	}
-	if len(assignments) > 0 {
-		query := `update threads set ` + strings.Join(assignments, ", ")
-		if len(conditions) > 0 {
-			query += ` where ` + strings.Join(conditions, " or ")
-		}
-		if _, err := s.db.ExecContext(ctx, query); err != nil {
-			return fmt.Errorf("sanitize portable thread compatibility columns: %w", err)
-		}
-	}
+func (s *Store) sanitizePortableRepositoryCompatibilityColumn(ctx context.Context) error {
 	if s.hasColumn(ctx, "repositories", "raw_json") {
 		if _, err := s.db.ExecContext(ctx, `update repositories set raw_json = '' where raw_json != ''`); err != nil {
 			return fmt.Errorf("sanitize portable repository compatibility column: %w", err)
 		}
 	}
 	return nil
+}
+
+var portableThreadsCreateTablePattern = regexp.MustCompile("(?i)^(\\s*CREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?)(?:\"threads\"|`threads`|\\[threads\\]|threads)(\\s*\\()")
+
+type portableSchemaObject struct {
+	name string
+	sql  string
+}
+
+func (s *Store) rebuildPortableCompatibilityThreads(ctx context.Context) (_ []string, retErr error) {
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("open portable threads rebuild connection: %w", err)
+	}
+	defer conn.Close()
+	var createSQL string
+	if err := conn.QueryRowContext(ctx, `select sql from sqlite_schema where type = 'table' and name = 'threads'`).Scan(&createSQL); err != nil {
+		return nil, fmt.Errorf("read portable threads schema: %w", err)
+	}
+	sibling, err := portableThreadsSiblingName()
+	if err != nil {
+		return nil, err
+	}
+	siblingCreateSQL, err := rewritePortableThreadsCreateSQL(createSQL, sibling)
+	if err != nil {
+		return nil, err
+	}
+	columns, selectExpressions, err := portableThreadsRebuildColumns(ctx, conn)
+	if err != nil {
+		return nil, err
+	}
+	ordinaryIndexes, uniqueIndexes, err := portableThreadsRebuildIndexes(ctx, conn)
+	if err != nil {
+		return nil, err
+	}
+	triggers, err := portableThreadsRebuildTriggers(ctx, conn)
+	if err != nil {
+		return nil, err
+	}
+	hasConvergenceTrigger := false
+	for _, trigger := range triggers {
+		canonicalConvergence := false
+		for _, definition := range observationConvergenceTriggers {
+			if definition.table == "threads" && definition.name == trigger.name && trigger.sql == sqliteStoredSQL(observationConvergenceTriggerSQL(definition)) {
+				canonicalConvergence = true
+				hasConvergenceTrigger = true
+				break
+			}
+		}
+		if canonicalConvergence {
+			continue
+		}
+		updatesThreads, err := portableTriggerUpdatesThreads(trigger.sql)
+		if err != nil {
+			return nil, fmt.Errorf("inspect portable threads trigger %s: %w", trigger.name, err)
+		}
+		if updatesThreads {
+			return nil, fmt.Errorf("portable threads rebuild cannot preserve update-trigger semantics for %s", trigger.name)
+		}
+	}
+	originalSequence, err := portableThreadsSequence(ctx, conn)
+	if err != nil {
+		return nil, err
+	}
+	if originalSequence.Valid && !strings.Contains(strings.ToUpper(createSQL), "AUTOINCREMENT") {
+		return nil, fmt.Errorf("portable threads sqlite_sequence exists without AUTOINCREMENT schema")
+	}
+	foreignKeysOff := false
+	legacyAlterChanged := false
+	var originalLegacyAlter int
+	defer func() {
+		if foreignKeysOff {
+			if _, err := conn.ExecContext(context.Background(), `pragma foreign_keys = on`); err != nil {
+				retErr = errors.Join(retErr, fmt.Errorf("restore portable threads foreign keys: %w", err))
+			}
+		}
+		if legacyAlterChanged {
+			if _, err := conn.ExecContext(context.Background(), fmt.Sprintf(`pragma legacy_alter_table = %d`, originalLegacyAlter)); err != nil {
+				retErr = errors.Join(retErr, fmt.Errorf("restore portable threads legacy alter mode: %w", err))
+			}
+		}
+	}()
+	if err := conn.QueryRowContext(ctx, `pragma legacy_alter_table`).Scan(&originalLegacyAlter); err != nil {
+		return nil, fmt.Errorf("read portable threads legacy alter mode: %w", err)
+	}
+	if originalLegacyAlter != 1 {
+		if _, err := conn.ExecContext(ctx, `pragma legacy_alter_table = on`); err != nil {
+			return nil, fmt.Errorf("enable portable threads legacy alter mode: %w", err)
+		}
+		legacyAlterChanged = true
+	}
+	var legacyAlter int
+	if err := conn.QueryRowContext(ctx, `pragma legacy_alter_table`).Scan(&legacyAlter); err != nil {
+		return nil, fmt.Errorf("verify portable threads legacy alter mode: %w", err)
+	}
+	if legacyAlter != 1 {
+		return nil, fmt.Errorf("enable portable threads legacy alter mode: pragma remained %d", legacyAlter)
+	}
+	if _, err := conn.ExecContext(ctx, `pragma foreign_keys = off`); err != nil {
+		return nil, fmt.Errorf("disable portable threads foreign keys: %w", err)
+	}
+	foreignKeysOff = true
+	var foreignKeys int
+	if err := conn.QueryRowContext(ctx, `pragma foreign_keys`).Scan(&foreignKeys); err != nil {
+		return nil, fmt.Errorf("verify disabled portable threads foreign keys: %w", err)
+	}
+	if foreignKeys != 0 {
+		return nil, fmt.Errorf("disable portable threads foreign keys: pragma remained %d", foreignKeys)
+	}
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin portable threads rebuild: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, siblingCreateSQL); err != nil {
+		return nil, fmt.Errorf("create portable threads sibling: %w", err)
+	}
+	insertSQL := `insert or abort into ` + sqliteIdentifier(sibling) + ` (` + strings.Join(columns, ", ") + `) select ` + strings.Join(selectExpressions, ", ") + ` from "threads"`
+	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {
+		return nil, fmt.Errorf("copy compact portable threads: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `drop table "threads"`); err != nil {
+		return nil, fmt.Errorf("drop uncompact portable threads: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `alter table `+sqliteIdentifier(sibling)+` rename to "threads"`); err != nil {
+		return nil, fmt.Errorf("rename compact portable threads: %w", err)
+	}
+	if originalSequence.Valid {
+		var rebuiltSequence sql.NullInt64
+		if err := tx.QueryRowContext(ctx, `select max(seq) from sqlite_sequence where name in ('threads', ?)`, sibling).Scan(&rebuiltSequence); err != nil {
+			return nil, fmt.Errorf("read rebuilt portable threads sequence: %w", err)
+		}
+		highWater := originalSequence.Int64
+		if rebuiltSequence.Valid && rebuiltSequence.Int64 > highWater {
+			highWater = rebuiltSequence.Int64
+		}
+		if _, err := tx.ExecContext(ctx, `delete from sqlite_sequence where name in ('threads', ?)`, sibling); err != nil {
+			return nil, fmt.Errorf("clear rebuilt portable threads sequence: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `insert into sqlite_sequence(name, seq) values('threads', ?)`, highWater); err != nil {
+			return nil, fmt.Errorf("restore portable threads sequence: %w", err)
+		}
+	}
+	for _, index := range uniqueIndexes {
+		if _, err := tx.ExecContext(ctx, index.sql); err != nil {
+			return nil, fmt.Errorf("recreate portable unique index %s: %w", index.name, err)
+		}
+	}
+	for _, trigger := range triggers {
+		if _, err := tx.ExecContext(ctx, trigger.sql); err != nil {
+			return nil, fmt.Errorf("recreate portable threads trigger %s: %w", trigger.name, err)
+		}
+	}
+	// Bulk-copy rows intentionally do not fire table triggers. Definitions are
+	// restored for future writes; the known convergence triggers' net effect is
+	// applied once below instead of once per copied row.
+	var convergenceTable int
+	if err := tx.QueryRowContext(ctx, `select exists(select 1 from sqlite_schema where type = 'table' and name = 'observation_schema_convergence')`).Scan(&convergenceTable); err != nil {
+		return nil, fmt.Errorf("inspect portable observation convergence table: %w", err)
+	}
+	if convergenceTable == 1 && hasConvergenceTrigger {
+		if _, err := tx.ExecContext(ctx, `update observation_schema_convergence set checked_observation_sequence = -1 where id = 1`); err != nil {
+			return nil, fmt.Errorf("invalidate portable observation convergence after threads rebuild: %w", err)
+		}
+	}
+	violations, err := portableForeignKeyViolationCount(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	if violations != 0 {
+		return nil, fmt.Errorf("portable threads rebuild left %d foreign-key violations before commit", violations)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit portable threads rebuild: %w", err)
+	}
+	if _, err := conn.ExecContext(context.Background(), `pragma foreign_keys = on`); err != nil {
+		return nil, fmt.Errorf("restore portable threads foreign keys: %w", err)
+	}
+	foreignKeysOff = false
+	if legacyAlterChanged {
+		if _, err := conn.ExecContext(context.Background(), fmt.Sprintf(`pragma legacy_alter_table = %d`, originalLegacyAlter)); err != nil {
+			return nil, fmt.Errorf("restore portable threads legacy alter mode: %w", err)
+		}
+		legacyAlterChanged = false
+	}
+	if err := conn.QueryRowContext(ctx, `pragma foreign_keys`).Scan(&foreignKeys); err != nil {
+		return nil, fmt.Errorf("verify restored portable threads foreign keys: %w", err)
+	}
+	if foreignKeys != 1 {
+		return nil, fmt.Errorf("restore portable threads foreign keys: pragma remained %d", foreignKeys)
+	}
+	violations, err = portableForeignKeyViolationCount(ctx, conn)
+	if err != nil {
+		return nil, err
+	}
+	if violations != 0 {
+		return nil, fmt.Errorf("portable threads rebuild left %d foreign-key violations", violations)
+	}
+	return ordinaryIndexes, nil
+}
+
+type portableSQLToken struct {
+	value  string
+	quoted bool
+}
+
+func portableTriggerUpdatesThreads(triggerSQL string) (bool, error) {
+	tokens, err := tokenizePortableSQL(triggerSQL)
+	if err != nil {
+		return false, err
+	}
+	headerEnd := len(tokens)
+	for index, token := range tokens {
+		if !token.quoted && strings.EqualFold(token.value, "BEGIN") {
+			headerEnd = index
+			break
+		}
+	}
+	header := tokens[:headerEnd]
+	for index, token := range header {
+		if token.quoted || !strings.EqualFold(token.value, "ON") {
+			continue
+		}
+		targetIndex := index + 1
+		if targetIndex+2 < len(header) && header[targetIndex+1].value == "." {
+			targetIndex += 2
+		}
+		if targetIndex >= len(header) || !strings.EqualFold(header[targetIndex].value, "threads") {
+			continue
+		}
+		for _, prior := range header[:index] {
+			if !prior.quoted && strings.EqualFold(prior.value, "UPDATE") {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+	return false, fmt.Errorf("unrecognized trigger target")
+}
+
+func tokenizePortableSQL(value string) ([]portableSQLToken, error) {
+	var tokens []portableSQLToken
+	for index := 0; index < len(value); {
+		switch {
+		case isPortableSQLSpace(value[index]):
+			index++
+		case index+1 < len(value) && value[index:index+2] == "--":
+			index += 2
+			for index < len(value) && value[index] != '\n' {
+				index++
+			}
+		case index+1 < len(value) && value[index:index+2] == "/*":
+			end := strings.Index(value[index+2:], "*/")
+			if end < 0 {
+				return nil, fmt.Errorf("unterminated SQL comment")
+			}
+			index += end + 4
+		case value[index] == '\'' || value[index] == '"' || value[index] == '`':
+			quote := value[index]
+			start := index + 1
+			index++
+			var text strings.Builder
+			for {
+				if index >= len(value) {
+					return nil, fmt.Errorf("unterminated SQL quote")
+				}
+				if value[index] == quote {
+					if index+1 < len(value) && value[index+1] == quote {
+						text.WriteString(value[start:index])
+						text.WriteByte(quote)
+						index += 2
+						start = index
+						continue
+					}
+					text.WriteString(value[start:index])
+					index++
+					break
+				}
+				index++
+			}
+			tokens = append(tokens, portableSQLToken{value: text.String(), quoted: true})
+		case value[index] == '[':
+			end := strings.IndexByte(value[index+1:], ']')
+			if end < 0 {
+				return nil, fmt.Errorf("unterminated SQL bracket identifier")
+			}
+			tokens = append(tokens, portableSQLToken{value: value[index+1 : index+1+end], quoted: true})
+			index += end + 2
+		case isPortableSQLWord(value[index]):
+			start := index
+			for index < len(value) && isPortableSQLWord(value[index]) {
+				index++
+			}
+			tokens = append(tokens, portableSQLToken{value: value[start:index]})
+		default:
+			tokens = append(tokens, portableSQLToken{value: value[index : index+1]})
+			index++
+		}
+	}
+	return tokens, nil
+}
+
+func isPortableSQLSpace(value byte) bool {
+	return value == ' ' || value == '\t' || value == '\r' || value == '\n' || value == '\f'
+}
+
+func isPortableSQLWord(value byte) bool {
+	return value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z' || value >= '0' && value <= '9' || value == '_' || value == '$'
+}
+
+func portableThreadsSequence(ctx context.Context, q dbQueries) (sql.NullInt64, error) {
+	var sequenceTable int
+	if err := q.QueryRowContext(ctx, `select exists(select 1 from sqlite_schema where type = 'table' and name = 'sqlite_sequence')`).Scan(&sequenceTable); err != nil {
+		return sql.NullInt64{}, fmt.Errorf("inspect portable threads sequence table: %w", err)
+	}
+	if sequenceTable == 0 {
+		return sql.NullInt64{}, nil
+	}
+	var sequence sql.NullInt64
+	if err := q.QueryRowContext(ctx, `select seq from sqlite_sequence where name = 'threads'`).Scan(&sequence); err != nil {
+		if err == sql.ErrNoRows {
+			return sql.NullInt64{}, nil
+		}
+		return sql.NullInt64{}, fmt.Errorf("read portable threads sequence: %w", err)
+	}
+	return sequence, nil
+}
+
+func portableThreadsSiblingName() (string, error) {
+	var value [8]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", fmt.Errorf("generate portable threads sibling name: %w", err)
+	}
+	return "threads_portable_" + hex.EncodeToString(value[:]), nil
+}
+
+func rewritePortableThreadsCreateSQL(createSQL, sibling string) (string, error) {
+	match := portableThreadsCreateTablePattern.FindStringSubmatchIndex(createSQL)
+	if match == nil {
+		return "", fmt.Errorf("unrecognized portable threads CREATE TABLE SQL")
+	}
+	return createSQL[:match[3]] + sqliteIdentifier(sibling) + createSQL[match[4]:], nil
+}
+
+func portableThreadsRebuildColumns(ctx context.Context, q dbQueries) ([]string, []string, error) {
+	rows, err := q.QueryContext(ctx, `pragma table_xinfo("threads")`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("inspect portable threads columns: %w", err)
+	}
+	defer rows.Close()
+	var columns, expressions []string
+	seen := make(map[string]bool)
+	for rows.Next() {
+		var cid, notNull, primaryKey, hidden int
+		var name, columnType string
+		var defaultValue any
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey, &hidden); err != nil {
+			return nil, nil, fmt.Errorf("scan portable threads columns: %w", err)
+		}
+		seen[name] = true
+		if hidden != 0 {
+			continue
+		}
+		columns = append(columns, sqliteIdentifier(name))
+		switch name {
+		case "body":
+			expressions = append(expressions, `"body_excerpt"`)
+		case "raw_json":
+			expressions = append(expressions, `''`)
+		default:
+			expressions = append(expressions, sqliteIdentifier(name))
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("read portable threads columns: %w", err)
+	}
+	for _, required := range []string{"body", "body_excerpt", "raw_json"} {
+		if !seen[required] {
+			return nil, nil, fmt.Errorf("portable threads rebuild requires column %s", required)
+		}
+	}
+	return columns, expressions, nil
+}
+
+func portableThreadsRebuildIndexes(ctx context.Context, q dbQueries) ([]string, []portableSchemaObject, error) {
+	rows, err := q.QueryContext(ctx, `pragma index_list("threads")`)
+	if err != nil {
+		return nil, nil, fmt.Errorf("inspect portable threads indexes: %w", err)
+	}
+	defer rows.Close()
+	var ordinary []string
+	var uniqueNames []string
+	for rows.Next() {
+		var sequence, unique, partial int
+		var name, origin string
+		if err := rows.Scan(&sequence, &name, &unique, &origin, &partial); err != nil {
+			return nil, nil, fmt.Errorf("scan portable threads indexes: %w", err)
+		}
+		if origin != "c" {
+			continue
+		}
+		if unique == 0 {
+			ordinary = append(ordinary, name)
+			continue
+		}
+		uniqueNames = append(uniqueNames, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("read portable threads indexes: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, nil, fmt.Errorf("close portable threads indexes: %w", err)
+	}
+	var uniqueIndexes []portableSchemaObject
+	for _, name := range uniqueNames {
+		var indexSQL sql.NullString
+		if err := q.QueryRowContext(ctx, `select sql from sqlite_schema where type = 'index' and tbl_name = 'threads' and name = ?`, name).Scan(&indexSQL); err != nil {
+			return nil, nil, fmt.Errorf("read portable unique index %s: %w", name, err)
+		}
+		if !indexSQL.Valid || !strings.HasPrefix(strings.ToUpper(strings.TrimSpace(indexSQL.String)), "CREATE UNIQUE INDEX") {
+			return nil, nil, fmt.Errorf("portable unique index %s has unrecognized SQL", name)
+		}
+		uniqueIndexes = append(uniqueIndexes, portableSchemaObject{name: name, sql: indexSQL.String})
+	}
+	sort.Strings(ordinary)
+	sort.Slice(uniqueIndexes, func(left, right int) bool { return uniqueIndexes[left].name < uniqueIndexes[right].name })
+	return ordinary, uniqueIndexes, nil
+}
+
+func portableThreadsRebuildTriggers(ctx context.Context, q dbQueries) ([]portableSchemaObject, error) {
+	rows, err := q.QueryContext(ctx, `select name, sql from sqlite_schema where type = 'trigger' and tbl_name = 'threads' order by name`)
+	if err != nil {
+		return nil, fmt.Errorf("inspect portable threads triggers: %w", err)
+	}
+	defer rows.Close()
+	var triggers []portableSchemaObject
+	for rows.Next() {
+		var trigger portableSchemaObject
+		var triggerSQL sql.NullString
+		if err := rows.Scan(&trigger.name, &triggerSQL); err != nil {
+			return nil, fmt.Errorf("scan portable threads trigger: %w", err)
+		}
+		if !triggerSQL.Valid || !strings.HasPrefix(strings.ToUpper(strings.TrimSpace(triggerSQL.String)), "CREATE TRIGGER") {
+			return nil, fmt.Errorf("portable threads trigger %s has unrecognized SQL", trigger.name)
+		}
+		trigger.sql = triggerSQL.String
+		triggers = append(triggers, trigger)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read portable threads triggers: %w", err)
+	}
+	return triggers, nil
 }
 
 func (s *Store) compactPortableThreadMetadata(ctx context.Context) (int64, int64, error) {

--- a/internal/store/portable.go
+++ b/internal/store/portable.go
@@ -55,6 +55,205 @@ type PortablePruneStats struct {
 	Vacuumed                  bool     `json:"vacuumed"`
 }
 
+type PortableRepositoryScope struct {
+	Repository          Repository `json:"repository"`
+	RepositoriesBefore  int64      `json:"repositories_before"`
+	RepositoriesRemoved int64      `json:"repositories_removed"`
+}
+
+// RestrictPortableRepository reduces a disposable portable snapshot to one
+// repository. It combines current foreign-key cascades with column-aware
+// deletion so repository-owned rows remain covered as the schema evolves.
+func (s *Store) RestrictPortableRepository(ctx context.Context, fullName string) (PortableRepositoryScope, error) {
+	var result PortableRepositoryScope
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return result, fmt.Errorf("open portable repository scope connection: %w", err)
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, `pragma foreign_keys = on`); err != nil {
+		return result, fmt.Errorf("enable portable repository foreign keys: %w", err)
+	}
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return result, fmt.Errorf("begin portable repository scope: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	var targetCount int64
+	if err := tx.QueryRowContext(ctx, `select count(*) from repositories where full_name = ?`, fullName).Scan(&targetCount); err != nil {
+		return result, fmt.Errorf("count portable target repository: %w", err)
+	}
+	if targetCount != 1 {
+		return result, fmt.Errorf("portable export target repository %q count is %d, expected 1", fullName, targetCount)
+	}
+	if err := tx.QueryRowContext(ctx, `
+		select id, owner, name, full_name
+		from repositories
+		where full_name = ?
+	`, fullName).Scan(
+		&result.Repository.ID,
+		&result.Repository.Owner,
+		&result.Repository.Name,
+		&result.Repository.FullName,
+	); err != nil {
+		return result, fmt.Errorf("read portable target repository: %w", err)
+	}
+	if err := tx.QueryRowContext(ctx, `select count(*) from repositories`).Scan(&result.RepositoriesBefore); err != nil {
+		return result, fmt.Errorf("count portable repositories before scope: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		create temp table _portable_scope_threads as
+		select id from threads where repo_id != ?
+	`, result.Repository.ID); err != nil {
+		return result, fmt.Errorf("capture out-of-scope portable threads: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		create temp table _portable_scope_revisions as
+		select id from thread_revisions where thread_id in (select id from _portable_scope_threads)
+	`); err != nil {
+		return result, fmt.Errorf("capture out-of-scope portable revisions: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		create temp table _portable_scope_clusters as
+		select id from cluster_groups where repo_id != ?
+	`, result.Repository.ID); err != nil {
+		return result, fmt.Errorf("capture out-of-scope portable clusters: %w", err)
+	}
+	tables, err := portableTableNames(ctx, tx)
+	if err != nil {
+		return result, err
+	}
+	for _, table := range tables {
+		switch table {
+		case "repositories", "threads", "thread_revisions", "cluster_groups":
+			continue
+		}
+		columns, err := portableTableColumnSet(ctx, tx, table)
+		if err != nil {
+			return result, err
+		}
+		var conditions []string
+		var args []any
+		if columns["thread_revision_id"] {
+			conditions = append(conditions, `thread_revision_id in (select id from _portable_scope_revisions)`)
+		}
+		if columns["thread_id"] {
+			conditions = append(conditions, `thread_id in (select id from _portable_scope_threads)`)
+		}
+		if columns["cluster_id"] {
+			conditions = append(conditions, `cluster_id in (select id from _portable_scope_clusters)`)
+		}
+		if columns["repo_id"] {
+			conditions = append(conditions, `repo_id != ?`)
+			args = append(args, result.Repository.ID)
+		}
+		if len(conditions) == 0 {
+			continue
+		}
+		query := `delete from ` + sqliteIdentifier(table) + ` where ` + strings.Join(conditions, " or ")
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+			return result, fmt.Errorf("delete out-of-scope portable rows from %s: %w", table, err)
+		}
+	}
+	for _, statement := range []string{
+		`delete from thread_revisions where id in (select id from _portable_scope_revisions)`,
+		`delete from cluster_groups where id in (select id from _portable_scope_clusters)`,
+		`delete from threads where id in (select id from _portable_scope_threads)`,
+	} {
+		if _, err := tx.ExecContext(ctx, statement); err != nil {
+			return result, fmt.Errorf("finalize portable repository scope: %w", err)
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `delete from repositories where id != ?`, result.Repository.ID); err != nil {
+		return result, fmt.Errorf("finalize portable repository scope: %w", err)
+	}
+	var repositoryCount, matchingCount int64
+	if err := tx.QueryRowContext(ctx, `select count(*) from repositories`).Scan(&repositoryCount); err != nil {
+		return result, fmt.Errorf("verify portable repository count: %w", err)
+	}
+	if err := tx.QueryRowContext(ctx, `select count(*) from repositories where id = ? and full_name = ?`, result.Repository.ID, fullName).Scan(&matchingCount); err != nil {
+		return result, fmt.Errorf("verify portable target repository: %w", err)
+	}
+	if repositoryCount != 1 || matchingCount != 1 {
+		return result, fmt.Errorf("portable repository restriction left %d repositories with %d matching %q", repositoryCount, matchingCount, fullName)
+	}
+	if err := tx.Commit(); err != nil {
+		return result, fmt.Errorf("commit portable repository scope: %w", err)
+	}
+	violations, err := portableForeignKeyViolationCount(ctx, conn)
+	if err != nil {
+		return result, err
+	}
+	if violations != 0 {
+		return result, fmt.Errorf("portable repository restriction left %d foreign-key violations", violations)
+	}
+	result.RepositoriesRemoved = result.RepositoriesBefore - 1
+	return result, nil
+}
+
+func portableTableNames(ctx context.Context, q dbQueries) ([]string, error) {
+	rows, err := q.QueryContext(ctx, `
+		select name
+		from sqlite_schema
+		where type = 'table' and name not like 'sqlite_%'
+		order by name
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list portable repository scope tables: %w", err)
+	}
+	defer rows.Close()
+	var tables []string
+	for rows.Next() {
+		var table string
+		if err := rows.Scan(&table); err != nil {
+			return nil, fmt.Errorf("scan portable repository scope table: %w", err)
+		}
+		tables = append(tables, table)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read portable repository scope tables: %w", err)
+	}
+	return tables, nil
+}
+
+func portableTableColumnSet(ctx context.Context, q dbQueries, table string) (map[string]bool, error) {
+	rows, err := q.QueryContext(ctx, `pragma table_info(`+sqliteIdentifier(table)+`)`)
+	if err != nil {
+		return nil, fmt.Errorf("inspect portable repository scope table %s: %w", table, err)
+	}
+	defer rows.Close()
+	columns := make(map[string]bool)
+	for rows.Next() {
+		var cid, notNull, primaryKey int
+		var name, columnType string
+		var defaultValue any
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			return nil, fmt.Errorf("scan portable repository scope table %s: %w", table, err)
+		}
+		columns[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read portable repository scope table %s: %w", table, err)
+	}
+	return columns, nil
+}
+
+func portableForeignKeyViolationCount(ctx context.Context, q dbQueries) (int, error) {
+	rows, err := q.QueryContext(ctx, `pragma foreign_key_check`)
+	if err != nil {
+		return 0, fmt.Errorf("run portable repository foreign_key_check: %w", err)
+	}
+	defer rows.Close()
+	count := 0
+	for rows.Next() {
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("read portable repository foreign_key_check: %w", err)
+	}
+	return count, nil
+}
+
 func (s *Store) PrunePortablePayloads(ctx context.Context, options PortablePruneOptions) (PortablePruneStats, error) {
 	if options.BodyChars <= 0 {
 		options.BodyChars = 256

--- a/internal/store/portable.go
+++ b/internal/store/portable.go
@@ -23,9 +23,10 @@ type PortablePruneOptions struct {
 	BodyChars           int
 	Vacuum              bool
 	IncludeSyncFailures bool
-	// DeferSecureRewrite leaves the scrub marker in place so a derived export
-	// can perform one final VACUUM after applying additional profile shaping.
-	// The in-place portable prune command must leave this false.
+	// DeferSecureRewrite guarantees that a derived, non-visible snapshot receives
+	// one final VACUUM. It may therefore skip writes to columns or tables that
+	// canonical shaping removes. The in-place portable prune command must leave
+	// this false so --no-vacuum still scrubs visible payloads before returning.
 	DeferSecureRewrite bool
 }
 
@@ -266,39 +267,8 @@ func (s *Store) PrunePortablePayloads(ctx context.Context, options PortablePrune
 		stats.BytesBefore = info.Size()
 	}
 
-	if s.hasColumn(ctx, "threads", "body") {
-		if err := s.ensurePortableExcerptColumns(ctx, "threads"); err != nil {
-			return stats, err
-		}
-		if result, err := s.db.ExecContext(ctx, `
-			update threads
-			   set body_length = case when body is not null then length(body) else body_length end,
-			       body_excerpt = case
-			         when body is not null and length(body) > ? then substr(body, 1, ?)
-			         when body is not null then body
-			         else body_excerpt
-			       end
-			 where body is not null
-		`, options.BodyChars, options.BodyChars); err != nil {
-			return stats, fmt.Errorf("prune thread body excerpts: %w", err)
-		} else {
-			stats.ThreadsPruned += rowsAffected(result)
-		}
-		if _, err := s.db.ExecContext(ctx, `update threads set body = body_excerpt`); err != nil {
-			return stats, fmt.Errorf("replace thread bodies with excerpts: %w", err)
-		}
-	}
-	if s.hasColumn(ctx, "threads", "raw_json") {
-		if _, err := s.db.ExecContext(ctx, `update threads set raw_json = '' where raw_json is not null and raw_json != ''`); err != nil {
-			return stats, fmt.Errorf("clear thread raw json: %w", err)
-		}
-	}
-	if s.hasColumn(ctx, "repositories", "raw_json") {
-		result, err := s.db.ExecContext(ctx, `update repositories set raw_json = '' where raw_json is not null and raw_json != ''`)
-		if err != nil {
-			return stats, fmt.Errorf("clear repository raw json: %w", err)
-		}
-		stats.RepositoriesPruned = rowsAffected(result)
+	if err := s.preparePortableThreadPayloads(ctx, options, &stats); err != nil {
+		return stats, err
 	}
 	if s.tableExists(ctx, "comments") && s.hasColumn(ctx, "comments", "body") {
 		if err := s.ensurePortableExcerptColumns(ctx, "comments"); err != nil {
@@ -358,22 +328,26 @@ func (s *Store) PrunePortablePayloads(ctx context.Context, options PortablePrune
 	} else {
 		stats.LegacySummariesDeleted = deleted
 	}
-	if s.tableExists(ctx, "documents") {
+	if !options.DeferSecureRewrite && s.tableExists(ctx, "documents") {
 		result, err := s.db.ExecContext(ctx, `delete from documents`)
 		if err != nil {
 			return stats, fmt.Errorf("delete generated documents: %w", err)
 		}
 		stats.DocumentsDeleted = rowsAffected(result)
 	}
-	if s.tableExists(ctx, "documents_fts") {
+	if !options.DeferSecureRewrite && s.tableExists(ctx, "documents_fts") {
 		if _, err := s.db.ExecContext(ctx, `insert into documents_fts(documents_fts) values('rebuild')`); err != nil {
 			return stats, fmt.Errorf("rebuild document fts: %w", err)
 		}
 		stats.DocumentsFTSRebuilt = true
 	}
-	syncFailureScrubRequired, err := s.scrubPortableSyncFailures(ctx, options.IncludeSyncFailures, &stats)
-	if err != nil {
-		return stats, err
+	syncFailureScrubRequired := false
+	if !(options.DeferSecureRewrite && !options.IncludeSyncFailures) {
+		var err error
+		syncFailureScrubRequired, err = s.scrubPortableSyncFailures(ctx, options.IncludeSyncFailures, &stats)
+		if err != nil {
+			return stats, err
+		}
 	}
 	if syncFailureScrubRequired && !options.DeferSecureRewrite {
 		if err := s.vacuumPortableDatabase(ctx); err != nil {
@@ -398,6 +372,49 @@ func (s *Store) PrunePortablePayloads(ctx context.Context, options PortablePrune
 		stats.BytesAfter = info.Size()
 	}
 	return stats, nil
+}
+
+func (s *Store) preparePortableThreadPayloads(ctx context.Context, options PortablePruneOptions, stats *PortablePruneStats) error {
+	if s.hasColumn(ctx, "threads", "body") {
+		if err := s.ensurePortableExcerptColumns(ctx, "threads"); err != nil {
+			return err
+		}
+		result, err := s.db.ExecContext(ctx, `
+			update threads
+			   set body_length = case when body is not null then length(body) else body_length end,
+			       body_excerpt = case
+			         when body is not null and length(body) > ? then substr(body, 1, ?)
+			         when body is not null then body
+			         else body_excerpt
+			       end
+			 where body is not null
+		`, options.BodyChars, options.BodyChars)
+		if err != nil {
+			return fmt.Errorf("prune thread body excerpts: %w", err)
+		}
+		stats.ThreadsPruned += rowsAffected(result)
+		if !options.DeferSecureRewrite {
+			if _, err := s.db.ExecContext(ctx, `update threads set body = body_excerpt`); err != nil {
+				return fmt.Errorf("replace thread bodies with excerpts: %w", err)
+			}
+		}
+	}
+	if options.DeferSecureRewrite {
+		return nil
+	}
+	if s.hasColumn(ctx, "threads", "raw_json") {
+		if _, err := s.db.ExecContext(ctx, `update threads set raw_json = '' where raw_json is not null and raw_json != ''`); err != nil {
+			return fmt.Errorf("clear thread raw json: %w", err)
+		}
+	}
+	if s.hasColumn(ctx, "repositories", "raw_json") {
+		result, err := s.db.ExecContext(ctx, `update repositories set raw_json = '' where raw_json is not null and raw_json != ''`)
+		if err != nil {
+			return fmt.Errorf("clear repository raw json: %w", err)
+		}
+		stats.RepositoriesPruned = rowsAffected(result)
+	}
+	return nil
 }
 
 func (s *Store) vacuumPortableDatabase(ctx context.Context) error {

--- a/internal/store/portable.go
+++ b/internal/store/portable.go
@@ -23,6 +23,10 @@ type PortablePruneOptions struct {
 	BodyChars           int
 	Vacuum              bool
 	IncludeSyncFailures bool
+	// DeferSecureRewrite leaves the scrub marker in place so a derived export
+	// can perform one final VACUUM after applying additional profile shaping.
+	// The in-place portable prune command must leave this false.
+	DeferSecureRewrite bool
 }
 
 type PortablePruneStats struct {
@@ -169,7 +173,7 @@ func (s *Store) PrunePortablePayloads(ctx context.Context, options PortablePrune
 	if err != nil {
 		return stats, err
 	}
-	if syncFailureScrubRequired {
+	if syncFailureScrubRequired && !options.DeferSecureRewrite {
 		if err := s.vacuumPortableDatabase(ctx); err != nil {
 			return stats, err
 		}

--- a/internal/store/portable.go
+++ b/internal/store/portable.go
@@ -19,6 +19,19 @@ const portableSyncFailureErrorRedaction = "[redacted for portable export]"
 
 const portableSyncFailureScrubPendingKey = "sync_failure_scrub_pending"
 
+type PortablePruneStage string
+
+const (
+	PortablePruneStageThreadBodies          PortablePruneStage = "thread bodies"
+	PortablePruneStageCommentReviewBodies   PortablePruneStage = "comment and review bodies"
+	PortablePruneStageMetadataRawPayloads   PortablePruneStage = "metadata and raw payload cleanup"
+	PortablePruneStageFingerprintsSummaries PortablePruneStage = "fingerprints and summaries"
+	PortablePruneStageDiscardedData         PortablePruneStage = "discarded tables and failure ledger"
+	PortablePruneStageCanonicalSchema       PortablePruneStage = "canonical schema drops"
+)
+
+type PortablePruneProgressFunc func(PortablePruneStage)
+
 type PortablePruneOptions struct {
 	BodyChars           int
 	Vacuum              bool
@@ -28,6 +41,7 @@ type PortablePruneOptions struct {
 	// canonical shaping removes. The in-place portable prune command must leave
 	// this false so --no-vacuum still scrubs visible payloads before returning.
 	DeferSecureRewrite bool
+	Progress           PortablePruneProgressFunc `json:"-"`
 }
 
 type PortablePruneStats struct {
@@ -267,9 +281,11 @@ func (s *Store) PrunePortablePayloads(ctx context.Context, options PortablePrune
 		stats.BytesBefore = info.Size()
 	}
 
+	reportPortablePruneProgress(options.Progress, PortablePruneStageThreadBodies)
 	if err := s.preparePortableThreadPayloads(ctx, options, &stats); err != nil {
 		return stats, err
 	}
+	reportPortablePruneProgress(options.Progress, PortablePruneStageCommentReviewBodies)
 	if s.tableExists(ctx, "comments") && s.hasColumn(ctx, "comments", "body") {
 		if err := s.ensurePortableExcerptColumns(ctx, "comments"); err != nil {
 			return stats, err
@@ -296,6 +312,7 @@ func (s *Store) PrunePortablePayloads(ctx context.Context, options PortablePrune
 	if err := s.compactPortableReviewThreadBodies(ctx, options.BodyChars); err != nil {
 		return stats, err
 	}
+	reportPortablePruneProgress(options.Progress, PortablePruneStageMetadataRawPayloads)
 	if labels, assignees, err := s.compactPortableThreadMetadata(ctx); err != nil {
 		return stats, err
 	} else {
@@ -310,6 +327,7 @@ func (s *Store) PrunePortablePayloads(ctx context.Context, options PortablePrune
 	if err := s.clearPortablePullRequestFilePatches(ctx); err != nil {
 		return stats, err
 	}
+	reportPortablePruneProgress(options.Progress, PortablePruneStageFingerprintsSummaries)
 	if s.tableExists(ctx, "thread_fingerprints") {
 		result, err := s.db.ExecContext(ctx, `
 			update thread_fingerprints
@@ -328,6 +346,7 @@ func (s *Store) PrunePortablePayloads(ctx context.Context, options PortablePrune
 	} else {
 		stats.LegacySummariesDeleted = deleted
 	}
+	reportPortablePruneProgress(options.Progress, PortablePruneStageDiscardedData)
 	if !options.DeferSecureRewrite && s.tableExists(ctx, "documents") {
 		result, err := s.db.ExecContext(ctx, `delete from documents`)
 		if err != nil {
@@ -359,6 +378,7 @@ func (s *Store) PrunePortablePayloads(ctx context.Context, options PortablePrune
 			return stats, fmt.Errorf("clear portable sync failure scrub marker: %w", err)
 		}
 	}
+	reportPortablePruneProgress(options.Progress, PortablePruneStageCanonicalSchema)
 	if err := s.canonicalizePortableSchema(ctx, options.BodyChars, options.IncludeSyncFailures, &stats); err != nil {
 		return stats, err
 	}
@@ -372,6 +392,12 @@ func (s *Store) PrunePortablePayloads(ctx context.Context, options PortablePrune
 		stats.BytesAfter = info.Size()
 	}
 	return stats, nil
+}
+
+func reportPortablePruneProgress(progress PortablePruneProgressFunc, stage PortablePruneStage) {
+	if progress != nil {
+		progress(stage)
+	}
 }
 
 func (s *Store) preparePortableThreadPayloads(ctx context.Context, options PortablePruneOptions, stats *PortablePruneStats) error {

--- a/internal/store/portable.go
+++ b/internal/store/portable.go
@@ -337,6 +337,9 @@ func (s *Store) PrunePortablePayloads(ctx context.Context, options PortablePrune
 	} else {
 		stats.RawJSONPruned = pruned
 	}
+	if err := s.clearPortablePullRequestFilePatches(ctx); err != nil {
+		return stats, err
+	}
 	if s.tableExists(ctx, "thread_fingerprints") {
 		result, err := s.db.ExecContext(ctx, `
 			update thread_fingerprints
@@ -577,7 +580,7 @@ func (s *Store) canonicalizePortableSchema(ctx context.Context, bodyChars int, i
 	}
 	capabilities := "body_excerpts,comment_excerpts,author_association,thread_revisions,thread_fingerprints,thread_key_summaries,pr_details,pr_files,pr_commits,pr_checks,pr_review_threads,workflow_runs,family_tombstones,comment_revisions,pr_review_thread_revisions,raw_json_stripped"
 	includes := "repositories,threads,comments,comment_revisions,thread_revisions,thread_fingerprints,thread_key_summaries,pull_request_details,pull_request_files,pull_request_commits,pull_request_checks,pull_request_review_threads,pull_request_review_thread_revisions,pull_request_review_thread_syncs,github_workflow_runs"
-	excluded := "raw_json,documents,fts,vectors,code_snapshots,code_documents,cluster_events,run_history,similarity_edges,blobs,sync_attempt_failures"
+	excluded := "raw_json,pull_request_file_patches,documents,fts,vectors,code_snapshots,code_documents,cluster_events,run_history,similarity_edges,blobs,sync_attempt_failures"
 	if stats.SyncFailuresIncluded {
 		capabilities += ",sync_failure_ledger_redacted"
 		includes += ",sync_attempt_failures"
@@ -858,6 +861,20 @@ func (s *Store) clearPortableRawJSON(ctx context.Context) (int64, error) {
 		}
 	}
 	return total, nil
+}
+
+func (s *Store) clearPortablePullRequestFilePatches(ctx context.Context) error {
+	if !s.tableExists(ctx, "pull_request_files") || !s.hasColumn(ctx, "pull_request_files", "patch") {
+		return nil
+	}
+	if _, err := s.db.ExecContext(ctx, `
+		update pull_request_files
+		set patch = null
+		where patch is not null and patch != ''
+	`); err != nil {
+		return fmt.Errorf("clear portable pull request file patches: %w", err)
+	}
+	return nil
 }
 
 func canonicalPortableDroppedTables() []string {

--- a/internal/store/portable.go
+++ b/internal/store/portable.go
@@ -19,15 +19,17 @@ const portableSyncFailureErrorRedaction = "[redacted for portable export]"
 
 const portableSyncFailureScrubPendingKey = "sync_failure_scrub_pending"
 
+const PortableColumnProfileSanitizedCompatibility = "sanitized-compatibility"
+
 type PortablePruneStage string
 
 const (
-	PortablePruneStageThreadBodies          PortablePruneStage = "thread bodies"
-	PortablePruneStageCommentReviewBodies   PortablePruneStage = "comment and review bodies"
-	PortablePruneStageMetadataRawPayloads   PortablePruneStage = "metadata and raw payload cleanup"
-	PortablePruneStageFingerprintsSummaries PortablePruneStage = "fingerprints and summaries"
-	PortablePruneStageDiscardedData         PortablePruneStage = "discarded tables and failure ledger"
-	PortablePruneStageCanonicalSchema       PortablePruneStage = "canonical schema drops"
+	PortablePruneStageThreadBodies                PortablePruneStage = "thread bodies"
+	PortablePruneStageCommentReviewBodies         PortablePruneStage = "comment and review bodies"
+	PortablePruneStageMetadataRawPayloads         PortablePruneStage = "metadata and raw payload cleanup"
+	PortablePruneStageFingerprintsSummaries       PortablePruneStage = "fingerprints and summaries"
+	PortablePruneStageDiscardedData               PortablePruneStage = "discarded tables and failure ledger"
+	PortablePruneStageCanonicalSchemaFinalization PortablePruneStage = "canonical schema finalization"
 )
 
 type PortablePruneProgressFunc func(PortablePruneStage)
@@ -40,8 +42,9 @@ type PortablePruneOptions struct {
 	// one final VACUUM. It may therefore skip writes to columns or tables that
 	// canonical shaping removes. The in-place portable prune command must leave
 	// this false so --no-vacuum still scrubs visible payloads before returning.
-	DeferSecureRewrite bool
-	Progress           PortablePruneProgressFunc `json:"-"`
+	DeferSecureRewrite            bool
+	RetainSanitizedPayloadColumns bool
+	Progress                      PortablePruneProgressFunc `json:"-"`
 }
 
 type PortablePruneStats struct {
@@ -378,8 +381,8 @@ func (s *Store) PrunePortablePayloads(ctx context.Context, options PortablePrune
 			return stats, fmt.Errorf("clear portable sync failure scrub marker: %w", err)
 		}
 	}
-	reportPortablePruneProgress(options.Progress, PortablePruneStageCanonicalSchema)
-	if err := s.canonicalizePortableSchema(ctx, options.BodyChars, options.IncludeSyncFailures, &stats); err != nil {
+	reportPortablePruneProgress(options.Progress, PortablePruneStageCanonicalSchemaFinalization)
+	if err := s.canonicalizePortableSchema(ctx, options.BodyChars, options.IncludeSyncFailures, options.RetainSanitizedPayloadColumns, &stats); err != nil {
 		return stats, err
 	}
 	if options.Vacuum {
@@ -572,7 +575,7 @@ func (s *Store) pruneEquivalentLegacyKeySummaries(ctx context.Context) (int64, e
 	return rowsAffected(result), nil
 }
 
-func (s *Store) canonicalizePortableSchema(ctx context.Context, bodyChars int, includeSyncFailures bool, stats *PortablePruneStats) error {
+func (s *Store) canonicalizePortableSchema(ctx context.Context, bodyChars int, includeSyncFailures, retainSanitizedPayloadColumns bool, stats *PortablePruneStats) error {
 	if s.hasColumn(ctx, "threads", "body") && !s.hasColumn(ctx, "threads", "body_excerpt") {
 		if _, err := s.db.ExecContext(ctx, `alter table threads add column body_excerpt text`); err != nil {
 			return fmt.Errorf("add portable threads.body_excerpt: %w", err)
@@ -590,6 +593,11 @@ func (s *Store) canonicalizePortableSchema(ctx context.Context, bodyChars int, i
 			return fmt.Errorf("add portable threads.body_length: %w", err)
 		}
 	}
+	if retainSanitizedPayloadColumns {
+		if err := s.sanitizePortableCompatibilityColumns(ctx); err != nil {
+			return err
+		}
+	}
 	for _, column := range []struct {
 		table string
 		name  string
@@ -598,6 +606,9 @@ func (s *Store) canonicalizePortableSchema(ctx context.Context, bodyChars int, i
 		{table: "threads", name: "raw_json"},
 		{table: "threads", name: "body"},
 	} {
+		if retainSanitizedPayloadColumns {
+			continue
+		}
 		if !s.hasColumn(ctx, column.table, column.name) {
 			continue
 		}
@@ -639,6 +650,11 @@ func (s *Store) canonicalizePortableSchema(ctx context.Context, bodyChars int, i
 		"source_path":           s.path,
 		"thread_author_profile": "login,type,association",
 	}
+	if retainSanitizedPayloadColumns {
+		metadata["column_profile"] = PortableColumnProfileSanitizedCompatibility
+	} else if _, err := s.db.ExecContext(ctx, `delete from portable_metadata where key = 'column_profile'`); err != nil {
+		return fmt.Errorf("clear portable column profile metadata: %w", err)
+	}
 	for key, value := range metadata {
 		if _, err := s.db.ExecContext(ctx, `
 			insert into portable_metadata(key, value)
@@ -650,6 +666,33 @@ func (s *Store) canonicalizePortableSchema(ctx context.Context, bodyChars int, i
 	}
 	if _, err := s.db.ExecContext(ctx, fmt.Sprintf(`pragma user_version = %d`, portableSchemaVersion)); err != nil {
 		return fmt.Errorf("set portable schema compatibility version: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) sanitizePortableCompatibilityColumns(ctx context.Context) error {
+	var assignments, conditions []string
+	if s.hasColumns(ctx, "threads", "body", "body_excerpt") {
+		assignments = append(assignments, `body = body_excerpt`)
+		conditions = append(conditions, `body is not body_excerpt`)
+	}
+	if s.hasColumn(ctx, "threads", "raw_json") {
+		assignments = append(assignments, `raw_json = ''`)
+		conditions = append(conditions, `raw_json != ''`)
+	}
+	if len(assignments) > 0 {
+		query := `update threads set ` + strings.Join(assignments, ", ")
+		if len(conditions) > 0 {
+			query += ` where ` + strings.Join(conditions, " or ")
+		}
+		if _, err := s.db.ExecContext(ctx, query); err != nil {
+			return fmt.Errorf("sanitize portable thread compatibility columns: %w", err)
+		}
+	}
+	if s.hasColumn(ctx, "repositories", "raw_json") {
+		if _, err := s.db.ExecContext(ctx, `update repositories set raw_json = '' where raw_json != ''`); err != nil {
+			return fmt.Errorf("sanitize portable repository compatibility column: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/store/portable_bulk_drop_test.go
+++ b/internal/store/portable_bulk_drop_test.go
@@ -1,0 +1,421 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestCanonicalPortableBulkDropOrderMatchesKnownSet(t *testing.T) {
+	want := append([]string(nil), canonicalPortableDroppedTables()...)
+	got := append([]string(nil), canonicalPortableBulkDropOrder()...)
+	slices.Sort(want)
+	slices.Sort(got)
+	if !slices.Equal(got, want) {
+		t.Fatalf("bulk drop set = %v, want %v", got, want)
+	}
+	for index := 1; index < len(got); index++ {
+		if got[index] == got[index-1] {
+			t.Fatalf("bulk drop table %s appears more than once", got[index])
+		}
+	}
+}
+
+func TestPortableBulkDropResolvesCaseVariantTableNames(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "case-variant.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	if _, err := db.ExecContext(ctx, `create table "Documents"(id integer primary key, payload text)`); err != nil {
+		t.Fatalf("create case-variant disposable table: %v", err)
+	}
+	st := &Store{db: db, path: "case-variant.db"}
+	stats := &PortablePruneStats{}
+	if err := st.dropCanonicalPortableTablesBulk(ctx, false, stats, nil); err != nil {
+		t.Fatalf("drop case-variant portable table: %v", err)
+	}
+	if tableExistsForPortableTest(t, db, "Documents") {
+		t.Fatal("case-variant disposable table remains")
+	}
+	if !slices.Contains(stats.DroppedTables, "Documents") {
+		t.Fatalf("case-variant dropped tables = %v", stats.DroppedTables)
+	}
+}
+
+func TestDropPortableDerivedBlobPointerColumnsRemovesForeignKeys(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "blob-pointers.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	stats := &PortablePruneStats{}
+	if err := st.dropPortableDerivedBlobPointerColumns(ctx, stats); err != nil {
+		t.Fatalf("drop derived blob pointer columns: %v", err)
+	}
+	for _, table := range []string{"comments", "thread_revisions"} {
+		if st.hasColumn(ctx, table, "raw_json_blob_id") {
+			t.Fatalf("derived blob pointer remains on %s", table)
+		}
+		definitions, err := portableForeignKeysForTable(ctx, st.DB(), table)
+		if err != nil {
+			t.Fatalf("inspect %s foreign keys: %v", table, err)
+		}
+		for _, definition := range definitions {
+			if strings.EqualFold(definition.referencedTable, "blobs") {
+				t.Fatalf("derived %s schema still references blobs: %+v", table, definition)
+			}
+		}
+	}
+	want := []string{"comments.raw_json_blob_id", "thread_revisions.raw_json_blob_id"}
+	if !slices.Equal(stats.DroppedColumns, want) {
+		t.Fatalf("dropped blob pointer columns = %v, want %v", stats.DroppedColumns, want)
+	}
+}
+
+func TestPortableBulkDropValidatesQuotedRetainedViewName(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "quoted-view.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	if _, err := st.DB().ExecContext(ctx, `create view "report""view" as select id from repositories`); err != nil {
+		t.Fatalf("create quoted retained view: %v", err)
+	}
+	stats := &PortablePruneStats{}
+	preparePortableBulkDropTest(t, ctx, st, stats)
+	if err := st.dropCanonicalPortableTablesBulk(ctx, false, stats, nil); err != nil {
+		t.Fatalf("bulk drop with quoted retained view: %v", err)
+	}
+}
+
+func TestPortableBulkDropRemovesLargeDisposableGraphAndRestoresForeignKeys(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "bulk-drop.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	if _, err := st.DB().ExecContext(ctx, `
+		pragma foreign_keys = on;
+		insert into repositories(id, owner, name, full_name, raw_json, updated_at)
+		values(1, 'openclaw', 'gitcrawl', 'openclaw/gitcrawl', '{}', '2026-08-09T00:00:00Z');
+		insert into code_snapshots(id, repo_id, source_root, git_sha, worktree_dirty, file_count, byte_count, indexed_at)
+		values(1, 1, '/source', 'sha', 0, 2000, 4096000, '2026-08-09T00:00:00Z');
+		with recursive sequence(value) as (
+			select 1
+			union all
+			select value + 1 from sequence where value < 2000
+		)
+		insert into code_documents(snapshot_id, repo_id, path, language, content_hash, text_content, byte_size, updated_at)
+		select 1, 1, printf('file-%04d.go', value), 'go', printf('hash-%d', value),
+		       hex(zeroblob(1024)), 2048, '2026-08-09T00:00:00Z'
+		from sequence;
+	`); err != nil {
+		t.Fatalf("seed large disposable graph: %v", err)
+	}
+	var before int
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from code_documents`).Scan(&before); err != nil || before != 2000 {
+		t.Fatalf("seeded code documents=%d err=%v", before, err)
+	}
+	var expectedDropped []string
+	for _, table := range canonicalPortableBulkDropOrder() {
+		if tableExistsForPortableTest(t, st.DB(), table) {
+			expectedDropped = append(expectedDropped, table)
+		}
+	}
+	stats := &PortablePruneStats{}
+	preparePortableBulkDropTest(t, ctx, st, stats)
+	if err := st.dropCanonicalPortableTablesBulk(ctx, false, stats, nil); err != nil {
+		t.Fatalf("bulk drop portable tables: %v", err)
+	}
+	if got := portableTestForeignKeys(t, st.DB()); got != 1 {
+		t.Fatalf("foreign_keys after bulk drop = %d, want 1", got)
+	}
+	for _, table := range canonicalPortableBulkDropOrder() {
+		if tableExistsForPortableTest(t, st.DB(), table) {
+			t.Fatalf("bulk-dropped table %s still exists", table)
+		}
+	}
+	if !slices.Equal(stats.DroppedTables, expectedDropped) {
+		t.Fatalf("bulk drop stats = %v, want %v", stats.DroppedTables, expectedDropped)
+	}
+	seen := make(map[string]bool)
+	for _, table := range stats.DroppedTables {
+		if seen[table] {
+			t.Fatalf("bulk-dropped table %s reported twice: %v", table, stats.DroppedTables)
+		}
+		seen[table] = true
+	}
+	for _, table := range []string{"code_documents_fts", "code_documents", "code_snapshots"} {
+		if !seen[table] {
+			t.Fatalf("bulk drop stats missing %s: %v", table, stats.DroppedTables)
+		}
+	}
+	violations, err := portableForeignKeyViolationCount(ctx, st.DB())
+	if err != nil || violations != 0 {
+		t.Fatalf("bulk-dropped store FK violations=%d err=%v", violations, err)
+	}
+}
+
+func TestPortableBulkDropRollsBackAndRestoresForeignKeys(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "bulk-drop-rollback.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	st.DB().SetMaxOpenConns(1)
+	st.DB().SetMaxIdleConns(1)
+	var journalMode string
+	if err := st.DB().QueryRowContext(ctx, `pragma journal_mode = off`).Scan(&journalMode); err != nil || journalMode != "off" {
+		t.Fatalf("set rollback fixture journal mode=%q err=%v", journalMode, err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `
+		pragma foreign_keys = on;
+		insert into repositories(id, owner, name, full_name, raw_json, updated_at)
+		values(1, 'openclaw', 'gitcrawl', 'openclaw/gitcrawl', '{}', '2026-08-09T00:00:00Z');
+		insert into code_snapshots(id, repo_id, source_root, git_sha, worktree_dirty, file_count, byte_count, indexed_at)
+		values(1, 1, '/source', 'sha', 0, 1, 4, '2026-08-09T00:00:00Z');
+		insert into code_documents(id, snapshot_id, repo_id, path, language, content_hash, text_content, byte_size, updated_at)
+		values(1, 1, 1, 'file.go', 'go', 'hash', 'body', 4, '2026-08-09T00:00:00Z');
+	`); err != nil {
+		t.Fatalf("seed rollback graph: %v", err)
+	}
+	stats := &PortablePruneStats{}
+	preparePortableBulkDropTest(t, ctx, st, stats)
+	transactionJournalMode := ""
+	err = st.dropCanonicalPortableTablesBulk(ctx, false, stats, func(_ context.Context, tx *sql.Tx, table string) error {
+		if table == "code_snapshots" {
+			if err := tx.QueryRowContext(ctx, `pragma journal_mode`).Scan(&transactionJournalMode); err != nil {
+				return err
+			}
+			return errors.New("injected drop failure")
+		}
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "injected drop failure") {
+		t.Fatalf("bulk drop rollback error = %v", err)
+	}
+	if len(stats.DroppedTables) != 0 {
+		t.Fatalf("rolled-back drops reported as committed: %v", stats.DroppedTables)
+	}
+	for _, table := range []string{"code_documents_fts", "code_documents", "code_snapshots"} {
+		if !tableExistsForPortableTest(t, st.DB(), table) {
+			t.Fatalf("rollback did not restore %s", table)
+		}
+	}
+	var documents int
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from code_documents`).Scan(&documents); err != nil || documents != 1 {
+		t.Fatalf("code documents after rollback=%d err=%v", documents, err)
+	}
+	if got := portableTestForeignKeys(t, st.DB()); got != 1 {
+		t.Fatalf("foreign_keys after rollback = %d, want 1", got)
+	}
+	if transactionJournalMode != "memory" {
+		t.Fatalf("bulk drop transaction journal_mode = %q, want memory", transactionJournalMode)
+	}
+	if err := st.DB().QueryRowContext(ctx, `pragma journal_mode`).Scan(&journalMode); err != nil || journalMode != "off" {
+		t.Fatalf("journal mode after rollback=%q err=%v", journalMode, err)
+	}
+}
+
+func TestPortableBulkDropRespectsSyncFailuresAndRestoresDisabledForeignKeys(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "bulk-drop-sync-failures.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	st.DB().SetMaxOpenConns(1)
+	st.DB().SetMaxIdleConns(1)
+	if _, err := st.DB().ExecContext(ctx, `pragma foreign_keys = off`); err != nil {
+		t.Fatalf("disable fixture foreign keys: %v", err)
+	}
+	stats := &PortablePruneStats{}
+	preparePortableBulkDropTest(t, ctx, st, stats)
+	if err := st.dropCanonicalPortableTablesBulk(ctx, true, stats, nil); err != nil {
+		t.Fatalf("bulk drop retaining sync failures: %v", err)
+	}
+	if !tableExistsForPortableTest(t, st.DB(), "sync_attempt_failures") {
+		t.Fatal("bulk drop removed included sync_attempt_failures")
+	}
+	if slices.Contains(stats.DroppedTables, "sync_attempt_failures") {
+		t.Fatalf("included sync_attempt_failures reported dropped: %v", stats.DroppedTables)
+	}
+	if got := portableTestForeignKeys(t, st.DB()); got != 0 {
+		t.Fatalf("foreign_keys after disabled-state bulk drop = %d, want 0", got)
+	}
+}
+
+func TestPortableBulkDropRejectsRetainedSchemaDependencies(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		statement string
+		wantError string
+	}{
+		{
+			name:      "foreign key",
+			statement: `create table retained_documents_fk(id integer primary key, document_id integer references documents(id))`,
+			wantError: "retained portable table retained_documents_fk foreign key references dropped table documents",
+		},
+		{
+			name:      "view",
+			statement: `create view retained_documents_view as select id from documents`,
+			wantError: "retained portable view retained_documents_view is invalid",
+		},
+		{
+			name:      "trigger",
+			statement: `create trigger retained_documents_trigger after update on repositories begin select count(*) from documents; end`,
+			wantError: "retained portable trigger retained_documents_trigger references dropped table documents",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			st, err := Open(ctx, filepath.Join(t.TempDir(), "dependency.db"))
+			if err != nil {
+				t.Fatalf("open store: %v", err)
+			}
+			defer st.Close()
+			if _, err := st.DB().ExecContext(ctx, test.statement); err != nil {
+				t.Fatalf("seed retained dependency: %v", err)
+			}
+			stats := &PortablePruneStats{}
+			preparePortableBulkDropTest(t, ctx, st, stats)
+			err = st.dropCanonicalPortableTablesBulk(ctx, false, stats, nil)
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("retained dependency error = %v", err)
+			}
+			if got := portableTestForeignKeys(t, st.DB()); got != 1 {
+				t.Fatalf("foreign_keys after dependency failure = %d, want 1", got)
+			}
+		})
+	}
+}
+
+func TestPortableTriggerDroppedDependencyUsesTablePositions(t *testing.T) {
+	dropped := map[string]bool{"documents": true}
+	dependency, err := portableTriggerDroppedDependency(`
+		create trigger retained_literal after update on repositories
+		begin
+			select 'documents';
+		end
+	`, dropped)
+	if err != nil || dependency != "" {
+		t.Fatalf("literal dependency=%q err=%v", dependency, err)
+	}
+	dependency, err = portableTriggerDroppedDependency(`
+		create trigger retained_identifier after update on repositories
+		begin
+			select count(*) from "documents";
+		end
+	`, dropped)
+	if err != nil || dependency != "documents" {
+		t.Fatalf("quoted identifier dependency=%q err=%v", dependency, err)
+	}
+	dependency, err = portableTriggerDroppedDependency(`
+		create trigger retained_single_quoted after update on repositories
+		begin
+			select count(*) from 'documents';
+		end
+	`, dropped)
+	if err != nil || dependency != "documents" {
+		t.Fatalf("single-quoted identifier dependency=%q err=%v", dependency, err)
+	}
+	dependency, err = portableTriggerDroppedDependency(`
+		create trigger retained_column after update on repositories
+		begin
+			insert into retained_audit(documents) values('column value');
+		end
+	`, dropped)
+	if err != nil || dependency != "" {
+		t.Fatalf("column-name dependency=%q err=%v", dependency, err)
+	}
+	dependency, err = portableTriggerDroppedDependency(`
+		create trigger retained_when after update on repositories
+		when exists(select 1 from documents)
+		begin
+			select 1;
+		end
+	`, dropped)
+	if err != nil || dependency != "documents" {
+		t.Fatalf("WHEN dependency=%q err=%v", dependency, err)
+	}
+	dependency, err = portableTriggerDroppedDependency(`
+		create trigger retained_cte after update on repositories
+		begin
+			with documents as (select 1 as id)
+			select id from documents;
+		end
+	`, dropped)
+	if err != nil || dependency != "documents" {
+		t.Fatalf("CTE dependency=%q err=%v", dependency, err)
+	}
+	dependency, err = portableTriggerDroppedDependency(`
+		create trigger retained_cte_scope after update on repositories
+		begin
+			with documents as (select 1 as id)
+			select id from documents;
+			select count(*) from documents;
+		end
+	`, dropped)
+	if err != nil || dependency != "documents" {
+		t.Fatalf("later-statement dependency=%q err=%v", dependency, err)
+	}
+	dependency, err = portableTriggerDroppedDependency(`
+		create trigger retained_cte_target after update on repositories
+		begin
+			with documents as (select 1 as id)
+			delete from documents;
+		end
+	`, dropped)
+	if err != nil || dependency != "documents" {
+		t.Fatalf("CTE DML target dependency=%q err=%v", dependency, err)
+	}
+	dependency, err = portableTriggerDroppedDependency(`
+		create trigger retained_grouped_source after update on repositories
+		begin
+			select * from (select 1 where true), documents;
+		end
+	`, dropped)
+	if err != nil || dependency != "documents" {
+		t.Fatalf("grouped source dependency=%q err=%v", dependency, err)
+	}
+	dependency, err = portableTriggerDroppedDependency(`
+		create trigger retained_join_comma after update on repositories
+		begin
+			select *
+			from repositories r
+			join threads t on coalesce(r.id, t.repo_id) = t.repo_id,
+			     documents d;
+		end
+	`, dropped)
+	if err != nil || dependency != "documents" {
+		t.Fatalf("JOIN comma dependency=%q err=%v", dependency, err)
+	}
+}
+
+func portableTestForeignKeys(t *testing.T, db *sql.DB) int {
+	t.Helper()
+	var enabled int
+	if err := db.QueryRow(`pragma foreign_keys`).Scan(&enabled); err != nil {
+		t.Fatalf("read foreign_keys: %v", err)
+	}
+	return enabled
+}
+
+func preparePortableBulkDropTest(t *testing.T, ctx context.Context, st *Store, stats *PortablePruneStats) {
+	t.Helper()
+	if err := st.dropPortableDerivedBlobPointerColumns(ctx, stats); err != nil {
+		t.Fatalf("drop derived blob pointer columns: %v", err)
+	}
+}

--- a/internal/store/portable_deferred_test.go
+++ b/internal/store/portable_deferred_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"path/filepath"
 	"reflect"
 	"slices"
@@ -46,13 +47,23 @@ func TestPortablePruneDeferredRewriteVisibleEquivalence(t *testing.T) {
 	ctx := context.Background()
 	legacy := seedPortableDeferredStore(t, ctx, filepath.Join(t.TempDir(), "legacy.db"))
 	deferred := seedPortableDeferredStore(t, ctx, filepath.Join(t.TempDir(), "deferred.db"))
+	retained := seedPortableDeferredStore(t, ctx, filepath.Join(t.TempDir(), "retained.db"))
 	defer legacy.Close()
 	defer deferred.Close()
+	defer retained.Close()
 	if _, err := legacy.PrunePortablePayloads(ctx, PortablePruneOptions{BodyChars: 8, Vacuum: false}); err != nil {
 		t.Fatalf("legacy prune: %v", err)
 	}
 	if _, err := deferred.PrunePortablePayloads(ctx, PortablePruneOptions{BodyChars: 8, Vacuum: false, DeferSecureRewrite: true}); err != nil {
 		t.Fatalf("deferred prune: %v", err)
+	}
+	retainedStats, err := retained.PrunePortablePayloads(ctx, PortablePruneOptions{
+		BodyChars:                     8,
+		DeferSecureRewrite:            true,
+		RetainSanitizedPayloadColumns: true,
+	})
+	if err != nil {
+		t.Fatalf("retained-column prune: %v", err)
 	}
 	for _, st := range []*Store{legacy, deferred} {
 		if st.hasColumn(ctx, "threads", "body") || st.hasColumn(ctx, "threads", "raw_json") || st.hasColumn(ctx, "repositories", "raw_json") {
@@ -63,6 +74,29 @@ func TestPortablePruneDeferredRewriteVisibleEquivalence(t *testing.T) {
 	deferredVisible := portableVisibleState(t, ctx, deferred)
 	if !reflect.DeepEqual(legacyVisible, deferredVisible) {
 		t.Fatalf("visible portable state differs:\nlegacy=%#v\ndeferred=%#v", legacyVisible, deferredVisible)
+	}
+	retainedVisible := portableVisibleState(t, ctx, retained)
+	if !reflect.DeepEqual(legacyVisible, retainedVisible) {
+		t.Fatalf("retained-column visible state differs:\nlegacy=%#v\nretained=%#v", legacyVisible, retainedVisible)
+	}
+	if !retained.hasColumn(ctx, "repositories", "raw_json") || !retained.hasColumn(ctx, "threads", "raw_json") || !retained.hasColumn(ctx, "threads", "body") {
+		t.Fatal("sanitized compatibility columns were physically dropped")
+	}
+	if len(retainedStats.DroppedColumns) != 0 {
+		t.Fatalf("retained-column dropped stats = %v", retainedStats.DroppedColumns)
+	}
+	var repositoryRaw, threadRaw, body, excerpt, columnProfile string
+	if err := retained.DB().QueryRowContext(ctx, `select raw_json from repositories where id = 1`).Scan(&repositoryRaw); err != nil {
+		t.Fatal(err)
+	}
+	if err := retained.DB().QueryRowContext(ctx, `select raw_json, body, body_excerpt from threads where id = 1`).Scan(&threadRaw, &body, &excerpt); err != nil {
+		t.Fatal(err)
+	}
+	if err := retained.DB().QueryRowContext(ctx, `select value from portable_metadata where key = 'column_profile'`).Scan(&columnProfile); err != nil {
+		t.Fatal(err)
+	}
+	if repositoryRaw != "" || threadRaw != "" || body != "abcdefgh" || excerpt != "abcdefgh" || columnProfile != PortableColumnProfileSanitizedCompatibility {
+		t.Fatalf("sanitized columns repository_raw=%q thread_raw=%q body=%q excerpt=%q profile=%q", repositoryRaw, threadRaw, body, excerpt, columnProfile)
 	}
 }
 
@@ -86,10 +120,42 @@ func TestPortablePruneProgressStagesOrdered(t *testing.T) {
 		PortablePruneStageMetadataRawPayloads,
 		PortablePruneStageFingerprintsSummaries,
 		PortablePruneStageDiscardedData,
-		PortablePruneStageCanonicalSchema,
+		PortablePruneStageCanonicalSchemaFinalization,
 	}
 	if !slices.Equal(stages, want) {
 		t.Fatalf("portable prune stages = %v, want %v", stages, want)
+	}
+}
+
+func TestPortablePrunePhysicalDropClearsCompatibilityColumnProfile(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "column-profile.db")
+	st := seedPortableDeferredStore(t, ctx, dbPath)
+	if _, err := st.PrunePortablePayloads(ctx, PortablePruneOptions{
+		BodyChars:                     8,
+		DeferSecureRewrite:            true,
+		RetainSanitizedPayloadColumns: true,
+	}); err != nil {
+		t.Fatalf("retained-column prune: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close retained-column store: %v", err)
+	}
+	var err error
+	st, err = Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("reopen retained-column store: %v", err)
+	}
+	defer st.Close()
+	if _, err := st.PrunePortablePayloads(ctx, PortablePruneOptions{BodyChars: 8}); err != nil {
+		t.Fatalf("physical-drop prune: %v", err)
+	}
+	if st.hasColumn(ctx, "repositories", "raw_json") || st.hasColumn(ctx, "threads", "raw_json") || st.hasColumn(ctx, "threads", "body") {
+		t.Fatal("physical-drop prune retained compatibility columns")
+	}
+	var value string
+	if err := st.DB().QueryRowContext(ctx, `select value from portable_metadata where key = 'column_profile'`).Scan(&value); err != sql.ErrNoRows {
+		t.Fatalf("column_profile after physical drop = %q, err=%v", value, err)
 	}
 }
 

--- a/internal/store/portable_deferred_test.go
+++ b/internal/store/portable_deferred_test.go
@@ -1,0 +1,130 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestPreparePortableThreadPayloadsDefersOnlyDisposableWrites(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name              string
+		deferRewrite      bool
+		wantBody          string
+		wantThreadRaw     string
+		wantRepositoryRaw string
+	}{
+		{name: "legacy no-vacuum", wantBody: "abcdefgh", wantThreadRaw: "", wantRepositoryRaw: ""},
+		{name: "derived final rewrite", deferRewrite: true, wantBody: "abcdefghijklmnopqrstuvwxyz", wantThreadRaw: `{"thread":true}`, wantRepositoryRaw: `{"repository":true}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st := seedPortableDeferredStore(t, ctx, filepath.Join(t.TempDir(), "payloads.db"))
+			defer st.Close()
+			stats := PortablePruneStats{}
+			if err := st.preparePortableThreadPayloads(ctx, PortablePruneOptions{BodyChars: 8, DeferSecureRewrite: tc.deferRewrite}, &stats); err != nil {
+				t.Fatalf("prepare portable thread payloads: %v", err)
+			}
+			var body, excerpt, threadRaw, repositoryRaw string
+			var length int
+			if err := st.DB().QueryRowContext(ctx, `select body, body_excerpt, body_length, raw_json from threads where id = 1`).Scan(&body, &excerpt, &length, &threadRaw); err != nil {
+				t.Fatalf("read prepared thread: %v", err)
+			}
+			if err := st.DB().QueryRowContext(ctx, `select raw_json from repositories where id = 1`).Scan(&repositoryRaw); err != nil {
+				t.Fatalf("read prepared repository: %v", err)
+			}
+			if body != tc.wantBody || excerpt != "abcdefgh" || length != 26 || threadRaw != tc.wantThreadRaw || repositoryRaw != tc.wantRepositoryRaw {
+				t.Fatalf("prepared body=%q excerpt=%q length=%d thread_raw=%q repository_raw=%q", body, excerpt, length, threadRaw, repositoryRaw)
+			}
+		})
+	}
+}
+
+func TestPortablePruneDeferredRewriteVisibleEquivalence(t *testing.T) {
+	ctx := context.Background()
+	legacy := seedPortableDeferredStore(t, ctx, filepath.Join(t.TempDir(), "legacy.db"))
+	deferred := seedPortableDeferredStore(t, ctx, filepath.Join(t.TempDir(), "deferred.db"))
+	defer legacy.Close()
+	defer deferred.Close()
+	if _, err := legacy.PrunePortablePayloads(ctx, PortablePruneOptions{BodyChars: 8, Vacuum: false}); err != nil {
+		t.Fatalf("legacy prune: %v", err)
+	}
+	if _, err := deferred.PrunePortablePayloads(ctx, PortablePruneOptions{BodyChars: 8, Vacuum: false, DeferSecureRewrite: true}); err != nil {
+		t.Fatalf("deferred prune: %v", err)
+	}
+	for _, st := range []*Store{legacy, deferred} {
+		if st.hasColumn(ctx, "threads", "body") || st.hasColumn(ctx, "threads", "raw_json") || st.hasColumn(ctx, "repositories", "raw_json") {
+			t.Fatal("portable shaping retained removed payload columns")
+		}
+	}
+	legacyVisible := portableVisibleState(t, ctx, legacy)
+	deferredVisible := portableVisibleState(t, ctx, deferred)
+	if !reflect.DeepEqual(legacyVisible, deferredVisible) {
+		t.Fatalf("visible portable state differs:\nlegacy=%#v\ndeferred=%#v", legacyVisible, deferredVisible)
+	}
+}
+
+type portableVisible struct {
+	BodyExcerpt string
+	BodyLength  int
+	CommentBody string
+	Metadata    map[string]string
+	Tables      []string
+}
+
+func portableVisibleState(t *testing.T, ctx context.Context, st *Store) portableVisible {
+	t.Helper()
+	var visible portableVisible
+	if err := st.DB().QueryRowContext(ctx, `select body_excerpt, body_length from threads where id = 1`).Scan(&visible.BodyExcerpt, &visible.BodyLength); err != nil {
+		t.Fatalf("read portable thread state: %v", err)
+	}
+	if err := st.DB().QueryRowContext(ctx, `select body from comments where id = 1`).Scan(&visible.CommentBody); err != nil {
+		t.Fatalf("read portable comment state: %v", err)
+	}
+	visible.Metadata = make(map[string]string)
+	for _, key := range []string{"schema", "body_chars", "capabilities", "includes", "excluded", "thread_author_profile"} {
+		var value string
+		if err := st.DB().QueryRowContext(ctx, `select value from portable_metadata where key = ?`, key).Scan(&value); err != nil {
+			t.Fatalf("read portable metadata %s: %v", key, err)
+		}
+		visible.Metadata[key] = value
+	}
+	rows, err := st.DB().QueryContext(ctx, `select name from sqlite_schema where type = 'table' and name not like 'sqlite_%' order by name`)
+	if err != nil {
+		t.Fatalf("list portable tables: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var table string
+		if err := rows.Scan(&table); err != nil {
+			t.Fatalf("scan portable table: %v", err)
+		}
+		visible.Tables = append(visible.Tables, table)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read portable tables: %v", err)
+	}
+	return visible
+}
+
+func seedPortableDeferredStore(t *testing.T, ctx context.Context, dbPath string) *Store {
+	t.Helper()
+	st, err := Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open portable test store: %v", err)
+	}
+	_, err = st.DB().ExecContext(ctx, `
+		insert into repositories(id, owner, name, full_name, raw_json, updated_at)
+		values(1, 'openclaw', 'gitcrawl', 'openclaw/gitcrawl', '{"repository":true}', '2026-08-09T00:00:00Z');
+		insert into threads(id, repo_id, github_id, number, kind, state, title, body, html_url, labels_json, assignees_json, raw_json, content_hash, updated_at)
+		values(1, 1, 'T1', 1, 'issue', 'open', 'portable', 'abcdefghijklmnopqrstuvwxyz', 'https://github.com/openclaw/gitcrawl/issues/1', '[]', '[]', '{"thread":true}', 'hash', '2026-08-09T00:00:00Z');
+		insert into comments(id, thread_id, github_id, comment_type, body, raw_json)
+		values(1, 1, 'C1', 'issue_comment', 'comment-payload', '{}');
+	`)
+	if err != nil {
+		_ = st.Close()
+		t.Fatalf("seed portable test store: %v", err)
+	}
+	return st
+}

--- a/internal/store/portable_deferred_test.go
+++ b/internal/store/portable_deferred_test.go
@@ -82,8 +82,9 @@ func TestPortablePruneDeferredRewriteVisibleEquivalence(t *testing.T) {
 	if !retained.hasColumn(ctx, "repositories", "raw_json") || !retained.hasColumn(ctx, "threads", "raw_json") || !retained.hasColumn(ctx, "threads", "body") {
 		t.Fatal("sanitized compatibility columns were physically dropped")
 	}
-	if len(retainedStats.DroppedColumns) != 0 {
-		t.Fatalf("retained-column dropped stats = %v", retainedStats.DroppedColumns)
+	wantDroppedColumns := []string{"comments.raw_json_blob_id", "thread_revisions.raw_json_blob_id"}
+	if !slices.Equal(retainedStats.DroppedColumns, wantDroppedColumns) {
+		t.Fatalf("retained-column dropped stats = %v, want %v", retainedStats.DroppedColumns, wantDroppedColumns)
 	}
 	var repositoryRaw, threadRaw, body, excerpt, columnProfile string
 	if err := retained.DB().QueryRowContext(ctx, `select raw_json from repositories where id = 1`).Scan(&repositoryRaw); err != nil {
@@ -149,6 +150,7 @@ func TestPortablePruneRetainedColumnProgressStagesOrdered(t *testing.T) {
 		PortablePruneStageFingerprintsSummaries,
 		PortablePruneStageDiscardedData,
 		PortablePruneStageCanonicalSchemaFinalization,
+		PortablePruneStageDisposableTableDrop,
 		PortablePruneStageThreadsRebuildPreflight,
 		PortablePruneStageThreadsRebuildForeignKeys,
 		PortablePruneStageThreadsRebuildCompactCopy,

--- a/internal/store/portable_deferred_test.go
+++ b/internal/store/portable_deferred_test.go
@@ -127,6 +127,39 @@ func TestPortablePruneProgressStagesOrdered(t *testing.T) {
 	}
 }
 
+func TestPortablePruneRetainedColumnProgressStagesOrdered(t *testing.T) {
+	ctx := context.Background()
+	st := seedPortableDeferredStore(t, ctx, filepath.Join(t.TempDir(), "retained-progress.db"))
+	defer st.Close()
+	var stages []PortablePruneStage
+	if _, err := st.PrunePortablePayloads(ctx, PortablePruneOptions{
+		BodyChars:                     8,
+		DeferSecureRewrite:            true,
+		RetainSanitizedPayloadColumns: true,
+		Progress: func(stage PortablePruneStage) {
+			stages = append(stages, stage)
+		},
+	}); err != nil {
+		t.Fatalf("retained-column prune with progress: %v", err)
+	}
+	want := []PortablePruneStage{
+		PortablePruneStageThreadBodies,
+		PortablePruneStageCommentReviewBodies,
+		PortablePruneStageMetadataRawPayloads,
+		PortablePruneStageFingerprintsSummaries,
+		PortablePruneStageDiscardedData,
+		PortablePruneStageCanonicalSchemaFinalization,
+		PortablePruneStageThreadsRebuildPreflight,
+		PortablePruneStageThreadsRebuildForeignKeys,
+		PortablePruneStageThreadsRebuildCompactCopy,
+		PortablePruneStageThreadsRebuildSchemaSwap,
+		PortablePruneStageThreadsRebuildSchemaRestore,
+	}
+	if !slices.Equal(stages, want) {
+		t.Fatalf("retained-column prune stages = %v, want %v", stages, want)
+	}
+}
+
 func TestPortablePrunePhysicalDropClearsCompatibilityColumnProfile(t *testing.T) {
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "column-profile.db")

--- a/internal/store/portable_deferred_test.go
+++ b/internal/store/portable_deferred_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -62,6 +63,33 @@ func TestPortablePruneDeferredRewriteVisibleEquivalence(t *testing.T) {
 	deferredVisible := portableVisibleState(t, ctx, deferred)
 	if !reflect.DeepEqual(legacyVisible, deferredVisible) {
 		t.Fatalf("visible portable state differs:\nlegacy=%#v\ndeferred=%#v", legacyVisible, deferredVisible)
+	}
+}
+
+func TestPortablePruneProgressStagesOrdered(t *testing.T) {
+	ctx := context.Background()
+	st := seedPortableDeferredStore(t, ctx, filepath.Join(t.TempDir(), "progress.db"))
+	defer st.Close()
+	var stages []PortablePruneStage
+	if _, err := st.PrunePortablePayloads(ctx, PortablePruneOptions{
+		BodyChars:          8,
+		DeferSecureRewrite: true,
+		Progress: func(stage PortablePruneStage) {
+			stages = append(stages, stage)
+		},
+	}); err != nil {
+		t.Fatalf("prune with progress: %v", err)
+	}
+	want := []PortablePruneStage{
+		PortablePruneStageThreadBodies,
+		PortablePruneStageCommentReviewBodies,
+		PortablePruneStageMetadataRawPayloads,
+		PortablePruneStageFingerprintsSummaries,
+		PortablePruneStageDiscardedData,
+		PortablePruneStageCanonicalSchema,
+	}
+	if !slices.Equal(stages, want) {
+		t.Fatalf("portable prune stages = %v, want %v", stages, want)
 	}
 }
 

--- a/internal/store/portable_failure_paths_test.go
+++ b/internal/store/portable_failure_paths_test.go
@@ -1,0 +1,924 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestPortableSQLTokenizerRejectsMalformedSchema(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		value     string
+		wantError string
+	}{
+		{name: "comment", value: "select /* missing", wantError: "unterminated SQL comment"},
+		{name: "single quote", value: "select 'missing", wantError: "unterminated SQL quote"},
+		{name: "double quote", value: `select "missing`, wantError: "unterminated SQL quote"},
+		{name: "backtick", value: "select `missing", wantError: "unterminated SQL quote"},
+		{name: "bracket", value: "select [missing", wantError: "unterminated SQL bracket identifier"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := tokenizePortableSQL(test.value); err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("tokenize error = %v, want %q", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestPortableSQLTokenizerPreservesQuotedIdentifiersAndLiterals(t *testing.T) {
+	tokens, err := tokenizePortableSQL("-- ignored\n SELECT 'it''s', \"table\"\"name\", `tick``name`, [bracket-name], schema.table $value /* ignored */;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var values []string
+	var literals int
+	for _, token := range tokens {
+		values = append(values, token.value)
+		if token.literal {
+			literals++
+		}
+	}
+	joined := strings.Join(values, "|")
+	for _, want := range []string{"it's", `table"name`, "tick`name", "bracket-name", "schema", "table", "$value"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("tokenized values %q do not contain %q", joined, want)
+		}
+	}
+	if literals != 1 {
+		t.Fatalf("literal token count = %d, want 1", literals)
+	}
+}
+
+func TestPortableSQLTableIdentifierShapes(t *testing.T) {
+	tests := []struct {
+		name     string
+		tokens   []portableSQLToken
+		wantName string
+		wantUsed int
+	}{
+		{name: "empty"},
+		{name: "subquery", tokens: []portableSQLToken{{value: "("}}},
+		{name: "simple", tokens: []portableSQLToken{{value: "documents"}}, wantName: "documents", wantUsed: 1},
+		{name: "qualified", tokens: []portableSQLToken{{value: "main"}, {value: "."}, {value: "documents"}}, wantName: "documents", wantUsed: 3},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			name, used := portableSQLTableIdentifier(test.tokens)
+			if name != test.wantName || used != test.wantUsed {
+				t.Fatalf("identifier = %q/%d, want %q/%d", name, used, test.wantName, test.wantUsed)
+			}
+		})
+	}
+}
+
+func TestPortableTriggerDependencyRejectsMalformedDefinitions(t *testing.T) {
+	dropped := map[string]bool{"documents": true}
+	for _, test := range []struct {
+		name      string
+		sql       string
+		wantError string
+	}{
+		{name: "tokenization", sql: "create trigger broken /*", wantError: "unterminated SQL comment"},
+		{name: "missing body", sql: "create trigger broken after update on repositories", wantError: "unrecognized trigger body"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := portableTriggerDroppedDependency(test.sql, dropped); err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("trigger dependency error = %v, want %q", err, test.wantError)
+			}
+		})
+	}
+
+	updates, err := portableTriggerUpdatesThreads("create trigger broken /*")
+	if err == nil || updates {
+		t.Fatalf("malformed update trigger result = %v, %v", updates, err)
+	}
+}
+
+func TestPortableDependencyScannerHandlesDMLAndNestedSources(t *testing.T) {
+	dropped := map[string]bool{"documents": true}
+	statements := []string{
+		`delete from documents where id = 1`,
+		`update or abort main.documents set title = 'x'`,
+		`insert or replace into documents(id) values(1)`,
+		`select * from (select * from documents) nested`,
+		`select * from repositories where exists(select 1 from documents)`,
+		`select * from repositories union select * from documents`,
+	}
+	for _, statement := range statements {
+		tokens, err := tokenizePortableSQL(statement)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if dependency := portableDroppedTableDependency(tokens, dropped); !strings.EqualFold(dependency, "documents") {
+			t.Fatalf("dependency for %q = %q, want documents", statement, dependency)
+		}
+	}
+
+	tokens, err := tokenizePortableSQL(`select * from (select 1`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if end := portableSQLMatchingParenthesis(tokens, 3); end != len(tokens)-1 {
+		t.Fatalf("unmatched parenthesis ended at %d, want %d", end, len(tokens)-1)
+	}
+}
+
+func TestPortableForeignKeyTransformSafetyContracts(t *testing.T) {
+	verbatim := map[string]bool{"id": true, "repo_id": true, "parent_id": true}
+	valid := []portableForeignKeyDefinition{
+		{fromColumn: "repo_id", referencedTable: "repositories", toColumn: "id"},
+		{fromColumn: "parent_id", referencedTable: "threads", toColumn: ""},
+		{fromColumn: "repo_id", referencedTable: "THREADS", toColumn: "repo_id"},
+	}
+	if err := validatePortableThreadsForeignKeyTransformSafety(valid, verbatim); err != nil {
+		t.Fatalf("safe foreign keys rejected: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		definition portableForeignKeyDefinition
+		wantError  string
+	}{
+		{
+			name:       "transformed source",
+			definition: portableForeignKeyDefinition{fromColumn: "body", referencedTable: "repositories", toColumn: "id"},
+			wantError:  "foreign key from transformed threads column body",
+		},
+		{
+			name:       "transformed self target",
+			definition: portableForeignKeyDefinition{fromColumn: "parent_id", referencedTable: "threads", toColumn: "body"},
+			wantError:  "self-referencing foreign key targeting transformed threads column body",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validatePortableThreadsForeignKeyTransformSafety([]portableForeignKeyDefinition{test.definition}, verbatim)
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("foreign key safety error = %v, want %q", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestPortablePragmaSettersFailClosed(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "pragma.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if err := setPortableForeignKeys(ctx, conn, 2); err == nil || !strings.Contains(err.Error(), "invalid portable foreign_keys") {
+		t.Fatalf("invalid foreign_keys error = %v", err)
+	}
+	if err := setPortableJournalMode(ctx, conn, "unknown"); err == nil || !strings.Contains(err.Error(), "invalid portable journal_mode") {
+		t.Fatalf("invalid journal mode error = %v", err)
+	}
+
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+	if err := setPortableForeignKeys(canceled, conn, 1); err == nil {
+		t.Fatal("canceled foreign_keys change succeeded")
+	}
+	if err := setPortableJournalMode(canceled, conn, "memory"); err == nil {
+		t.Fatal("canceled journal mode change succeeded")
+	}
+
+	if _, err := conn.ExecContext(ctx, `pragma foreign_keys = on; begin`); err != nil {
+		t.Fatal(err)
+	}
+	defer conn.ExecContext(context.Background(), `rollback`)
+	if err := setPortableForeignKeys(ctx, conn, 0); err == nil || !strings.Contains(err.Error(), "pragma remained") {
+		t.Fatalf("ignored in-transaction foreign_keys change error = %v", err)
+	}
+}
+
+func TestPortableStoreHelpersPropagateCancellation(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "canceled.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+
+	checks := []struct {
+		name string
+		run  func() error
+	}{
+		{name: "repository scope", run: func() error { _, err := st.RestrictPortableRepository(canceled, "openclaw/gitcrawl"); return err }},
+		{name: "table names", run: func() error { _, err := portableTableNames(canceled, st.DB()); return err }},
+		{name: "column set", run: func() error { _, err := portableTableColumnSet(canceled, st.DB(), "threads"); return err }},
+		{name: "foreign key count", run: func() error { _, err := portableForeignKeyViolationCount(canceled, st.DB()); return err }},
+		{name: "schema table name", run: func() error { _, _, err := portableSchemaTableName(canceled, st.DB(), "threads"); return err }},
+		{name: "retained dependencies", run: func() error {
+			return validatePortableRetainedSchemaDependencies(canceled, st.DB(), []string{"documents"})
+		}},
+		{name: "bulk drop", run: func() error { return st.dropCanonicalPortableTablesBulk(canceled, false, &PortablePruneStats{}, nil) }},
+		{name: "threads rebuild", run: func() error { _, err := st.rebuildPortableCompatibilityThreads(canceled); return err }},
+		{name: "threads sequence", run: func() error { _, err := portableThreadsSequence(canceled, st.DB()); return err }},
+		{name: "threads identity", run: func() error { _, err := portableThreadsIdentityForTable(canceled, st.DB(), "threads"); return err }},
+		{name: "foreign keys", run: func() error { _, err := portableForeignKeysForTable(canceled, st.DB(), "threads"); return err }},
+		{name: "child foreign keys", run: func() error { _, err := portableChildForeignKeysReferencingThreads(canceled, st.DB()); return err }},
+		{name: "rebuild columns", run: func() error { _, _, _, err := portableThreadsRebuildColumns(canceled, st.DB()); return err }},
+		{name: "rebuild indexes", run: func() error { _, _, err := portableThreadsRebuildIndexes(canceled, st.DB()); return err }},
+		{name: "rebuild triggers", run: func() error { _, err := portableThreadsRebuildTriggers(canceled, st.DB()); return err }},
+	}
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			if err := check.run(); err == nil {
+				t.Fatal("canceled store operation succeeded")
+			}
+		})
+	}
+}
+
+func TestRestrictPortableRepositoryFutureSchemaColumns(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "future-schema.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	if _, err := st.DB().ExecContext(ctx, `
+		insert into repositories(id, owner, name, full_name, raw_json, updated_at)
+		values(1, 'openclaw', 'keep', 'openclaw/keep', '{}', '2026-08-09T00:00:00Z'),
+		      (2, 'openclaw', 'drop', 'openclaw/drop', '{}', '2026-08-09T00:00:00Z');
+		insert into threads(id, repo_id, github_id, number, kind, state, title, html_url, labels_json, assignees_json, raw_json, content_hash, updated_at)
+		values(1, 1, 'keep', 1, 'issue', 'open', 'keep', 'https://example.test/1', '[]', '[]', '{}', 'keep', '2026-08-09T00:00:00Z'),
+		      (2, 2, 'drop', 2, 'issue', 'open', 'drop', 'https://example.test/2', '[]', '[]', '{}', 'drop', '2026-08-09T00:00:00Z');
+		create table future_repo_data(id integer primary key, repo_id integer, payload text);
+		create table future_thread_data(id integer primary key, thread_id integer, payload text);
+		insert into future_repo_data values(1, 1, 'keep'), (2, 2, 'drop');
+		insert into future_thread_data values(1, 1, 'keep'), (2, 2, 'drop');
+	`); err != nil {
+		t.Fatal(err)
+	}
+	result, err := st.RestrictPortableRepositoryWithOptions(ctx, "openclaw/keep", PortableRepositoryScopeOptions{DeferForeignKeyValidation: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RepositoriesRemoved != 1 {
+		t.Fatalf("repositories removed = %d, want 1", result.RepositoriesRemoved)
+	}
+	for _, table := range []string{"future_repo_data", "future_thread_data"} {
+		var count int
+		var payload string
+		if err := st.DB().QueryRowContext(ctx, `select count(*), payload from `+sqliteIdentifier(table)).Scan(&count, &payload); err != nil {
+			t.Fatal(err)
+		}
+		if count != 1 || payload != "keep" {
+			t.Fatalf("%s retained count/payload = %d/%q", table, count, payload)
+		}
+	}
+}
+
+func TestPortableRuntimeIdentifierRejectsNUL(t *testing.T) {
+	if _, err := portableRuntimeIdentifier("bad\x00name"); err == nil {
+		t.Fatal("runtime identifier with NUL succeeded")
+	}
+	if got, err := portableRuntimeIdentifier(`report"name`); err != nil || got != `"report""name"` {
+		t.Fatalf("quoted runtime identifier = %q, %v", got, err)
+	}
+}
+
+func TestValidatePortableRetainedSchemaDependenciesNoDrops(t *testing.T) {
+	if err := validatePortableRetainedSchemaDependencies(context.Background(), nil, nil); err != nil {
+		t.Fatalf("empty dropped set queried database: %v", err)
+	}
+}
+
+func TestPortableChildForeignKeyTargetDefaultsToID(t *testing.T) {
+	if err := validatePortableChildForeignKeyIdentityTargets([]portableForeignKeyDefinition{{ownerTable: "child", fromColumn: "thread_id"}}); err != nil {
+		t.Fatalf("implicit primary-key target rejected: %v", err)
+	}
+	err := validatePortableChildForeignKeyIdentityTargets([]portableForeignKeyDefinition{{ownerTable: "child", fromColumn: "body", toColumn: "body"}})
+	if err == nil || !strings.Contains(err.Error(), "referencing mutable threads column body") {
+		t.Fatalf("mutable child target error = %v", err)
+	}
+}
+
+func TestPortableCanceledErrorRemainsDiscoverable(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "closed.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	_, err = portableTableNames(ctx, db)
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("portable cancellation error = %v", err)
+	}
+}
+
+func TestPortablePayloadCompactionEdgeCases(t *testing.T) {
+	if got := compactPortableReviewComments("not-json", 8); got != "[]" {
+		t.Fatalf("malformed review comments compacted to %q", got)
+	}
+	got := compactPortableReviewComments(`[{"body":"abcdefghijk","nested":{"bodyText":"123456789","body":7},"other":"preserved"}]`, 5)
+	if got != `[{"body":"abcde","nested":{"body":7,"bodyText":"12345"},"other":"preserved"}]` {
+		t.Fatalf("nested review comments compacted to %q", got)
+	}
+	if got := truncatePortableText("abcdef", 0); got != "" {
+		t.Fatalf("zero-limit text = %q", got)
+	}
+	if got := truncatePortableText("short", 8); got != "short" {
+		t.Fatalf("short text = %q", got)
+	}
+	if got := truncatePortableText("åßçdé", 3); got != "åßç" {
+		t.Fatalf("rune-safe text = %q", got)
+	}
+
+	nameTests := []struct {
+		name  string
+		raw   string
+		field string
+		want  string
+	}{
+		{name: "malformed", raw: "{", field: "name", want: "{"},
+		{name: "strings", raw: `[" bug ","feature"]`, field: "name", want: `["bug","feature"]`},
+		{name: "objects", raw: `[{"name":" bug "},{"name":"feature"}]`, field: "name", want: `["bug","feature"]`},
+		{name: "wrong type", raw: `[7]`, field: "name", want: `[7]`},
+		{name: "missing field", raw: `[{"color":"red"}]`, field: "name", want: `[{"color":"red"}]`},
+	}
+	for _, test := range nameTests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := compactPortableNameList(test.raw, test.field); got != test.want {
+				t.Fatalf("compact name list = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestPortablePayloadHelpersHandleMissingAndExistingColumns(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "payload-helpers.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.ExecContext(ctx, `create table threads(id integer primary key); create table custom_payload(id integer primary key)`); err != nil {
+		t.Fatal(err)
+	}
+	st := &Store{db: db, path: "payload-helpers.db"}
+	labels, assignees, err := st.compactPortableThreadMetadata(ctx)
+	if err != nil || labels != 0 || assignees != 0 {
+		t.Fatalf("missing metadata columns result = %d/%d, %v", labels, assignees, err)
+	}
+	if err := st.ensurePortableExcerptColumns(ctx, "custom_payload"); err != nil {
+		t.Fatal(err)
+	}
+	if !st.hasColumn(ctx, "custom_payload", "body_excerpt") || !st.hasColumn(ctx, "custom_payload", "body_length") {
+		t.Fatal("excerpt helper did not add compatibility columns")
+	}
+	if err := st.ensurePortableExcerptColumns(ctx, "custom_payload"); err != nil {
+		t.Fatalf("idempotent excerpt helper: %v", err)
+	}
+}
+
+func TestPortablePayloadHelpersPropagateCancellation(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "payload-canceled.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+	checks := []struct {
+		name string
+		run  func() error
+	}{
+		{name: "vacuum", run: func() error { return st.vacuumPortableDatabase(canceled) }},
+		{name: "metadata", run: func() error { return st.ensurePortableMetadata(canceled) }},
+		{name: "canonical schema", run: func() error {
+			return st.canonicalizePortableSchema(canceled, PortablePruneOptions{}, &PortablePruneStats{})
+		}},
+	}
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			if err := check.run(); err == nil {
+				t.Fatal("canceled payload operation succeeded")
+			}
+		})
+	}
+}
+
+func TestRestrictPortableRepositoryRollsBackFutureSchemaDeleteFailure(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "scope-rollback.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	if _, err := st.DB().ExecContext(ctx, `
+		insert into repositories(id, owner, name, full_name, raw_json, updated_at)
+		values(1, 'openclaw', 'keep', 'openclaw/keep', '{}', '2026-08-09T00:00:00Z'),
+		      (2, 'openclaw', 'drop', 'openclaw/drop', '{}', '2026-08-09T00:00:00Z');
+		insert into threads(id, repo_id, github_id, number, kind, state, title, html_url, labels_json, assignees_json, raw_json, content_hash, updated_at)
+		values(1, 1, 'keep', 1, 'issue', 'open', 'keep', 'https://example.test/1', '[]', '[]', '{}', 'keep', '2026-08-09T00:00:00Z'),
+		      (2, 2, 'drop', 2, 'issue', 'open', 'drop', 'https://example.test/2', '[]', '[]', '{}', 'drop', '2026-08-09T00:00:00Z');
+		create table future_guarded(id integer primary key, repo_id integer, payload text);
+		insert into future_guarded values(1, 1, 'keep'), (2, 2, 'drop');
+		create trigger reject_future_delete before delete on future_guarded
+		when old.repo_id = 2 begin select raise(abort, 'guarded future row'); end;
+	`); err != nil {
+		t.Fatal(err)
+	}
+	_, err = st.RestrictPortableRepository(ctx, "openclaw/keep")
+	if err == nil || !strings.Contains(err.Error(), "delete out-of-scope portable rows from future_guarded") {
+		t.Fatalf("future schema delete error = %v", err)
+	}
+	var repositories, futureRows int
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from repositories`).Scan(&repositories); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from future_guarded`).Scan(&futureRows); err != nil {
+		t.Fatal(err)
+	}
+	if repositories != 2 || futureRows != 2 {
+		t.Fatalf("failed scope persisted repositories/future rows = %d/%d", repositories, futureRows)
+	}
+}
+
+func TestRestrictPortableRepositoryReportsRetainedForeignKeyViolation(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "scope-fk.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	if _, err := st.DB().ExecContext(ctx, `
+		insert into repositories(id, owner, name, full_name, raw_json, updated_at)
+		values(1, 'openclaw', 'keep', 'openclaw/keep', '{}', '2026-08-09T00:00:00Z');
+		pragma foreign_keys = off;
+		insert into pull_request_checks(id, thread_id, name, status, raw_json, fetched_at)
+		values(99, 999, 'orphan', 'completed', '{}', '2026-08-09T00:00:00Z');
+		pragma foreign_keys = on;
+	`); err != nil {
+		t.Fatal(err)
+	}
+	_, err = st.RestrictPortableRepository(ctx, "openclaw/keep")
+	if err == nil || !strings.Contains(err.Error(), "left 1 foreign-key violations") {
+		t.Fatalf("retained foreign-key violation error = %v", err)
+	}
+}
+
+func TestRestrictPortableRepositoryRejectsIncompleteFutureSchemas(t *testing.T) {
+	tests := []struct {
+		name      string
+		schema    string
+		wantError string
+	}{
+		{
+			name:      "missing threads",
+			schema:    ``,
+			wantError: "capture out-of-scope portable threads",
+		},
+		{
+			name:      "missing revisions",
+			schema:    `create table threads(id integer primary key, repo_id integer not null);`,
+			wantError: "capture out-of-scope portable revisions",
+		},
+		{
+			name: "missing clusters",
+			schema: `
+				create table threads(id integer primary key, repo_id integer not null);
+				create table thread_revisions(id integer primary key, thread_id integer not null);
+			`,
+			wantError: "capture out-of-scope portable clusters",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "incomplete.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			if _, err := db.ExecContext(ctx, `
+				create table repositories(id integer primary key, owner text, name text, full_name text);
+				insert into repositories values(1, 'openclaw', 'keep', 'openclaw/keep');
+			`+test.schema); err != nil {
+				t.Fatal(err)
+			}
+			st := &Store{db: db, path: "incomplete.db"}
+			_, err = st.RestrictPortableRepository(ctx, "openclaw/keep")
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("incomplete schema error = %v, want %q", err, test.wantError)
+			}
+			var repositories int
+			if err := db.QueryRowContext(ctx, `select count(*) from repositories`).Scan(&repositories); err != nil {
+				t.Fatal(err)
+			}
+			if repositories != 1 {
+				t.Fatalf("incomplete schema changed repository count to %d", repositories)
+			}
+		})
+	}
+}
+
+func TestRestrictPortableRepositoryRejectsNullIdentityWithoutMutation(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "null-identity.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.ExecContext(ctx, `
+		create table repositories(id integer primary key, owner text, name text, full_name text);
+		insert into repositories values(1, null, 'keep', 'openclaw/keep');
+	`); err != nil {
+		t.Fatal(err)
+	}
+	st := &Store{db: db, path: "null-identity.db"}
+	_, err = st.RestrictPortableRepository(ctx, "openclaw/keep")
+	if err == nil || !strings.Contains(err.Error(), "read portable target repository") {
+		t.Fatalf("null repository identity error = %v", err)
+	}
+	var count int
+	if err := db.QueryRowContext(ctx, `select count(*) from repositories`).Scan(&count); err != nil || count != 1 {
+		t.Fatalf("null identity repository count = %d, %v", count, err)
+	}
+}
+
+func TestPortablePayloadMutationFailuresPreserveSensitiveRows(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name      string
+		schema    string
+		run       func(*Store) error
+		read      string
+		wantValue any
+		wantError string
+	}{
+		{
+			name: "thread excerpt",
+			schema: `
+				create table threads(id integer primary key, body text, raw_json text, body_excerpt text, body_length integer not null default 0);
+				insert into threads values(1, 'private body', '{}', null, 0);
+				create trigger reject_excerpt before update of body_excerpt on threads begin select raise(abort, 'reject excerpt'); end;
+			`,
+			run: func(st *Store) error {
+				_, err := st.PrunePortablePayloads(ctx, PortablePruneOptions{BodyChars: 4, DeferSecureRewrite: true})
+				return err
+			},
+			read:      `select body from threads where id = 1`,
+			wantValue: "private body",
+			wantError: "prune thread body excerpts",
+		},
+		{
+			name: "comment body",
+			schema: `
+				create table comments(id integer primary key, body text, body_excerpt text, body_length integer not null default 0);
+				insert into comments values(1, 'private comment', null, 0);
+				create trigger reject_comment before update of body on comments begin select raise(abort, 'reject comment'); end;
+			`,
+			run: func(st *Store) error {
+				_, err := st.PrunePortablePayloads(ctx, PortablePruneOptions{BodyChars: 4, DeferSecureRewrite: true})
+				return err
+			},
+			read:      `select body from comments where id = 1`,
+			wantValue: "private comment",
+			wantError: "prune comment bodies",
+		},
+		{
+			name: "comment revision body",
+			schema: `
+				create table comment_revisions(id integer primary key, body text);
+				insert into comment_revisions values(1, 'private revision');
+				create trigger reject_revision before update of body on comment_revisions begin select raise(abort, 'reject revision'); end;
+			`,
+			run: func(st *Store) error {
+				_, err := st.PrunePortablePayloads(ctx, PortablePruneOptions{BodyChars: 4, DeferSecureRewrite: true})
+				return err
+			},
+			read:      `select body from comment_revisions where id = 1`,
+			wantValue: "private revision",
+			wantError: "prune comment revision bodies",
+		},
+		{
+			name: "thread metadata",
+			schema: `
+				create table threads(id integer primary key, labels_json text, assignees_json text);
+				insert into threads values(1, '[{"name":"bug"}]', '[{"login":"octocat"}]');
+				create trigger reject_metadata before update of labels_json on threads begin select raise(abort, 'reject metadata'); end;
+			`,
+			run: func(st *Store) error {
+				_, err := st.PrunePortablePayloads(ctx, PortablePruneOptions{BodyChars: 4, DeferSecureRewrite: true})
+				return err
+			},
+			read:      `select labels_json from threads where id = 1`,
+			wantValue: `[{"name":"bug"}]`,
+			wantError: "compact portable thread metadata",
+		},
+		{
+			name: "review bodies",
+			schema: `
+				create table pull_request_review_threads(first_comment_body text, comments_json text);
+				insert into pull_request_review_threads values('private review', '[{"body":"private review"}]');
+				create trigger reject_review before update on pull_request_review_threads begin select raise(abort, 'reject review'); end;
+			`,
+			run: func(st *Store) error {
+				_, err := st.PrunePortablePayloads(ctx, PortablePruneOptions{BodyChars: 4, DeferSecureRewrite: true})
+				return err
+			},
+			read:      `select first_comment_body from pull_request_review_threads`,
+			wantValue: "private review",
+			wantError: "compact portable review bodies",
+		},
+		{
+			name: "raw json",
+			schema: `
+				create table comments(raw_json text);
+				insert into comments values('{"private":true}');
+				create trigger reject_raw before update of raw_json on comments begin select raise(abort, 'reject raw'); end;
+			`,
+			run: func(st *Store) error {
+				_, err := st.PrunePortablePayloads(ctx, PortablePruneOptions{BodyChars: 4, DeferSecureRewrite: true})
+				return err
+			},
+			read:      `select raw_json from comments`,
+			wantValue: `{"private":true}`,
+			wantError: "clear portable raw json comments.raw_json",
+		},
+		{
+			name: "pull request patch",
+			schema: `
+				create table pull_request_files(patch text);
+				insert into pull_request_files values('private patch');
+				create trigger reject_patch before update of patch on pull_request_files begin select raise(abort, 'reject patch'); end;
+			`,
+			run: func(st *Store) error {
+				_, err := st.PrunePortablePayloads(ctx, PortablePruneOptions{BodyChars: 4, DeferSecureRewrite: true})
+				return err
+			},
+			read:      `select patch from pull_request_files`,
+			wantValue: "private patch",
+			wantError: "clear portable pull request file patches",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "payload.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			if _, err := db.ExecContext(ctx, test.schema); err != nil {
+				t.Fatal(err)
+			}
+			st := &Store{db: db, path: "payload.db"}
+			err = test.run(st)
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("payload mutation error = %v, want %q", err, test.wantError)
+			}
+			var got any
+			if err := db.QueryRowContext(ctx, test.read).Scan(&got); err != nil {
+				t.Fatal(err)
+			}
+			if got != test.wantValue {
+				t.Fatalf("failed payload mutation changed value to %#v, want %#v", got, test.wantValue)
+			}
+		})
+	}
+}
+
+func TestPortableSchemaInspectionRejectsUnsafeDefinitions(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("sequence table without threads entry", func(t *testing.T) {
+		db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "sequence.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		if _, err := db.ExecContext(ctx, `create table other(id integer primary key autoincrement)`); err != nil {
+			t.Fatal(err)
+		}
+		sequence, err := portableThreadsSequence(ctx, db)
+		if err != nil || sequence.Valid {
+			t.Fatalf("missing threads sequence = %#v, %v", sequence, err)
+		}
+	})
+
+	t.Run("missing required rebuild column", func(t *testing.T) {
+		db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "columns.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		if _, err := db.ExecContext(ctx, `create table threads(id integer primary key, body text, body_excerpt text)`); err != nil {
+			t.Fatal(err)
+		}
+		_, _, _, err = portableThreadsRebuildColumns(ctx, db)
+		if err == nil || !strings.Contains(err.Error(), "requires column raw_json") {
+			t.Fatalf("missing raw_json rebuild error = %v", err)
+		}
+	})
+
+	t.Run("generated columns stay out of compact copy", func(t *testing.T) {
+		db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "generated.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		if _, err := db.ExecContext(ctx, `create table threads(id integer primary key, body text, body_excerpt text, raw_json text, generated text generated always as (body || raw_json) virtual)`); err != nil {
+			t.Fatal(err)
+		}
+		columns, expressions, _, err := portableThreadsRebuildColumns(ctx, db)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if slices.Contains(columns, `"generated"`) || len(columns) != len(expressions) {
+			t.Fatalf("generated rebuild columns/expressions = %v / %v", columns, expressions)
+		}
+	})
+
+	t.Run("unrecognized unique index SQL", func(t *testing.T) {
+		db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "index.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		if _, err := db.ExecContext(ctx, `
+			create table threads(id integer primary key, value text);
+			create unique index custom_unique on threads(value);
+			pragma writable_schema = on;
+			update sqlite_schema set sql = 'CREATE INDEX custom_unique on threads(value)' where name = 'custom_unique';
+			pragma writable_schema = off;
+		`); err != nil {
+			t.Fatal(err)
+		}
+		_, _, err = portableThreadsRebuildIndexes(ctx, db)
+		if err == nil || !strings.Contains(err.Error(), "has unrecognized SQL") {
+			t.Fatalf("unsafe unique index error = %v", err)
+		}
+	})
+
+	t.Run("unrecognized trigger SQL", func(t *testing.T) {
+		db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "trigger.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer db.Close()
+		if _, err := db.ExecContext(ctx, `
+			create table threads(id integer primary key);
+			create trigger custom_trigger after insert on threads begin select 1; end;
+			pragma writable_schema = on;
+			update sqlite_schema set sql = 'SELECT 1' where name = 'custom_trigger';
+			pragma writable_schema = off;
+		`); err != nil {
+			t.Fatal(err)
+		}
+		_, err = portableThreadsRebuildTriggers(ctx, db)
+		if err == nil || !strings.Contains(err.Error(), "has unrecognized SQL") {
+			t.Fatalf("unsafe trigger error = %v", err)
+		}
+	})
+}
+
+func TestSanitizePortableRepositoryCompatibilityColumnFailsClosed(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "repository-raw.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.ExecContext(ctx, `
+		create table repositories(id integer primary key, raw_json text);
+		insert into repositories values(1, '{"private":true}');
+		create trigger reject_repository_raw before update of raw_json on repositories begin select raise(abort, 'reject raw'); end;
+	`); err != nil {
+		t.Fatal(err)
+	}
+	st := &Store{db: db, path: "repository-raw.db"}
+	if err := st.sanitizePortableRepositoryCompatibilityColumn(ctx); err == nil || !strings.Contains(err.Error(), "sanitize portable repository compatibility column") {
+		t.Fatalf("repository compatibility sanitization error = %v", err)
+	}
+	var rawJSON string
+	if err := db.QueryRowContext(ctx, `select raw_json from repositories`).Scan(&rawJSON); err != nil {
+		t.Fatal(err)
+	}
+	if rawJSON != `{"private":true}` {
+		t.Fatalf("failed compatibility sanitization changed raw JSON to %q", rawJSON)
+	}
+}
+
+func TestValidatePortableRetainedSchemaRejectsMalformedTriggerSQL(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "retained-trigger.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.ExecContext(ctx, `
+		create table retained(id integer primary key);
+		create table disposable(id integer primary key);
+		create trigger retained_trigger after insert on retained begin select 1; end;
+		drop table disposable;
+		pragma writable_schema = on;
+		update sqlite_schema set sql = 'create trigger retained_trigger /*' where name = 'retained_trigger';
+		pragma writable_schema = off;
+	`); err != nil {
+		t.Fatal(err)
+	}
+	err = validatePortableRetainedSchemaDependencies(ctx, db, []string{"disposable"})
+	if err == nil || !strings.Contains(err.Error(), "inspect retained portable trigger retained_trigger") {
+		t.Fatalf("malformed retained trigger error = %v", err)
+	}
+}
+
+func TestCanonicalizePortableSchemaUpgradesLegacyPayloadColumns(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "legacy-columns.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.ExecContext(ctx, `
+		create table repositories(id integer primary key, raw_json text);
+		create table threads(id integer primary key, repo_id integer, body text, raw_json text);
+		insert into repositories values(1, '{"private":true}');
+		insert into threads values(1, 1, 'abcdef', '{"private":true}');
+	`); err != nil {
+		t.Fatal(err)
+	}
+	st := &Store{db: db, path: "legacy-columns.db"}
+	stats := &PortablePruneStats{}
+	if err := st.canonicalizePortableSchema(ctx, PortablePruneOptions{BodyChars: 3}, stats); err != nil {
+		t.Fatalf("canonicalize legacy columns: %v", err)
+	}
+	for _, column := range []struct{ table, name string }{
+		{table: "repositories", name: "raw_json"},
+		{table: "threads", name: "raw_json"},
+		{table: "threads", name: "body"},
+	} {
+		if st.hasColumn(ctx, column.table, column.name) {
+			t.Fatalf("legacy payload column remains: %s.%s", column.table, column.name)
+		}
+	}
+	var excerpt string
+	var bodyLength int
+	if err := db.QueryRowContext(ctx, `select body_excerpt, body_length from threads`).Scan(&excerpt, &bodyLength); err != nil {
+		t.Fatal(err)
+	}
+	if excerpt != "abc" || bodyLength != 0 {
+		t.Fatalf("canonical legacy excerpt/length = %q/%d", excerpt, bodyLength)
+	}
+	if !slices.Contains(stats.DroppedColumns, "threads.body") || !slices.Contains(stats.DroppedColumns, "repositories.raw_json") {
+		t.Fatalf("legacy dropped columns = %v", stats.DroppedColumns)
+	}
+}
+
+func TestEnsurePortableExcerptColumnsRejectsViews(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "excerpt-view.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.ExecContext(ctx, `
+		create table payload(body text);
+		create view missing_excerpt as select body from payload;
+		create view missing_length as select body as body_excerpt from payload;
+	`); err != nil {
+		t.Fatal(err)
+	}
+	st := &Store{db: db, path: "excerpt-view.db"}
+	if err := st.ensurePortableExcerptColumns(ctx, "missing_excerpt"); err == nil || !strings.Contains(err.Error(), "add portable missing_excerpt.body_excerpt") {
+		t.Fatalf("view excerpt alteration error = %v", err)
+	}
+	if err := st.ensurePortableExcerptColumns(ctx, "missing_length"); err == nil || !strings.Contains(err.Error(), "add portable missing_length.body_length") {
+		t.Fatalf("view length alteration error = %v", err)
+	}
+}
+
+func TestPortableThreadsIdentityRejectsNonIntegerIdentity(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "identity-types.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.ExecContext(ctx, `create table threads(id text, repo_id integer); insert into threads values('not-an-integer', 1)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := portableThreadsIdentityForTable(ctx, db, "threads"); err == nil || !strings.Contains(err.Error(), "scan portable threads identity") {
+		t.Fatalf("non-integer identity error = %v", err)
+	}
+}

--- a/internal/store/portable_scope_test.go
+++ b/internal/store/portable_scope_test.go
@@ -1,0 +1,91 @@
+package store
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRestrictPortableRepositoryRemovesDependentCurrentSchemaRows(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, t.TempDir()+"/scope.db")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	statements := []string{
+		`insert into repositories(id, owner, name, full_name, raw_json, updated_at) values(1, 'openclaw', 'keep', 'openclaw/keep', '{}', '2026-08-08T00:00:00Z')`,
+		`insert into repositories(id, owner, name, full_name, raw_json, updated_at) values(2, 'openclaw', 'drop', 'openclaw/drop', '{}', '2026-08-08T00:00:00Z')`,
+		`insert into threads(id, repo_id, github_id, number, kind, state, title, html_url, labels_json, assignees_json, raw_json, content_hash, updated_at) values(1, 1, 'T1', 1, 'pull_request', 'open', 'keep', 'https://github.com/openclaw/keep/pull/1', '[]', '[]', '{}', 'keep', '2026-08-08T00:00:00Z')`,
+		`insert into threads(id, repo_id, github_id, number, kind, state, title, html_url, labels_json, assignees_json, raw_json, content_hash, updated_at) values(2, 2, 'T2', 2, 'pull_request', 'open', 'drop', 'https://github.com/openclaw/drop/pull/2', '[]', '[]', '{}', 'drop', '2026-08-08T00:00:00Z')`,
+		`insert into comments(id, thread_id, github_id, comment_type, body, raw_json) values(1, 1, 'C1', 'issue_comment', 'keep', '{}')`,
+		`insert into comments(id, thread_id, github_id, comment_type, body, raw_json) values(2, 2, 'C2', 'issue_comment', 'drop', '{}')`,
+		`insert into comment_revisions(id, comment_id, body, raw_json, recorded_at) values(1, 1, 'keep history', '{}', '2026-08-08T00:00:00Z')`,
+		`insert into comment_revisions(id, comment_id, body, raw_json, recorded_at) values(2, 2, 'drop history', '{}', '2026-08-08T00:00:00Z')`,
+		`insert into thread_revisions(id, thread_id, content_hash, title_hash, body_hash, labels_hash, created_at) values(1, 1, 'keep', 'keep', 'keep', 'keep', '2026-08-08T00:00:00Z')`,
+		`insert into thread_revisions(id, thread_id, content_hash, title_hash, body_hash, labels_hash, created_at) values(2, 2, 'drop', 'drop', 'drop', 'drop', '2026-08-08T00:00:00Z')`,
+		`insert into thread_fingerprints(id, thread_revision_id, algorithm_version, fingerprint_hash, fingerprint_slug, title_tokens_json, body_token_hash, linked_refs_json, file_set_hash, module_buckets_json, simhash64, feature_json, created_at) values(1, 1, 'v1', 'keep', 'keep', '[]', 'keep', '[]', 'keep', '[]', '1', '{}', '2026-08-08T00:00:00Z')`,
+		`insert into thread_fingerprints(id, thread_revision_id, algorithm_version, fingerprint_hash, fingerprint_slug, title_tokens_json, body_token_hash, linked_refs_json, file_set_hash, module_buckets_json, simhash64, feature_json, created_at) values(2, 2, 'v1', 'drop', 'drop', '[]', 'drop', '[]', 'drop', '[]', '2', '{}', '2026-08-08T00:00:00Z')`,
+		`insert into pull_request_details(thread_id, repo_id, number, raw_json, fetched_at, updated_at) values(1, 1, 1, '{}', '2026-08-08T00:00:00Z', '2026-08-08T00:00:00Z')`,
+		`insert into pull_request_details(thread_id, repo_id, number, raw_json, fetched_at, updated_at) values(2, 2, 2, '{}', '2026-08-08T00:00:00Z', '2026-08-08T00:00:00Z')`,
+	}
+	for _, statement := range statements {
+		if _, err := st.DB().ExecContext(ctx, statement); err != nil {
+			t.Fatalf("seed portable scope with %q: %v", statement, err)
+		}
+	}
+	result, err := st.RestrictPortableRepository(ctx, "openclaw/keep")
+	if err != nil {
+		t.Fatalf("restrict repository: %v", err)
+	}
+	if result.Repository.ID != 1 || result.Repository.FullName != "openclaw/keep" || result.RepositoriesBefore != 2 || result.RepositoriesRemoved != 1 {
+		t.Fatalf("scope result = %+v", result)
+	}
+	for _, table := range []string{"repositories", "threads", "comments", "comment_revisions", "thread_revisions", "thread_fingerprints", "pull_request_details"} {
+		var count int
+		if err := st.DB().QueryRowContext(ctx, `select count(*) from `+sqliteIdentifier(table)).Scan(&count); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		if count != 1 {
+			t.Fatalf("%s rows = %d, want 1", table, count)
+		}
+	}
+	var title, commentBody, history string
+	if err := st.DB().QueryRowContext(ctx, `select title from threads`).Scan(&title); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.DB().QueryRowContext(ctx, `select body from comments`).Scan(&commentBody); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.DB().QueryRowContext(ctx, `select body from comment_revisions`).Scan(&history); err != nil {
+		t.Fatal(err)
+	}
+	if title != "keep" || commentBody != "keep" || history != "keep history" {
+		t.Fatalf("retained data = %q / %q / %q", title, commentBody, history)
+	}
+	violations, err := portableForeignKeyViolationCount(ctx, st.DB())
+	if err != nil || violations != 0 {
+		t.Fatalf("foreign key violations = %d, err=%v", violations, err)
+	}
+}
+
+func TestRestrictPortableRepositoryMissingTargetDoesNotMutate(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, t.TempDir()+"/missing.db")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	if _, err := st.DB().ExecContext(ctx, `insert into repositories(id, owner, name, full_name, raw_json, updated_at) values(1, 'openclaw', 'keep', 'openclaw/keep', '{}', '2026-08-08T00:00:00Z')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.RestrictPortableRepository(ctx, "openclaw/missing"); err == nil {
+		t.Fatal("missing repository restriction succeeded")
+	}
+	var count int
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from repositories`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("missing target mutated repository count to %d", count)
+	}
+}

--- a/internal/store/portable_threads_rebuild_test.go
+++ b/internal/store/portable_threads_rebuild_test.go
@@ -1,0 +1,499 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestPortableThreadsRebuildPreservesSchemaRelationshipsAndUniqueIndexes(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "threads-rebuild.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	statements := []string{
+		`alter table threads add column future_payload text not null default 'future-default'`,
+		`insert into repositories(id, owner, name, full_name, raw_json, updated_at) values(1, 'openclaw', 'gitcrawl', 'openclaw/gitcrawl', '{"large":"repo"}', '2026-08-09T00:00:00Z')`,
+		`insert into threads(
+			id, repo_id, github_id, number, kind, state, title, body,
+			author_login, author_type, author_association, html_url,
+			labels_json, assignees_json, raw_json, content_hash, is_draft,
+			created_at_gh, updated_at_gh, closed_at_gh, merged_at_gh,
+			closed_at_local, close_reason_local, first_pulled_at, last_pulled_at,
+			observation_sequence, evidence_observation_sequence,
+			evidence_source_updated_at, updated_at, future_payload
+		) values(
+			1, 1, 'THREAD-1', 42, 'pull_request', 'closed', 'rebuild thread',
+			'abcdefghijklmnopqrstuvwxyz', 'alice', 'User', 'MEMBER',
+			'https://github.com/openclaw/gitcrawl/pull/42', '[{"name":"bug"}]',
+			'[{"login":"bob"}]', '{"large":"thread"}', 'content-hash', 1,
+			'2026-08-01T00:00:00Z', '2026-08-02T00:00:00Z',
+			'2026-08-03T00:00:00Z', '2026-08-04T00:00:00Z',
+			'2026-08-05T00:00:00Z', 'local close', '2026-08-06T00:00:00Z',
+			'2026-08-07T00:00:00Z', 44, 43, '2026-08-02T00:00:00Z',
+			'2026-08-09T00:00:00Z', 'future-retained'
+		)`,
+		`insert into comments(id, thread_id, github_id, comment_type, body, raw_json) values(1, 1, 'COMMENT-1', 'issue_comment', 'comment-payload-retained', '{}')`,
+		`insert into thread_revisions(id, thread_id, content_hash, title_hash, body_hash, labels_hash, observation_sequence, created_at) values(1, 1, 'revision-content', 'title-hash', 'body-hash', 'labels-hash', 44, '2026-08-09T00:00:00Z')`,
+		`insert into thread_fingerprints(id, thread_revision_id, algorithm_version, fingerprint_hash, fingerprint_slug, title_tokens_json, body_token_hash, linked_refs_json, file_set_hash, module_buckets_json, simhash64, feature_json, created_at) values(1, 1, 'v1', 'fingerprint-retained', 'slug-retained', '[]', 'body-token', '[]', 'files', '[]', '123', '{}', '2026-08-09T00:00:00Z')`,
+		`insert into pull_request_details(thread_id, repo_id, number, base_sha, head_sha, head_ref, additions, deletions, changed_files, raw_json, fetched_at, updated_at) values(1, 1, 42, 'base', 'head', 'feature', 10, 2, 1, '{}', '2026-08-09T00:00:00Z', '2026-08-09T00:00:00Z')`,
+		`insert into pull_request_files(thread_id, position, path, status, additions, deletions, changes, previous_path, patch, raw_json, fetched_at) values(1, 0, 'new.go', 'renamed', 10, 2, 12, 'old.go', '@@ patch', '{}', '2026-08-09T00:00:00Z')`,
+		`insert into pull_request_checks(id, thread_id, name, status, conclusion, details_url, raw_json, fetched_at) values(1, 1, 'CI', 'completed', 'success', 'https://example.test/check', '{}', '2026-08-09T00:00:00Z')`,
+		`insert into pull_request_review_threads(thread_id, review_thread_id, path, line, is_resolved, first_comment_body, comments_json, raw_json, fetched_at) values(1, 'REVIEW-1', 'new.go', 7, 1, 'review-body-retained', '[]', '{}', '2026-08-09T00:00:00Z')`,
+		`insert into pull_request_review_thread_revisions(id, thread_id, review_thread_id, path, line, is_resolved, first_comment_body, comments_json, raw_json, fetched_at, recorded_at) values(1, 1, 'REVIEW-1', 'new.go', 7, 1, 'review-revision-retained', '[]', '{}', '2026-08-09T00:00:00Z', '2026-08-09T00:00:00Z')`,
+		`insert into pull_request_review_thread_syncs(thread_id, fetched_at) values(1, '2026-08-09T00:00:00Z')`,
+		`insert into thread_child_observation_memberships(thread_id, family, observation_sequence, member_ids_json) values(1, 'comments', 44, '["COMMENT-1"]')`,
+		`create index custom_threads_title on threads(title)`,
+		`create unique index unique_threads_github_id on threads(github_id)`,
+		`create table threads_audit(thread_id integer not null)`,
+		`create trigger custom_threads_audit after insert on threads begin insert into threads_audit(thread_id) values(new.id); end`,
+		`update observation_schema_convergence set checked_observation_sequence = 0 where id = 1`,
+	}
+	for _, statement := range statements {
+		if _, err := st.DB().ExecContext(ctx, statement); err != nil {
+			t.Fatalf("seed rebuild with %q: %v", statement, err)
+		}
+	}
+	stats, err := st.PrunePortablePayloads(ctx, PortablePruneOptions{
+		BodyChars:                     12,
+		DeferSecureRewrite:            true,
+		RetainSanitizedPayloadColumns: true,
+	})
+	if err != nil {
+		t.Fatalf("rebuild portable threads: %v", err)
+	}
+	for _, index := range []string{"custom_threads_title", "idx_threads_repo_number", "idx_threads_repo_state_closed", "idx_threads_repo_updated"} {
+		if !slices.Contains(stats.DroppedIndexes, index) {
+			t.Fatalf("dropped thread indexes = %v, missing %s", stats.DroppedIndexes, index)
+		}
+	}
+	if slices.Contains(stats.DroppedIndexes, "unique_threads_github_id") {
+		t.Fatalf("explicit unique index reported dropped: %v", stats.DroppedIndexes)
+	}
+	var title, body, excerpt, rawJSON, authorLogin, authorType, association, futurePayload string
+	var bodyLength, observationSequence, evidenceSequence int
+	if err := st.DB().QueryRowContext(ctx, `
+		select title, body, body_excerpt, body_length, raw_json,
+		       author_login, author_type, author_association, future_payload,
+		       observation_sequence, evidence_observation_sequence
+		from threads where id = 1
+	`).Scan(&title, &body, &excerpt, &bodyLength, &rawJSON, &authorLogin, &authorType, &association, &futurePayload, &observationSequence, &evidenceSequence); err != nil {
+		t.Fatalf("read rebuilt thread: %v", err)
+	}
+	if title != "rebuild thread" || body != "abcdefghijkl" || excerpt != body || bodyLength != 26 || rawJSON != "" || authorLogin != "alice" || authorType != "User" || association != "MEMBER" || futurePayload != "future-retained" || observationSequence != 44 || evidenceSequence != 43 {
+		t.Fatalf("rebuilt thread title=%q body=%q excerpt=%q length=%d raw=%q author=%q/%q/%q future=%q observation=%d/%d", title, body, excerpt, bodyLength, rawJSON, authorLogin, authorType, association, futurePayload, observationSequence, evidenceSequence)
+	}
+	for _, table := range []string{
+		"comments", "thread_revisions", "pull_request_details",
+		"pull_request_files", "pull_request_checks", "pull_request_review_threads",
+		"pull_request_review_thread_revisions", "pull_request_review_thread_syncs",
+		"thread_child_observation_memberships",
+	} {
+		var count int
+		if err := st.DB().QueryRowContext(ctx, `select count(*) from `+sqliteIdentifier(table)+` where thread_id = 1`).Scan(&count); err != nil {
+			t.Fatalf("count retained %s: %v", table, err)
+		}
+		if count != 1 {
+			t.Fatalf("retained %s rows = %d, want 1", table, count)
+		}
+	}
+	var fingerprintCount int
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from thread_fingerprints where thread_revision_id = 1`).Scan(&fingerprintCount); err != nil {
+		t.Fatalf("count retained thread_fingerprints: %v", err)
+	}
+	if fingerprintCount != 1 {
+		t.Fatalf("retained thread_fingerprints rows = %d, want 1", fingerprintCount)
+	}
+	var patch sql.NullString
+	var filePath, fileStatus, previousPath string
+	if err := st.DB().QueryRowContext(ctx, `select path, status, previous_path, patch from pull_request_files where thread_id = 1`).Scan(&filePath, &fileStatus, &previousPath, &patch); err != nil {
+		t.Fatal(err)
+	}
+	if filePath != "new.go" || fileStatus != "renamed" || previousPath != "old.go" || patch.Valid {
+		t.Fatalf("retained PR file=%q/%q/%q patch=%#v", filePath, fileStatus, previousPath, patch)
+	}
+	var commentBody, revisionHash, fingerprintHash, baseSHA, headSHA, checkConclusion, reviewPath, reviewBody, membershipJSON string
+	var reviewResolved int
+	if err := st.DB().QueryRowContext(ctx, `select body from comments where id = 1`).Scan(&commentBody); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.DB().QueryRowContext(ctx, `select content_hash from thread_revisions where id = 1`).Scan(&revisionHash); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.DB().QueryRowContext(ctx, `select fingerprint_hash from thread_fingerprints where id = 1`).Scan(&fingerprintHash); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.DB().QueryRowContext(ctx, `select base_sha, head_sha from pull_request_details where thread_id = 1`).Scan(&baseSHA, &headSHA); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.DB().QueryRowContext(ctx, `select conclusion from pull_request_checks where id = 1`).Scan(&checkConclusion); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.DB().QueryRowContext(ctx, `select path, is_resolved, first_comment_body from pull_request_review_threads where thread_id = 1`).Scan(&reviewPath, &reviewResolved, &reviewBody); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.DB().QueryRowContext(ctx, `select member_ids_json from thread_child_observation_memberships where thread_id = 1 and family = 'comments'`).Scan(&membershipJSON); err != nil {
+		t.Fatal(err)
+	}
+	if commentBody != "comment-payl" || revisionHash != "revision-content" || fingerprintHash != "fingerprint-retained" || baseSHA != "base" || headSHA != "head" || checkConclusion != "success" || reviewPath != "new.go" || reviewResolved != 1 || reviewBody != "review-body-" || membershipJSON != `["COMMENT-1"]` {
+		t.Fatalf("retained child values comment=%q revision=%q fingerprint=%q pr=%q/%q check=%q review=%q/%d/%q membership=%q", commentBody, revisionHash, fingerprintHash, baseSHA, headSHA, checkConclusion, reviewPath, reviewResolved, reviewBody, membershipJSON)
+	}
+	if !indexExistsForPortableTest(t, st.DB(), "unique_threads_github_id") {
+		t.Fatal("explicit unique threads index was not recreated")
+	}
+	if _, err := st.DB().ExecContext(ctx, `insert into threads(repo_id, github_id, number, kind, state, title, html_url, labels_json, assignees_json, raw_json, content_hash, updated_at) values(1, 'THREAD-2', 42, 'pull_request', 'open', 'duplicate tuple', 'https://example.test/2', '[]', '[]', '', 'hash-2', '2026-08-09T00:00:00Z')`); err == nil {
+		t.Fatal("table-declared unique(repo_id,kind,number) was not enforced")
+	}
+	if _, err := st.DB().ExecContext(ctx, `insert into threads(repo_id, github_id, number, kind, state, title, html_url, labels_json, assignees_json, raw_json, content_hash, updated_at) values(1, 'THREAD-1', 43, 'pull_request', 'open', 'duplicate github id', 'https://example.test/3', '[]', '[]', '', 'hash-3', '2026-08-09T00:00:00Z')`); err == nil {
+		t.Fatal("explicit unique threads index was not enforced")
+	}
+	var auditCount int
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from threads_audit`).Scan(&auditCount); err != nil {
+		t.Fatal(err)
+	}
+	if auditCount != 0 {
+		t.Fatalf("bulk rebuild fired custom trigger %d times", auditCount)
+	}
+	if _, err := st.DB().ExecContext(ctx, `insert into threads(repo_id, github_id, number, kind, state, title, html_url, labels_json, assignees_json, raw_json, content_hash, updated_at) values(1, 'THREAD-NEW', 44, 'pull_request', 'open', 'new thread', 'https://example.test/44', '[]', '[]', '', 'hash-44', '2026-08-09T00:00:00Z')`); err != nil {
+		t.Fatalf("insert through recreated custom trigger: %v", err)
+	}
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from threads_audit`).Scan(&auditCount); err != nil {
+		t.Fatal(err)
+	}
+	if auditCount != 1 {
+		t.Fatalf("recreated custom trigger audit rows = %d, want 1", auditCount)
+	}
+	for _, table := range []string{"comments", "thread_revisions", "pull_request_details", "pull_request_files", "pull_request_checks", "pull_request_review_threads", "pull_request_review_thread_syncs", "thread_child_observation_memberships"} {
+		if !foreignKeyReferencesPortableTable(t, st.DB(), table, "threads") {
+			t.Fatalf("child schema %s no longer references threads", table)
+		}
+	}
+	violations, err := portableForeignKeyViolationCount(ctx, st.DB())
+	if err != nil || violations != 0 {
+		t.Fatalf("rebuilt threads FK violations=%d err=%v", violations, err)
+	}
+	var triggerCount int
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from sqlite_schema where type = 'trigger' and tbl_name = 'threads'`).Scan(&triggerCount); err != nil {
+		t.Fatal(err)
+	}
+	if triggerCount != 4 {
+		t.Fatalf("rebuilt threads triggers = %d, want 4", triggerCount)
+	}
+	var convergence int
+	if err := st.DB().QueryRowContext(ctx, `select checked_observation_sequence from observation_schema_convergence where id = 1`).Scan(&convergence); err != nil {
+		t.Fatal(err)
+	}
+	if convergence != -1 {
+		t.Fatalf("observation convergence after rebuild = %d, want -1", convergence)
+	}
+}
+
+func TestRewritePortableThreadsCreateSQLReplacesOnlyTableIdentifier(t *testing.T) {
+	original := "CREATE TABLE IF NOT EXISTS \"threads\" (id integer primary key, title text not null, unique(title))"
+	rewritten, err := rewritePortableThreadsCreateSQL(original, "threads_portable_0123")
+	if err != nil {
+		t.Fatalf("rewrite threads DDL: %v", err)
+	}
+	want := "CREATE TABLE IF NOT EXISTS \"threads_portable_0123\" (id integer primary key, title text not null, unique(title))"
+	if rewritten != want {
+		t.Fatalf("rewritten DDL = %q, want %q", rewritten, want)
+	}
+	if _, err := rewritePortableThreadsCreateSQL("CREATE TABLE threads_archive(id integer)", "threads_portable_0123"); err == nil {
+		t.Fatal("unrecognized threads DDL was accepted")
+	}
+}
+
+func TestPortableThreadsRebuildPreservesAutoincrementAndDependentView(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "autoincrement.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	_, err = db.ExecContext(ctx, `
+		pragma foreign_keys = on;
+		create table repositories(id integer primary key);
+		create table threads(
+			id integer primary key autoincrement,
+			repo_id integer not null references repositories(id),
+			github_id text not null,
+			number integer not null,
+			kind text not null,
+			title text not null,
+			body text,
+			raw_json text not null,
+			body_excerpt text,
+			body_length integer not null default 0,
+			unique(repo_id, kind, number)
+		);
+		create table child_rows(thread_id integer not null references threads(id));
+		create view thread_titles as select id, title from threads;
+		create index ordinary_threads_title on threads(title);
+		create unique index unique_threads_github on threads(github_id);
+		insert into repositories(id) values(1);
+		insert into threads(id, repo_id, github_id, number, kind, title, body, raw_json, body_excerpt, body_length)
+		values(1, 1, 'one', 1, 'issue', 'retained title', 'full body', '{"raw":true}', 'compact body', 9);
+		insert into threads(id, repo_id, github_id, number, kind, title, body, raw_json, body_excerpt, body_length)
+		values(100, 1, 'deleted-high', 100, 'issue', 'deleted title', 'deleted', '{}', 'deleted', 7);
+		delete from threads where id = 100;
+		insert into child_rows(thread_id) values(1);
+	`)
+	if err != nil {
+		t.Fatalf("seed autoincrement rebuild: %v", err)
+	}
+	st := &Store{db: db, path: "autoincrement.db"}
+	dropped, err := st.rebuildPortableCompatibilityThreads(ctx)
+	if err != nil {
+		t.Fatalf("rebuild autoincrement threads: %v", err)
+	}
+	if !slices.Contains(dropped, "ordinary_threads_title") || slices.Contains(dropped, "unique_threads_github") {
+		t.Fatalf("rebuild dropped indexes = %v", dropped)
+	}
+	var sequence int64
+	if err := db.QueryRowContext(ctx, `select seq from sqlite_sequence where name = 'threads'`).Scan(&sequence); err != nil {
+		t.Fatalf("read threads sequence: %v", err)
+	}
+	if sequence != 100 {
+		t.Fatalf("threads sequence = %d, want 100", sequence)
+	}
+	result, err := db.ExecContext(ctx, `insert into threads(repo_id, github_id, number, kind, title, body, raw_json, body_excerpt, body_length) values(1, 'next', 2, 'issue', 'next title', 'next', '', 'next', 4)`)
+	if err != nil {
+		t.Fatalf("insert after rebuild: %v", err)
+	}
+	nextID, err := result.LastInsertId()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nextID != 101 {
+		t.Fatalf("next threads id = %d, want 101", nextID)
+	}
+	var viewTitle, body, rawJSON string
+	if err := db.QueryRowContext(ctx, `select title from thread_titles where id = 1`).Scan(&viewTitle); err != nil {
+		t.Fatalf("query retained view: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `select body, raw_json from threads where id = 1`).Scan(&body, &rawJSON); err != nil {
+		t.Fatal(err)
+	}
+	if viewTitle != "retained title" || body != "compact body" || rawJSON != "" {
+		t.Fatalf("rebuilt view/body/raw = %q/%q/%q", viewTitle, body, rawJSON)
+	}
+	if !indexExistsForPortableTest(t, db, "unique_threads_github") || indexExistsForPortableTest(t, db, "ordinary_threads_title") {
+		t.Fatal("rebuild did not preserve unique/omit ordinary indexes")
+	}
+	violations, err := portableForeignKeyViolationCount(ctx, db)
+	if err != nil || violations != 0 {
+		t.Fatalf("autoincrement rebuild FK violations=%d err=%v", violations, err)
+	}
+}
+
+func TestPortableThreadsRebuildFailsBeforeUnknownUpdateTrigger(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "update-trigger.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	if _, err := st.DB().ExecContext(ctx, `
+		alter table threads add column body_excerpt text;
+		alter table threads add column body_length integer not null default 0;
+		create table custom_update_audit(thread_id integer not null);
+		create trigger custom_threads_body_update after update of body on threads
+		begin
+		  insert into custom_update_audit(thread_id) values(new.id);
+		end;
+	`); err != nil {
+		t.Fatalf("create custom update trigger: %v", err)
+	}
+	if _, err := st.rebuildPortableCompatibilityThreads(ctx); err == nil || !strings.Contains(err.Error(), "cannot preserve update-trigger semantics") {
+		t.Fatalf("custom update trigger error = %v", err)
+	}
+	if !tableExistsForPortableTest(t, st.DB(), "threads") {
+		t.Fatal("failed trigger audit mutated threads table")
+	}
+}
+
+func TestPortableThreadsRebuildRejectsReplacedConvergenceUpdateTrigger(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "replaced-trigger.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	if _, err := st.DB().ExecContext(ctx, `
+		alter table threads add column body_excerpt text;
+		alter table threads add column body_length integer not null default 0;
+		drop trigger observation_convergence_threads_update;
+		create table replaced_update_audit(thread_id integer not null);
+		create trigger observation_convergence_threads_update after update of body on threads
+		begin
+		  insert into replaced_update_audit(thread_id) values(new.id);
+		end;
+	`); err != nil {
+		t.Fatalf("replace convergence update trigger: %v", err)
+	}
+	if _, err := st.rebuildPortableCompatibilityThreads(ctx); err == nil || !strings.Contains(err.Error(), "cannot preserve update-trigger semantics") {
+		t.Fatalf("replaced convergence trigger error = %v", err)
+	}
+}
+
+func TestPortableThreadsRebuildAbortsTransformedConstraintConflict(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "conflict.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	if _, err := db.ExecContext(ctx, `
+		pragma foreign_keys = on;
+		create table repositories(id integer primary key);
+		create table threads(
+			id integer primary key,
+			repo_id integer not null references repositories(id),
+			body text,
+			raw_json text not null unique on conflict replace,
+			body_excerpt text,
+			body_length integer not null default 0
+		);
+		insert into repositories(id) values(1);
+		insert into threads values(1, 1, 'body one', 'raw one', 'compact one', 8);
+		insert into threads values(2, 1, 'body two', 'raw two', 'compact two', 8);
+	`); err != nil {
+		t.Fatal(err)
+	}
+	st := &Store{db: db, path: "conflict.db"}
+	if _, err := st.rebuildPortableCompatibilityThreads(ctx); err == nil || !strings.Contains(err.Error(), "copy compact portable threads") {
+		t.Fatalf("transformed uniqueness conflict error = %v", err)
+	}
+	var count int
+	if err := db.QueryRowContext(ctx, `select count(*) from threads`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("constraint conflict retained %d threads, want 2", count)
+	}
+}
+
+func TestPortableThreadsRebuildRollsBackTransformedForeignKeyViolation(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "foreign-key.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	if _, err := db.ExecContext(ctx, `
+		pragma foreign_keys = on;
+		create table repositories(id integer primary key);
+		create table threads(
+			id integer primary key,
+			repo_id integer not null references repositories(id),
+			body text unique,
+			raw_json text not null,
+			body_excerpt text,
+			body_length integer not null default 0
+		);
+		create table body_children(body text references threads(body));
+		insert into repositories(id) values(1);
+		insert into threads values(1, 1, 'full body', '{}', 'compact body', 9);
+		insert into body_children(body) values('full body');
+	`); err != nil {
+		t.Fatal(err)
+	}
+	st := &Store{db: db, path: "foreign-key.db"}
+	if _, err := st.rebuildPortableCompatibilityThreads(ctx); err == nil || !strings.Contains(err.Error(), "foreign-key violations before commit") {
+		t.Fatalf("transformed foreign-key error = %v", err)
+	}
+	var body, childBody string
+	if err := db.QueryRowContext(ctx, `select body from threads where id = 1`).Scan(&body); err != nil {
+		t.Fatalf("read rolled-back thread: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `select body from body_children`).Scan(&childBody); err != nil {
+		t.Fatalf("read retained child: %v", err)
+	}
+	if body != "full body" || childBody != "full body" {
+		t.Fatalf("failed rebuild persisted body=%q child=%q", body, childBody)
+	}
+	violations, err := portableForeignKeyViolationCount(ctx, db)
+	if err != nil || violations != 0 {
+		t.Fatalf("rolled-back rebuild FK violations=%d err=%v", violations, err)
+	}
+}
+
+func TestPortableTriggerUpdateDetectionUsesSQLTokens(t *testing.T) {
+	updateSQL := `create trigger "BEGIN" after update /* BEGIN ON threads */ of body
+		on threads when new.body != 'BEGIN'
+		begin
+		  select 1;
+		end`
+	updates, err := portableTriggerUpdatesThreads(updateSQL)
+	if err != nil || !updates {
+		t.Fatalf("quoted/commented update trigger detected=%v err=%v", updates, err)
+	}
+	insertSQL := `create trigger custom_insert after insert on threads
+		begin
+		  update custom_table set value = 'ON threads BEGIN';
+		end`
+	updates, err = portableTriggerUpdatesThreads(insertSQL)
+	if err != nil || updates {
+		t.Fatalf("insert trigger detected as update=%v err=%v", updates, err)
+	}
+	if _, err := portableTriggerUpdatesThreads(`create trigger broken after update begin select 1; end`); err == nil {
+		t.Fatal("trigger without recognized ON threads target was accepted")
+	}
+}
+
+func indexExistsForPortableTest(t *testing.T, db *sql.DB, name string) bool {
+	t.Helper()
+	var exists int
+	if err := db.QueryRow(`select exists(select 1 from sqlite_schema where type = 'index' and name = ?)`, name).Scan(&exists); err != nil {
+		t.Fatalf("inspect index %s: %v", name, err)
+	}
+	return exists == 1
+}
+
+func tableExistsForPortableTest(t *testing.T, db *sql.DB, name string) bool {
+	t.Helper()
+	var exists int
+	if err := db.QueryRow(`select exists(select 1 from sqlite_schema where type = 'table' and name = ?)`, name).Scan(&exists); err != nil {
+		t.Fatalf("inspect table %s: %v", name, err)
+	}
+	return exists == 1
+}
+
+func foreignKeyReferencesPortableTable(t *testing.T, db *sql.DB, table, target string) bool {
+	t.Helper()
+	rows, err := db.Query(`pragma foreign_key_list(` + sqliteIdentifier(table) + `)`)
+	if err != nil {
+		t.Fatalf("inspect foreign keys for %s: %v", table, err)
+	}
+	defer rows.Close()
+	found := false
+	for rows.Next() {
+		var id, sequence int
+		var referencedTable, from, onUpdate, onDelete, match string
+		var to sql.NullString
+		if err := rows.Scan(&id, &sequence, &referencedTable, &from, &to, &onUpdate, &onDelete, &match); err != nil {
+			t.Fatalf("scan foreign keys for %s: %v", table, err)
+		}
+		if referencedTable == target {
+			found = true
+		}
+		if strings.HasPrefix(referencedTable, "threads_portable_") {
+			t.Fatalf("child %s references temporary sibling %s", table, referencedTable)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read foreign keys for %s: %v", table, err)
+	}
+	return found
+}

--- a/internal/store/portable_threads_rebuild_test.go
+++ b/internal/store/portable_threads_rebuild_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -410,7 +411,7 @@ func TestPortableThreadsRebuildRollsBackTransformedForeignKeyViolation(t *testin
 		t.Fatal(err)
 	}
 	st := &Store{db: db, path: "foreign-key.db"}
-	if _, err := st.rebuildPortableCompatibilityThreads(ctx); err == nil || !strings.Contains(err.Error(), "foreign-key violations before commit") {
+	if _, err := st.rebuildPortableCompatibilityThreads(ctx); err == nil || !strings.Contains(err.Error(), "referencing mutable threads column body") {
 		t.Fatalf("transformed foreign-key error = %v", err)
 	}
 	var body, childBody string
@@ -426,6 +427,162 @@ func TestPortableThreadsRebuildRollsBackTransformedForeignKeyViolation(t *testin
 	violations, err := portableForeignKeyViolationCount(ctx, db)
 	if err != nil || violations != 0 {
 		t.Fatalf("rolled-back rebuild FK violations=%d err=%v", violations, err)
+	}
+}
+
+func TestPortableThreadsRebuildRejectsForeignKeyFromTransformedColumn(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "outgoing-foreign-key.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	if _, err := db.ExecContext(ctx, `
+		pragma foreign_keys = on;
+		create table repositories(id integer primary key);
+		create table retained_bodies(body text primary key);
+		create table threads(
+			id integer primary key,
+			repo_id integer not null references repositories(id),
+			body text references retained_bodies(body),
+			raw_json text not null,
+			body_excerpt text,
+			body_length integer not null default 0
+		);
+		insert into repositories(id) values(1);
+		insert into retained_bodies(body) values('full body');
+		insert into threads values(1, 1, 'full body', '{}', 'compact body', 9);
+	`); err != nil {
+		t.Fatal(err)
+	}
+	st := &Store{db: db, path: "outgoing-foreign-key.db"}
+	if _, err := st.rebuildPortableCompatibilityThreads(ctx); err == nil || !strings.Contains(err.Error(), "foreign key from transformed threads column body") {
+		t.Fatalf("outgoing transformed foreign-key error = %v", err)
+	}
+	var body string
+	if err := db.QueryRowContext(ctx, `select body from threads where id = 1`).Scan(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body != "full body" {
+		t.Fatalf("rejected rebuild changed body to %q", body)
+	}
+}
+
+func TestPortableThreadsRebuildRejectsForeignKeyViolationBeforeSchemaSwap(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "preflight-violation.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	if _, err := st.DB().ExecContext(ctx, `
+		alter table threads add column body_excerpt text;
+		alter table threads add column body_length integer not null default 0;
+		insert into repositories(id, owner, name, full_name, raw_json, updated_at)
+		values(1, 'openclaw', 'gitcrawl', 'openclaw/gitcrawl', '{}', '2026-08-09T00:00:00Z');
+		insert into threads(id, repo_id, github_id, number, kind, state, title, body, html_url, labels_json, assignees_json, raw_json, content_hash, updated_at)
+		values(1, 1, 'THREAD-1', 1, 'issue', 'open', 'title', 'body', 'https://example.test/1', '[]', '[]', '{}', 'hash', '2026-08-09T00:00:00Z');
+		pragma foreign_keys = off;
+		insert into pull_request_checks(id, thread_id, name, status, raw_json, fetched_at)
+		values(99, 999, 'orphan', 'completed', '{}', '2026-08-09T00:00:00Z');
+		pragma foreign_keys = on;
+	`); err != nil {
+		t.Fatalf("seed FK violation: %v", err)
+	}
+	var stages []PortablePruneStage
+	stats := &PortablePruneStats{}
+	_, err = st.rebuildPortableCompatibilityThreadsWithOptions(ctx, PortablePruneOptions{
+		Progress: func(stage PortablePruneStage) { stages = append(stages, stage) },
+	}, stats)
+	if err == nil || !strings.Contains(err.Error(), "found 1 foreign-key violations before rebuild") {
+		t.Fatalf("pre-rebuild foreign-key error = %v", err)
+	}
+	if !stats.ForeignKeyValidated || stats.ForeignKeyViolations != 1 {
+		t.Fatalf("foreign-key stats = %+v", stats)
+	}
+	if slices.Contains(stages, PortablePruneStageThreadsRebuildSchemaSwap) {
+		t.Fatalf("invalid database reached schema swap: %v", stages)
+	}
+	if !tableExistsForPortableTest(t, st.DB(), "threads") {
+		t.Fatal("preflight violation removed original threads table")
+	}
+}
+
+func TestPortableThreadsRebuildIdentityMismatchRollsBack(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "identity-mismatch.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	if _, err := st.DB().ExecContext(ctx, `
+		alter table threads add column body_excerpt text;
+		alter table threads add column body_length integer not null default 0;
+		insert into repositories(id, owner, name, full_name, raw_json, updated_at)
+		values(1, 'openclaw', 'gitcrawl', 'openclaw/gitcrawl', '{}', '2026-08-09T00:00:00Z');
+		insert into threads(id, repo_id, github_id, number, kind, state, title, body, html_url, labels_json, assignees_json, raw_json, content_hash, updated_at)
+		values(1, 1, 'THREAD-1', 1, 'issue', 'open', 'title', 'full body', 'https://example.test/1', '[]', '[]', '{}', 'hash', '2026-08-09T00:00:00Z');
+		update threads set body_excerpt = 'compact', body_length = 9 where id = 1;
+	`); err != nil {
+		t.Fatalf("seed identity mismatch: %v", err)
+	}
+	stats := &PortablePruneStats{}
+	_, err = st.rebuildPortableCompatibilityThreadsWithOptions(ctx, PortablePruneOptions{
+		threadsRebuildHook: func(stage portableThreadsRebuildHookStage, tx *sql.Tx, sibling string) error {
+			if stage != portableThreadsRebuildHookAfterCopy {
+				return nil
+			}
+			_, err := tx.ExecContext(ctx, `update `+sqliteIdentifier(sibling)+` set repo_id = 2 where id = 1`)
+			return err
+		},
+	}, stats)
+	if err == nil || !strings.Contains(err.Error(), "identity mismatch") {
+		t.Fatalf("identity mismatch error = %v", err)
+	}
+	var repoID int64
+	var body string
+	if err := st.DB().QueryRowContext(ctx, `select repo_id, body from threads where id = 1`).Scan(&repoID, &body); err != nil {
+		t.Fatalf("read original threads after rollback: %v", err)
+	}
+	if repoID != 1 || body != "full body" {
+		t.Fatalf("identity mismatch persisted repo/body = %d/%q", repoID, body)
+	}
+}
+
+func TestPortablePruneExportModeRunsOneForeignKeyProof(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "one-fk-proof.db"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	checks := 0
+	stats, err := st.PrunePortablePayloads(ctx, PortablePruneOptions{
+		BodyChars:                     8,
+		DeferSecureRewrite:            true,
+		RetainSanitizedPayloadColumns: true,
+		foreignKeyCheck: func(ctx context.Context, q dbQueries) (int, error) {
+			checks++
+			var discardedTable, ordinaryIndex int
+			if err := q.QueryRowContext(ctx, `select exists(select 1 from sqlite_schema where type = 'table' and name = 'documents')`).Scan(&discardedTable); err != nil {
+				return 0, err
+			}
+			if err := q.QueryRowContext(ctx, `select exists(select 1 from sqlite_schema where type = 'index' and name = 'idx_threads_repo_number')`).Scan(&ordinaryIndex); err != nil {
+				return 0, err
+			}
+			if discardedTable != 0 || ordinaryIndex != 1 {
+				return 0, fmt.Errorf("foreign-key proof placement documents=%d ordinary_index=%d", discardedTable, ordinaryIndex)
+			}
+			return portableForeignKeyViolationCount(ctx, q)
+		},
+	})
+	if err != nil {
+		t.Fatalf("prune export mode: %v", err)
+	}
+	if checks != 1 || !stats.ForeignKeyValidated || stats.ForeignKeyViolations != 0 {
+		t.Fatalf("foreign-key proofs=%d stats=%+v", checks, stats)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -411,6 +411,9 @@ func (s *Store) ensureLegacyPortableColumns(ctx context.Context) error {
 	if err := s.ensureColumn(ctx, "repositories", "raw_json", "text"); err != nil {
 		return err
 	}
+	if err := s.ensureColumn(ctx, "comments", "raw_json_blob_id", "integer references blobs(id) on delete set null"); err != nil {
+		return err
+	}
 	if err := s.ensureColumn(ctx, "thread_revisions", "raw_json_blob_id", "integer references blobs(id) on delete set null"); err != nil {
 		return err
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2225,12 +2225,28 @@ func TestPrunePortablePayloads(t *testing.T) {
 	if prDetailCount != 1 || prFileCount != 1 || prCommitCount != 1 || prCheckCount != 1 || runCount != 1 {
 		t.Fatalf("pr/run rows not retained: detail=%d files=%d commits=%d checks=%d runs=%d", prDetailCount, prFileCount, prCommitCount, prCheckCount, runCount)
 	}
-	var portableSchema, capabilities, authorProfile, authorAssociation string
+	var prFilePath, prFileStatus string
+	var prFileAdditions, prFileDeletions, prFileChanges int
+	var prFilePatch sql.NullString
+	if err := st.DB().QueryRowContext(ctx, `
+		select path, status, additions, deletions, changes, patch
+		from pull_request_files
+		where thread_id = 1
+	`).Scan(&prFilePath, &prFileStatus, &prFileAdditions, &prFileDeletions, &prFileChanges, &prFilePatch); err != nil {
+		t.Fatalf("portable pull request file: %v", err)
+	}
+	if prFilePath != "README.md" || prFileStatus != "modified" || prFileAdditions != 10 || prFileDeletions != 2 || prFileChanges != 12 || prFilePatch.Valid {
+		t.Fatalf("portable pull request file metadata=%q/%q/%d/%d/%d patch=%#v", prFilePath, prFileStatus, prFileAdditions, prFileDeletions, prFileChanges, prFilePatch)
+	}
+	var portableSchema, capabilities, excluded, authorProfile, authorAssociation string
 	if err := st.DB().QueryRowContext(ctx, `select value from portable_metadata where key = 'schema'`).Scan(&portableSchema); err != nil {
 		t.Fatalf("portable schema metadata: %v", err)
 	}
 	if err := st.DB().QueryRowContext(ctx, `select value from portable_metadata where key = 'capabilities'`).Scan(&capabilities); err != nil {
 		t.Fatalf("portable capabilities metadata: %v", err)
+	}
+	if err := st.DB().QueryRowContext(ctx, `select value from portable_metadata where key = 'excluded'`).Scan(&excluded); err != nil {
+		t.Fatalf("portable excluded metadata: %v", err)
 	}
 	if err := st.DB().QueryRowContext(ctx, `select value from portable_metadata where key = 'thread_author_profile'`).Scan(&authorProfile); err != nil {
 		t.Fatalf("portable author profile metadata: %v", err)
@@ -2243,9 +2259,10 @@ func TestPrunePortablePayloads(t *testing.T) {
 		!strings.Contains(capabilities, "workflow_runs") ||
 		!strings.Contains(capabilities, "author_association") ||
 		!strings.Contains(capabilities, "thread_revisions") ||
+		!strings.Contains(excluded, "pull_request_file_patches") ||
 		authorProfile != "login,type,association" ||
 		authorAssociation != "MEMBER" {
-		t.Fatalf("portable metadata schema=%q capabilities=%q author_profile=%q association=%q", portableSchema, capabilities, authorProfile, authorAssociation)
+		t.Fatalf("portable metadata schema=%q capabilities=%q excluded=%q author_profile=%q association=%q", portableSchema, capabilities, excluded, authorProfile, authorAssociation)
 	}
 	if bodyExcerpt != "abcdefgh" || titleTokens != "[]" || linkedRefs != "[]" || buckets != "[]" || features != "{}" {
 		t.Fatalf("payloads not pruned: bodyExcerpt=%q titleTokens=%q linkedRefs=%q buckets=%q features=%q", bodyExcerpt, titleTokens, linkedRefs, buckets, features)


### PR DESCRIPTION
## Summary

- add `gitcrawl portable export` for source-preserving, validated portable generations
- add the generic `current-state-v1` profile with optional repository scoping and byte-budget enforcement
- own semantic shaping in Gitcrawl, including current-state omissions, patch stripping, compact metadata, repository scope, index policy, and manifest generation
- create the database and manifest as one atomically visible artifact directory while leaving Git publication external
- add signal-aware cancellation, stage timing, and regression coverage across SQLite schema, FK, trigger, view, index, privacy, and platform boundaries

## Ownership boundary

Gitcrawl now owns consistent SQLite snapshotting, semantic shaping, validation, artifact identity, manifest generation, and atomic generation creation. Git checkout promotion, commit/push, rollback, credentials, and host scheduling remain publication-layer concerns.

## Verification

- `GOWORK=off go test ./... -count=1`
- `make test`
- Windows amd64 compile-only tests for command, portable, store, and CLI packages
- `git diff --check origin/main...HEAD`
- Codex-backed autoreview clean with no actionable findings
- real ClawSweeper archive proof against a 3,510,677,504-byte live database:
  - completed in 19.5 seconds
  - live writer SHA-256 unchanged and `pragma integrity_check = ok`
  - output database 92,250,112 bytes under a 99,999,999-byte budget
  - output `quick_check` and full `integrity_check` returned `ok`
  - foreign-key violations: 0
  - manifest size and SHA-256 matched the artifact
  - published store was not touched during the proof

## CLI

```sh
gitcrawl --config /path/to/config.toml portable export \
  --profile current-state-v1 \
  --repository openclaw/openclaw \
  --body-chars 32 \
  --output-dir /path/to/new-generation \
  --database-name openclaw__openclaw.sync.db \
  --public-path data/openclaw__openclaw.sync.db \
  --max-bytes 99999999 \
  --json
```
