### PR TITLE
fix(portable): make artifact identity deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Portable stores
 
-- Add streamlined `portable export` generations with single-pass sanitized compatibility tables, journal-free staging, compact final files, granular progress, and clean interruption.
+- Add streamlined `portable export` generations with single-pass sanitized compatibility tables, journal-free staging, deterministic artifact identity for no-op publication, compact final files, granular progress, and clean interruption.
 
 ## 0.9.0 - 2026-08-08
 

--- a/docs/portable-stores.md
+++ b/docs/portable-stores.md
@@ -164,6 +164,12 @@ The manifest reports every retained table as a sorted `{name, rows}` object.
 It includes a singular repository object for scoped exports and for unscoped
 artifacts that naturally contain exactly one repository; multi-repository
 artifacts omit that singular field.
+Its `exportedAt` value is event metadata for that generation and is not embedded
+in the derived SQLite database. Identical source state and export options
+therefore produce identical database bytes, SHA-256, and artifact identity even
+when exported at different times, allowing publishers to skip unchanged data.
+Destructive `portable prune` continues to record its operation time as
+`portable_metadata.exported_at`.
 
 The `current-state-v1` profile starts with portable v2 shaping and keeps current
 repositories, issue and pull-request threads, current comments, compact thread

--- a/internal/portable/export.go
+++ b/internal/portable/export.go
@@ -209,6 +209,7 @@ type ExportResult struct {
 type exporter struct {
 	beforeManifest func() error
 	beforeCommit   func() error
+	now            func() time.Time
 }
 
 func Export(ctx context.Context, options ExportOptions) (ExportResult, error) {
@@ -379,25 +380,29 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 	if err != nil {
 		return result, err
 	}
-	exportedAt := time.Now().UTC().Format(time.RFC3339Nano)
+	exportTime := time.Now
+	if e.now != nil {
+		exportTime = e.now
+	}
+	exportedAt := exportTime().UTC().Format(time.RFC3339Nano)
 	metadata := map[string]string{
-		"schema":          portableSchema,
-		"profile":         profile.Name,
-		"profile_version": fmt.Sprintf("%d", profile.Version),
-		"body_chars":      fmt.Sprintf("%d", options.BodyChars),
-		"capabilities":    strings.Join(profile.Capabilities, ","),
-		"includes":        strings.Join(tableNames, ","),
-		"excluded":        strings.Join(profile.Excluded, ","),
-		"exported_at":     exportedAt,
-		"source_path":     options.PublicPath,
-		"index_profile":   profile.IndexProfile,
-		"column_profile":  profile.ColumnProfile,
+		"schema":                portableSchema,
+		"profile":               profile.Name,
+		"profile_version":       fmt.Sprintf("%d", profile.Version),
+		"body_chars":            fmt.Sprintf("%d", options.BodyChars),
+		"capabilities":          strings.Join(profile.Capabilities, ","),
+		"includes":              strings.Join(tableNames, ","),
+		"excluded":              strings.Join(profile.Excluded, ","),
+		"source_path":           options.PublicPath,
+		"index_profile":         profile.IndexProfile,
+		"column_profile":        profile.ColumnProfile,
+		"thread_author_profile": "login,type,association",
+	}
+	if _, err := st.DB().ExecContext(ctx, `delete from portable_metadata`); err != nil {
+		return result, fmt.Errorf("clear inherited portable metadata: %w", err)
 	}
 	if err := writeMetadata(ctx, st.DB(), metadata); err != nil {
 		return result, err
-	}
-	if _, err := st.DB().ExecContext(ctx, `delete from portable_metadata where key = 'sync_failure_scrub_pending'`); err != nil {
-		return result, fmt.Errorf("clear portable scrub marker: %w", err)
 	}
 	if err := reportProgress(ctx, options.Progress, StageFinalVacuum); err != nil {
 		return result, err

--- a/internal/portable/export_test.go
+++ b/internal/portable/export_test.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/openclaw/gitcrawl/internal/store"
 )
@@ -163,6 +164,66 @@ func TestExportCurrentStateV1SnapshotsLiveWALWithoutMutatingSource(t *testing.T)
 	assertManifestTableCounts(t, db, manifest.Tables)
 	if violations, err := testForeignKeyViolationCount(ctx, db); err != nil || violations != 0 {
 		t.Fatalf("independent final artifact FK violations=%d err=%v", violations, err)
+	}
+}
+
+func TestExportArtifactIdentityIsDeterministicAcrossExportTimes(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	defer st.Close()
+
+	exportAt := func(name, timestamp string) (ExportResult, Manifest) {
+		t.Helper()
+		instant, err := time.Parse(time.RFC3339Nano, timestamp)
+		if err != nil {
+			t.Fatalf("parse export time: %v", err)
+		}
+		result, err := (exporter{now: func() time.Time { return instant }}).export(
+			ctx,
+			testExportOptions(sourcePath, filepath.Join(dir, name)),
+		)
+		if err != nil {
+			t.Fatalf("export %s: %v", name, err)
+		}
+		manifest := readManifest(t, result.ManifestPath)
+		if manifest.ExportedAt != timestamp {
+			t.Fatalf("export %s manifest exportedAt = %q, want %q", name, manifest.ExportedAt, timestamp)
+		}
+		if err := validateManifestPair(ctx, result.DatabasePath, result.ManifestPath, manifest); err != nil {
+			t.Fatalf("validate export %s pair: %v", name, err)
+		}
+		db := openRawDB(t, result.DatabasePath)
+		defer db.Close()
+		var exportedAtCount int
+		if err := db.QueryRow(`select count(*) from portable_metadata where key = 'exported_at'`).Scan(&exportedAtCount); err != nil {
+			t.Fatalf("inspect export %s metadata: %v", name, err)
+		}
+		if exportedAtCount != 0 {
+			t.Fatalf("export %s retained portable_metadata.exported_at", name)
+		}
+		return result, manifest
+	}
+
+	first, firstManifest := exportAt("first", "2026-08-09T10:00:00Z")
+	second, secondManifest := exportAt("second", "2026-08-09T10:05:00Z")
+	if firstManifest.ExportedAt == secondManifest.ExportedAt {
+		t.Fatalf("manifest exportedAt values are equal: %q", firstManifest.ExportedAt)
+	}
+	if first.SHA256 != second.SHA256 || first.ArtifactID != second.ArtifactID || first.BytesAfter != second.BytesAfter {
+		t.Fatalf("unchanged export identity differs: first=%+v second=%+v", first, second)
+	}
+	if !bytes.Equal(readFile(t, first.DatabasePath), readFile(t, second.DatabasePath)) {
+		t.Fatal("unchanged exports produced different SQLite file bytes")
+	}
+
+	if _, err := st.DB().ExecContext(ctx, `update threads set title = 'portable export changed' where id = 1`); err != nil {
+		t.Fatalf("change retained source content: %v", err)
+	}
+	changed, _ := exportAt("changed", "2026-08-09T10:10:00Z")
+	if changed.ArtifactID == first.ArtifactID {
+		t.Fatalf("artifactId did not change with source content: %s", changed.ArtifactID)
 	}
 }
 


### PR DESCRIPTION
## Summary

- keep derived SQLite artifact bytes stable across export times
- retain dynamic `exportedAt` only in the manifest
- clear inherited volatile portable metadata before final artifact generation
- prove identical input yields identical DB SHA/artifact ID while real source changes alter identity

## Why

The store publisher uses `artifactId` for deterministic no-op publication. Embedding a fresh `exported_at` value inside SQLite made every export look different and would have produced large no-op commits on each schedule.

## Verification

- deterministic WAL-backed export regression across different clocks
- byte-for-byte DB equality and equal artifact IDs for unchanged input
- distinct manifest `exportedAt` values
- source content change produces a different artifact ID
- `make test-coverage`: 85.2%
- `GOWORK=off go test ./... -count=1`
- `make test`
- Windows amd64 compile-only tests
- `git diff --check origin/main...HEAD`
- Codex-backed autoreview clean
