### PR TITLE
fix(portable): ignore local churn in artifact identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Portable stores
 
-- Add streamlined `portable export` generations with single-pass sanitized compatibility tables, journal-free staging, deterministic artifact identity for no-op publication, compact final files, granular progress, and clean interruption.
+- Add streamlined `portable export` generations with single-pass sanitized compatibility tables, compact final files, and semantic artifact identity that ignores explicit local ingestion churn while retaining exact SQLite SHA-256 integrity, granular progress, and clean interruption.
 
 ## 0.9.0 - 2026-08-08
 

--- a/docs/portable-stores.md
+++ b/docs/portable-stores.md
@@ -167,9 +167,45 @@ artifacts omit that singular field.
 Its `exportedAt` value is event metadata for that generation and is not embedded
 in the derived SQLite database. Identical source state and export options
 therefore produce identical database bytes, SHA-256, and artifact identity even
-when exported at different times, allowing publishers to skip unchanged data.
+when exported at different times. The manifest `sha256` remains the exact digest
+of the finalized SQLite bytes. `artifactId` is instead the digest of a private,
+normalized compact copy and is identified by
+`artifactIdProfile: current-state-semantic-v1` (JSON command output uses
+`artifact_id_profile`). Publishers should use `artifactId` for no-op decisions
+and `sha256` for file integrity: repeated ingestion may legitimately change the
+file SHA while retaining the same meaningful portable state.
 Destructive `portable prune` continues to record its operation time as
 `portable_metadata.exported_at`.
+
+The semantic identity policy is an exact allowlist rather than a name pattern.
+Unknown future tables and columns remain in the identity, and a known column
+with an unexpected SQLite type fails identity computation. Missing known legacy
+tables and columns are skipped safely. The `current-state-semantic-v1` policy is:
+
+| Action | Tables or columns |
+| --- | --- |
+| Delete local-only tables when present | `observation_schema_convergence`, `repo_pipeline_state`, `repo_sync_state`, `sqlite_stat1`, `sqlite_stat4`, `thread_observation_sequence`, `thread_child_observation_reservations`, `workflow_run_observation_reservations`, `pull_request_review_thread_syncs` |
+| Clear repository ingestion time | `repositories.updated_at` |
+| Clear thread ingestion/order fields | `threads.first_pulled_at`, `last_pulled_at`, `updated_at`, `observation_sequence`, `evidence_observation_sequence`, `evidence_source_updated_at` |
+| Clear revision/fingerprint record bookkeeping | `thread_revisions.observation_sequence`, `thread_revisions.created_at`, `thread_fingerprints.created_at` |
+| Clear membership ordering but retain membership | `thread_child_observation_memberships.observation_sequence` becomes `1`; `member_ids_json` is retained |
+| Clear PR/workflow fetch and local record times | `pull_request_details.fetched_at` and `updated_at`; `pull_request_files.fetched_at`; `pull_request_commits.fetched_at`; `pull_request_checks.fetched_at`; `pull_request_review_threads.fetched_at`; `pull_request_review_thread_revisions.fetched_at` and `recorded_at`; `github_workflow_runs.fetched_at` |
+| Preserve tombstone state without local observation time | Non-NULL `threads.closed_at_local` and `deleted_at` values on comments, PR commits, review threads, and review-thread revisions become an empty non-NULL marker; NULL remains NULL |
+
+The policy also removes the named observation-convergence triggers associated
+with the deleted allocator/reservation state and normalizes SQLite's transient
+schema cookie before compaction. To prevent insertion-order-only hidden rowids
+from changing the compact bytes, it rebuilds child memberships, PR files, PR
+commits, review threads, workflow runs, and portable metadata in their declared
+primary-key order; retained triggers are restored in deterministic name order.
+The disposable compact file also zeroes SQLite's file-change,
+version-valid-for, and writer-library-version header words so a SQLite library
+upgrade cannot change semantic identity by itself. It does not clear titles, bodies or excerpts,
+body lengths, labels, assignees, states, URLs, GitHub timestamps, content hashes,
+comment/review content, revision or fingerprint content, membership IDs, PR or
+workflow public state, or repository identity. Manifest validation always
+recomputes the declared semantic profile and artifact ID in addition to checking
+the exact size and SHA-256 pair.
 
 The `current-state-v1` profile starts with portable v2 shaping and keeps current
 repositories, issue and pull-request threads, current comments, compact thread
@@ -209,9 +245,12 @@ It then creates one compact final generation with `VACUUM INTO`, closes and
 removes the larger private working database, and promotes the compact file
 within staging. The compact file must pass `quick_check` and full
 `integrity_check`; export then enforces the optional finalized byte
-budget, hashes the database with SHA-256, writes and fsyncs the manifest, then
+budget, hashes the database with SHA-256, derives semantic identity through a
+second bounded online backup and compact normalization pass, writes and fsyncs
+the manifest, then
 re-reads the pair without repeating the unindexed foreign-key scan. Concise
-stage progress is written to stderr, including during JSON output. Any failure
+stage progress, including `artifact identity`, is written to stderr, including
+during JSON output. Any failure
 or handled interrupt leaves the requested output directory absent and removes
 the private staging directory.
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -27,6 +27,7 @@ import (
 	clusterer "github.com/openclaw/gitcrawl/internal/cluster"
 	"github.com/openclaw/gitcrawl/internal/config"
 	gh "github.com/openclaw/gitcrawl/internal/github"
+	portableexport "github.com/openclaw/gitcrawl/internal/portable"
 	"github.com/openclaw/gitcrawl/internal/store"
 	"github.com/zalando/go-keyring"
 )
@@ -4858,6 +4859,7 @@ func TestPortableExportCommandCreatesCurrentStateGenerationFromLiveWAL(t *testin
 		BytesAfter           int64  `json:"bytes_after"`
 		MaxBytes             int64  `json:"max_bytes"`
 		ArtifactID           string `json:"artifact_id"`
+		ArtifactIDProfile    string `json:"artifact_id_profile"`
 		SHA256               string `json:"sha256"`
 		QuickCheck           string `json:"quick_check"`
 		IntegrityCheck       string `json:"integrity_check"`
@@ -4871,7 +4873,8 @@ func TestPortableExportCommandCreatesCurrentStateGenerationFromLiveWAL(t *testin
 	if payload.Profile != "current-state-v1" || payload.PortableSchema != "gitcrawl-portable-sync-v2" ||
 		payload.SourceDBPath != dbPath || payload.OutputDir != outputDir || payload.PublicPath != "data/openclaw__openclaw.sync.db" ||
 		payload.Repository.Owner != "openclaw" || payload.Repository.Name != "openclaw" || payload.Repository.FullName != "openclaw/openclaw" ||
-		payload.BodyChars != 32 || payload.MaxBytes != 99999999 || payload.BytesAfter <= 0 || payload.ArtifactID != payload.SHA256 ||
+		payload.BodyChars != 32 || payload.MaxBytes != 99999999 || payload.BytesAfter <= 0 || payload.ArtifactID == payload.SHA256 ||
+		payload.ArtifactIDProfile != portableexport.CurrentStateSemanticV1 ||
 		payload.QuickCheck != "ok" || payload.IntegrityCheck != "ok" || payload.ForeignKeyViolations != 0 || !payload.ArtifactCommitted ||
 		payload.ColumnProfile != store.PortableColumnProfileSanitizedCompatibility {
 		t.Fatalf("portable export payload = %+v", payload)
@@ -4908,7 +4911,7 @@ func TestPortableExportCommandCreatesCurrentStateGenerationFromLiveWAL(t *testin
 		"canonical shaping: threads rebuild: compact copy",
 		"canonical shaping: threads rebuild: schema swap",
 		"canonical shaping: threads rebuild: schema restore",
-		"index removal", "final vacuum", "validation", "manifest", "artifact commit", "complete",
+		"index removal", "final vacuum", "validation", "artifact identity", "manifest", "artifact commit", "complete",
 	} {
 		prefix := "gitcrawl: portable export: stage=" + stage + " "
 		var progressLine string

--- a/internal/cli/git_process_test.go
+++ b/internal/cli/git_process_test.go
@@ -4,9 +4,9 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 )
@@ -14,22 +14,47 @@ import (
 func TestRunGitKillsChildProcessGroupOnContextCancel(t *testing.T) {
 	dir := t.TempDir()
 	gitPath := filepath.Join(dir, "git")
-	script := "#!/bin/sh\n(sleep 30) &\nwait\n"
+	readyPath := filepath.Join(dir, "child-ready")
+	script := "#!/bin/sh\n(sleep 30) &\necho ready > \"$GITCRAWL_TEST_CHILD_READY\"\nwait\n"
 	if err := os.WriteFile(gitPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake git: %v", err)
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GITCRAWL_TEST_CHILD_READY", readyPath)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	start := time.Now()
+	canceledAt := make(chan time.Time, 1)
+	go func() {
+		deadline := time.NewTimer(5 * time.Second)
+		defer deadline.Stop()
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			if _, err := os.Stat(readyPath); err == nil {
+				canceledAt <- time.Now()
+				cancel()
+				return
+			}
+			select {
+			case <-ticker.C:
+			case <-deadline.C:
+				canceledAt <- time.Now()
+				cancel()
+				return
+			}
+		}
+	}()
 	err := runGit(ctx, "", "fetch")
-	elapsed := time.Since(start)
+	elapsed := time.Since(<-canceledAt)
+	if _, statErr := os.Stat(readyPath); statErr != nil {
+		t.Fatalf("fake git child never became ready: %v", statErr)
+	}
 	if err == nil {
 		t.Fatal("expected context cancellation error")
 	}
-	if !strings.Contains(err.Error(), "context deadline exceeded") {
-		t.Fatalf("error = %v, want context deadline exceeded", err)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context canceled", err)
 	}
 	if elapsed > 2*time.Second {
 		t.Fatalf("runGit took %s after context cancellation", elapsed)

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -16,6 +16,7 @@ import (
 
 	crawlremote "github.com/openclaw/crawlkit/remote"
 	"github.com/openclaw/gitcrawl/internal/config"
+	portableexport "github.com/openclaw/gitcrawl/internal/portable"
 	"github.com/openclaw/gitcrawl/internal/store"
 )
 
@@ -697,16 +698,19 @@ func sqliteStoreHealthWithOpen(ctx context.Context, path string, open func(conte
 }
 
 type portableDBManifest struct {
-	Schema        string `json:"schema,omitempty"`
-	ExportedAt    string `json:"exportedAt,omitempty"`
-	OutputPath    string `json:"outputPath,omitempty"`
-	OutputBytes   int64  `json:"outputBytes,omitempty"`
-	SHA256        string `json:"sha256,omitempty"`
-	QuickCheck    string `json:"quickCheck,omitempty"`
-	Compression   string `json:"compression,omitempty"`
-	ArchivePath   string `json:"archivePath,omitempty"`
-	ArchiveBytes  int64  `json:"archiveBytes,omitempty"`
-	ArchiveSHA256 string `json:"archiveSha256,omitempty"`
+	Schema            string `json:"schema,omitempty"`
+	Profile           string `json:"profile,omitempty"`
+	ExportedAt        string `json:"exportedAt,omitempty"`
+	OutputPath        string `json:"outputPath,omitempty"`
+	OutputBytes       int64  `json:"outputBytes,omitempty"`
+	SHA256            string `json:"sha256,omitempty"`
+	ArtifactID        string `json:"artifactId,omitempty"`
+	ArtifactIDProfile string `json:"artifactIdProfile,omitempty"`
+	QuickCheck        string `json:"quickCheck,omitempty"`
+	Compression       string `json:"compression,omitempty"`
+	ArchivePath       string `json:"archivePath,omitempty"`
+	ArchiveBytes      int64  `json:"archiveBytes,omitempty"`
+	ArchiveSHA256     string `json:"archiveSha256,omitempty"`
 }
 
 func portableDBManifestPath(dbPath string) string {
@@ -717,7 +721,7 @@ func validatePortableSQLiteFile(ctx context.Context, dbPath, manifestDBPath stri
 	if err := sqliteStoreHealth(ctx, dbPath); err != nil {
 		return err
 	}
-	return validatePortableDBManifest(dbPath, portableDBManifestPath(manifestDBPath))
+	return validatePortableDBManifest(ctx, dbPath, portableDBManifestPath(manifestDBPath))
 }
 
 func validatePortableSQLiteSourceFile(ctx context.Context, dbPath, manifestDBPath string) error {
@@ -729,7 +733,7 @@ func validatePortableSQLiteSourceFile(ctx context.Context, dbPath, manifestDBPat
 		if err := sqliteStoreImmutableHealth(ctx, dbPath); err != nil {
 			return err
 		}
-		return validatePortableDBManifest(dbPath, portableDBManifestPath(manifestDBPath))
+		return validatePortableDBManifest(ctx, dbPath, portableDBManifestPath(manifestDBPath))
 	}
 	tempDir, err := os.MkdirTemp("", "gitcrawl-portable-source-*")
 	if err != nil {
@@ -747,10 +751,10 @@ func validatePortableSQLiteSourceFile(ctx context.Context, dbPath, manifestDBPat
 	if err := sqliteStoreImmutableHealth(ctx, tempPath); err != nil {
 		return err
 	}
-	return validatePortableDBManifest(tempPath, portableDBManifestPath(manifestDBPath))
+	return validatePortableDBManifest(ctx, tempPath, portableDBManifestPath(manifestDBPath))
 }
 
-func validatePortableDBManifest(dbPath, manifestPath string) error {
+func validatePortableDBManifest(ctx context.Context, dbPath, manifestPath string) error {
 	manifest, ok, err := readPortableDBManifest(manifestPath)
 	if err != nil {
 		return fmt.Errorf("portable manifest mismatch: %w", err)
@@ -784,6 +788,29 @@ func validatePortableDBManifest(dbPath, manifestPath string) error {
 	sumText := fmt.Sprintf("%x", sum)
 	if !strings.EqualFold(sumText, strings.TrimSpace(manifest.SHA256)) {
 		return fmt.Errorf("portable manifest mismatch: sha256 %s != %s", sumText, manifest.SHA256)
+	}
+	artifactID := strings.TrimSpace(manifest.ArtifactID)
+	artifactIDProfile := strings.TrimSpace(manifest.ArtifactIDProfile)
+	if artifactIDProfile == "" {
+		// Derived manifests published before semantic identity used artifactId as
+		// an exact-SHA alias. Keep that additive manifest evolution readable.
+		if artifactID != "" && !strings.EqualFold(artifactID, strings.TrimSpace(manifest.SHA256)) {
+			return fmt.Errorf("portable manifest mismatch: legacy artifactId %s != sha256 %s", manifest.ArtifactID, manifest.SHA256)
+		}
+	} else {
+		if manifest.Profile != portableexport.CurrentStateV1 {
+			return fmt.Errorf("portable manifest mismatch: profile %q does not support semantic artifact identity", manifest.Profile)
+		}
+		if artifactIDProfile != portableexport.CurrentStateSemanticV1 {
+			return fmt.Errorf("portable manifest mismatch: unsupported artifactIdProfile %q", manifest.ArtifactIDProfile)
+		}
+		computedArtifactID, err := portableexport.ComputeArtifactID(ctx, dbPath, artifactIDProfile)
+		if err != nil {
+			return fmt.Errorf("portable manifest mismatch: recompute artifactId: %w", err)
+		}
+		if artifactID == "" || !strings.EqualFold(computedArtifactID, artifactID) {
+			return fmt.Errorf("portable manifest mismatch: artifactId %s != %s", computedArtifactID, manifest.ArtifactID)
+		}
 	}
 	return nil
 }
@@ -1134,7 +1161,7 @@ func publishPortableCheckoutPair(ctx context.Context, mirrorDBPath, mirrorManife
 	if err := sqliteStoreImmutableHealth(ctx, tempDB); err != nil {
 		return fmt.Errorf("validate staged portable db: %w", err)
 	}
-	if err := validatePortableDBManifest(tempDB, tempManifest); err != nil {
+	if err := validatePortableDBManifest(ctx, tempDB, tempManifest); err != nil {
 		return fmt.Errorf("validate staged portable manifest: %w", err)
 	}
 	// The pair is replaced with two adjacent renames; a crash between them is

--- a/internal/cli/runtime_extra_test.go
+++ b/internal/cli/runtime_extra_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/openclaw/gitcrawl/internal/config"
+	portableexport "github.com/openclaw/gitcrawl/internal/portable"
 )
 
 func writeTestCompressedPortableSource(t *testing.T, dbPath string) string {
@@ -96,6 +98,101 @@ func TestLocalRuntimeDBTarget(t *testing.T) {
 	}
 	if got := redirected.dbTarget(); got != want {
 		t.Fatalf("redirected db target = %+v, want %+v", got, want)
+	}
+}
+
+func TestPortableManifestValidatesSemanticArtifactIdentity(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "artifact.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`create table repositories(id integer primary key, full_name text, updated_at text); insert into repositories values(1, 'openclaw/gitcrawl', 'first')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	artifactID, err := portableexport.ComputeArtifactID(ctx, dbPath, portableexport.CurrentStateSemanticV1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := portableDBManifestPath(dbPath)
+	manifest := portableDBManifest{
+		Schema:            "gitcrawl-portable-sync-v2",
+		Profile:           portableexport.CurrentStateV1,
+		ArtifactID:        artifactID,
+		ArtifactIDProfile: portableexport.CurrentStateSemanticV1,
+		QuickCheck:        "ok",
+	}
+	refresh := func() {
+		t.Helper()
+		info, err := os.Stat(dbPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		sum, err := fileSHA256(dbPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		manifest.OutputBytes = info.Size()
+		manifest.SHA256 = fmt.Sprintf("%x", sum)
+		data, err := json.Marshal(manifest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(manifestPath, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	refresh()
+	if err := validatePortableDBManifest(ctx, dbPath, manifestPath); err != nil {
+		t.Fatalf("validate semantic manifest: %v", err)
+	}
+	manifest.ArtifactIDProfile = ""
+	manifest.ArtifactID = manifest.SHA256
+	refresh()
+	if err := validatePortableDBManifest(ctx, dbPath, manifestPath); err != nil {
+		t.Fatalf("validate legacy exact-SHA artifact identity: %v", err)
+	}
+	manifest.ArtifactID = strings.Repeat("0", 64)
+	refresh()
+	if err := validatePortableDBManifest(ctx, dbPath, manifestPath); err == nil || !strings.Contains(err.Error(), "legacy artifactId") {
+		t.Fatalf("mismatched legacy artifact identity error = %v", err)
+	}
+	manifest.ArtifactIDProfile = portableexport.CurrentStateSemanticV1
+	manifest.ArtifactID = artifactID
+	refresh()
+
+	db, err = sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`update repositories set updated_at = 'second'`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	refresh()
+	if err := validatePortableDBManifest(ctx, dbPath, manifestPath); err != nil {
+		t.Fatalf("local-only change invalidated semantic manifest: %v", err)
+	}
+
+	db, err = sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`update repositories set full_name = 'openclaw/changed'`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	refresh()
+	if err := validatePortableDBManifest(ctx, dbPath, manifestPath); err == nil || !strings.Contains(err.Error(), "artifactId") {
+		t.Fatalf("meaningful change semantic manifest error = %v", err)
 	}
 }
 

--- a/internal/portable/export.go
+++ b/internal/portable/export.go
@@ -126,6 +126,7 @@ const (
 	StageIndexRemoval     Stage = "index removal"
 	StageFinalVacuum      Stage = "final vacuum"
 	StageValidation       Stage = "validation"
+	StageArtifactIdentity Stage = "artifact identity"
 	StageManifest         Stage = "manifest"
 	StageArtifactCommit   Stage = "artifact commit"
 	StageComplete         Stage = "complete"
@@ -164,6 +165,7 @@ type Manifest struct {
 	OutputBytes          int64       `json:"outputBytes"`
 	SHA256               string      `json:"sha256"`
 	ArtifactID           string      `json:"artifactId"`
+	ArtifactIDProfile    string      `json:"artifactIdProfile"`
 	Repository           *Repository `json:"repository,omitempty"`
 	BodyChars            int         `json:"bodyChars"`
 	MaxBytes             *int64      `json:"maxBytes,omitempty"`
@@ -195,6 +197,7 @@ type ExportResult struct {
 	MaxBytes             *int64      `json:"max_bytes,omitempty"`
 	ByteBudgetOK         bool        `json:"byte_budget_ok"`
 	ArtifactID           string      `json:"artifact_id"`
+	ArtifactIDProfile    string      `json:"artifact_id_profile"`
 	SHA256               string      `json:"sha256"`
 	QuickCheck           string      `json:"quick_check"`
 	IntegrityCheck       string      `json:"integrity_check"`
@@ -478,7 +481,15 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 		return result, fmt.Errorf("hash portable database: %w", err)
 	}
 	result.SHA256 = sha
-	result.ArtifactID = sha
+	result.ArtifactIDProfile = CurrentStateSemanticV1
+	if err := reportProgress(ctx, options.Progress, StageArtifactIdentity); err != nil {
+		return result, err
+	}
+	artifactID, err := ComputeArtifactID(ctx, dbPath, result.ArtifactIDProfile)
+	if err != nil {
+		return result, fmt.Errorf("compute portable artifact identity: %w", err)
+	}
+	result.ArtifactID = artifactID
 	result.DroppedTables = droppedTables
 	result.DroppedIndexes = droppedIndexes
 	if err := reportProgress(ctx, options.Progress, StageManifest); err != nil {
@@ -493,7 +504,8 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 		OutputPath:           options.PublicPath,
 		OutputBytes:          info.Size(),
 		SHA256:               sha,
-		ArtifactID:           sha,
+		ArtifactID:           artifactID,
+		ArtifactIDProfile:    result.ArtifactIDProfile,
 		Repository:           result.Repository,
 		BodyChars:            options.BodyChars,
 		MaxBytes:             options.MaxBytes,
@@ -1081,8 +1093,21 @@ func validateManifestPair(ctx context.Context, dbPath, manifestPath string, expe
 	if err != nil {
 		return fmt.Errorf("re-hash portable database: %w", err)
 	}
-	if sha != actual.SHA256 || sha != actual.ArtifactID {
-		return fmt.Errorf("portable manifest digest does not match database")
+	if sha != actual.SHA256 {
+		return fmt.Errorf("portable manifest sha256 does not match database")
+	}
+	if actual.Profile != CurrentStateV1 {
+		return fmt.Errorf("portable manifest profile %q does not support semantic artifact identity", actual.Profile)
+	}
+	if actual.ArtifactIDProfile != CurrentStateSemanticV1 {
+		return fmt.Errorf("portable manifest artifactIdProfile %q is unsupported", actual.ArtifactIDProfile)
+	}
+	artifactID, err := ComputeArtifactID(ctx, dbPath, actual.ArtifactIDProfile)
+	if err != nil {
+		return fmt.Errorf("recompute portable artifact identity: %w", err)
+	}
+	if artifactID != actual.ArtifactID {
+		return fmt.Errorf("portable manifest artifactId does not match database semantic state")
 	}
 	db, err := sql.Open("sqlite", dbPath)
 	if err != nil {

--- a/internal/portable/export_failure_paths_test.go
+++ b/internal/portable/export_failure_paths_test.go
@@ -67,10 +67,26 @@ func TestValidateManifestPairRejectsInconsistentArtifacts(t *testing.T) {
 		},
 		{
 			name:      "digest mismatch",
-			wantError: "digest does not match",
+			wantError: "sha256 does not match",
 			mutate: func(t *testing.T, _, manifestPath string, manifest *Manifest) {
 				manifest.SHA256 = strings.Repeat("0", 64)
 				manifest.ArtifactID = manifest.SHA256
+				writeTestManifest(t, manifestPath, *manifest)
+			},
+		},
+		{
+			name:      "artifact identity profile mismatch",
+			wantError: "artifactIdProfile",
+			mutate: func(t *testing.T, _, manifestPath string, manifest *Manifest) {
+				manifest.ArtifactIDProfile = "future-semantic-v2"
+				writeTestManifest(t, manifestPath, *manifest)
+			},
+		},
+		{
+			name:      "artifact identity mismatch",
+			wantError: "artifactId does not match",
+			mutate: func(t *testing.T, _, manifestPath string, manifest *Manifest) {
+				manifest.ArtifactID = strings.Repeat("0", 64)
 				writeTestManifest(t, manifestPath, *manifest)
 			},
 		},
@@ -542,6 +558,7 @@ func TestExportCancellationAtSafetyBoundariesCleansStaging(t *testing.T) {
 		StageIndexRemoval,
 		StageFinalVacuum,
 		StageValidation,
+		StageArtifactIdentity,
 		StageManifest,
 		StageArtifactCommit,
 	}
@@ -839,7 +856,8 @@ func newTestManifestPair(t *testing.T) (string, string, Manifest) {
 	manifest := Manifest{
 		Schema: "portable-v1", PortableSchema: "portable-v1",
 		Profile: CurrentStateV1, ProfileVersion: 1,
-		OutputPath: "data/gitcrawl.db", Tables: tables,
+		ArtifactIDProfile: CurrentStateSemanticV1,
+		OutputPath:        "data/gitcrawl.db", Tables: tables,
 		Repository:   &Repository{ID: 1, Owner: "openclaw", Name: "gitcrawl", FullName: "openclaw/gitcrawl"},
 		ValidationOK: true, QuickCheck: "ok", IntegrityCheck: "ok",
 		IndexProfile: "unique-only", ColumnProfile: "sanitized-compatibility",
@@ -866,7 +884,11 @@ func refreshTestManifest(t *testing.T, dbPath string, manifest *Manifest) {
 	}
 	manifest.OutputBytes = info.Size()
 	manifest.SHA256 = hashFile(t, dbPath)
-	manifest.ArtifactID = manifest.SHA256
+	artifactID, err := ComputeArtifactID(context.Background(), dbPath, CurrentStateSemanticV1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest.ArtifactID = artifactID
 	manifest.Tables = tables
 }
 

--- a/internal/portable/export_test.go
+++ b/internal/portable/export_test.go
@@ -147,6 +147,7 @@ func TestExportCurrentStateV1SnapshotsLiveWALWithoutMutatingSource(t *testing.T)
 	manifest := readManifest(t, result.ManifestPath)
 	if manifest.OutputPath != result.PublicPath || manifest.OutputBytes != result.BytesAfter ||
 		manifest.SHA256 != result.SHA256 || manifest.ArtifactID != result.ArtifactID ||
+		manifest.ArtifactIDProfile != CurrentStateSemanticV1 || result.ArtifactIDProfile != CurrentStateSemanticV1 ||
 		manifest.ForeignKeyViolations != 0 || !manifest.ValidationOK ||
 		manifest.ColumnProfile != store.PortableColumnProfileSanitizedCompatibility || result.ColumnProfile != manifest.ColumnProfile {
 		t.Fatalf("manifest/result mismatch: manifest=%+v result=%+v", manifest, result)
@@ -224,6 +225,55 @@ func TestExportArtifactIdentityIsDeterministicAcrossExportTimes(t *testing.T) {
 	changed, _ := exportAt("changed", "2026-08-09T10:10:00Z")
 	if changed.ArtifactID == first.ArtifactID {
 		t.Fatalf("artifactId did not change with source content: %s", changed.ArtifactID)
+	}
+}
+
+func TestExportSemanticIdentityIgnoresLocalSourceChurnWhileExactSHAChanges(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	defer st.Close()
+
+	first, err := Export(ctx, testExportOptions(sourcePath, filepath.Join(dir, "first")))
+	if err != nil {
+		t.Fatalf("first export: %v", err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `
+		update repositories set updated_at = '2026-08-10T00:00:00Z';
+		update threads set
+			first_pulled_at = '2026-08-10T00:00:00Z',
+			last_pulled_at = '2026-08-10T00:01:00Z',
+			updated_at = '2026-08-10T00:02:00Z',
+			observation_sequence = 99,
+			evidence_observation_sequence = 99,
+			evidence_source_updated_at = '2026-08-10T00:03:00Z';
+		update thread_revisions set observation_sequence = 99;
+		update thread_child_observation_memberships set observation_sequence = 99;
+	`); err != nil {
+		t.Fatalf("mutate local source bookkeeping: %v", err)
+	}
+	second, err := Export(ctx, testExportOptions(sourcePath, filepath.Join(dir, "second")))
+	if err != nil {
+		t.Fatalf("second export: %v", err)
+	}
+	if first.SHA256 == second.SHA256 {
+		t.Fatalf("local source churn retained exact SHA %s", first.SHA256)
+	}
+	if first.ArtifactID != second.ArtifactID {
+		t.Fatalf("local source churn changed semantic identity: first=%s second=%s", first.ArtifactID, second.ArtifactID)
+	}
+	for _, result := range []ExportResult{first, second} {
+		manifest := readManifest(t, result.ManifestPath)
+		if manifest.ArtifactIDProfile != CurrentStateSemanticV1 || result.ArtifactIDProfile != CurrentStateSemanticV1 {
+			t.Fatalf("artifact identity profile manifest=%q result=%q", manifest.ArtifactIDProfile, result.ArtifactIDProfile)
+		}
+		if manifest.SHA256 == manifest.ArtifactID {
+			t.Fatalf("exact and semantic digests unexpectedly match: %s", manifest.SHA256)
+		}
+		if err := validateManifestPair(ctx, result.DatabasePath, result.ManifestPath, manifest); err != nil {
+			t.Fatalf("validate semantic manifest pair: %v", err)
+		}
 	}
 }
 
@@ -858,8 +908,17 @@ func seedExportSource(t *testing.T, ctx context.Context, dbPath string) *store.S
 		`insert into thread_key_summaries(id, thread_revision_id, summary_kind, prompt_version, provider, model, input_hash, output_hash, key_text, created_at) values(1, 1, 'llm_key', 'v1', 'openai', 'test', 'in', 'out', 'historical enrichment', '2026-08-08T00:00:00Z')`,
 		`insert into pull_request_details(thread_id, repo_id, number, raw_json, fetched_at, updated_at) values(1, 1, 7, '{}', '2026-08-08T00:00:00Z', '2026-08-08T00:00:00Z')`,
 		`insert into pull_request_files(thread_id, position, path, status, additions, deletions, changes, previous_path, patch, raw_json, fetched_at) values(1, 0, 'internal/portable/export.go', 'modified', 10, 2, 12, 'internal/export.go', '@@ retained repository patch', '{}', '2026-08-08T00:00:00Z')`,
+		`insert into pull_request_commits(thread_id, sha, message, author_login, author_name, committed_at, html_url, raw_json, fetched_at, deleted_at, deletion_reason) values(1, 'abc123', 'portable commit', 'octocat', 'Octo Cat', '2026-08-07T00:00:00Z', 'https://github.com/openclaw/gitcrawl/commit/abc123', '{}', '2026-08-08T00:00:00Z', '2026-08-08T01:00:00Z', 'not returned by source')`,
 		`insert into pull_request_checks(id, thread_id, name, status, raw_json, fetched_at) values(1, 1, 'test', 'completed', '{}', '2026-08-08T00:00:00Z')`,
+		`insert into pull_request_review_threads(thread_id, review_thread_id, path, first_comment_body, comments_json, raw_json, fetched_at, deleted_at, deletion_reason) values(1, 'RT1', 'internal/portable/export.go', 'review body', '[{"body":"review body"}]', '{}', '2026-08-08T00:00:00Z', '2026-08-08T01:00:00Z', 'not returned by source')`,
+		`insert into pull_request_review_thread_revisions(id, thread_id, review_thread_id, path, first_comment_body, comments_json, raw_json, fetched_at, deleted_at, deletion_reason, recorded_at) values(1, 1, 'RT1', 'internal/portable/export.go', 'review body', '[{"body":"review body"}]', '{}', '2026-08-08T00:00:00Z', '2026-08-08T01:00:00Z', 'not returned by source', '2026-08-08T02:00:00Z')`,
+		`insert into pull_request_review_thread_syncs(thread_id, fetched_at) values(1, '2026-08-08T00:00:00Z')`,
+		`insert into github_workflow_runs(repo_id, run_id, run_number, head_branch, head_sha, status, conclusion, workflow_name, event, html_url, created_at_gh, updated_at_gh, raw_json, fetched_at) values(1, 'RUN1', 1, 'main', 'abc123', 'completed', 'success', 'CI', 'pull_request', 'https://github.com/openclaw/gitcrawl/actions/runs/1', '2026-08-07T00:00:00Z', '2026-08-07T00:01:00Z', '{}', '2026-08-08T00:00:00Z')`,
+		`update thread_observation_sequence set value = 7, last_started_at = '2026-08-08T00:00:00Z' where id = 1`,
+		`insert into thread_child_observation_reservations(thread_id, family, source_updated_at, observation_sequence) values(1, 'comments', '2026-08-07T00:00:00Z', 7)`,
 		`insert into thread_child_observation_memberships(thread_id, family, observation_sequence, member_ids_json) values(1, 'comments', 1, '["C1"]')`,
+		`insert into workflow_run_observation_reservations(repo_id, head_sha, source_updated_at, observation_sequence) values(1, 'abc123', '2026-08-07T00:00:00Z', 7)`,
+		`insert into repo_sync_state(repo_id, last_full_open_scan_started_at, updated_at) values(1, '2026-08-08T00:00:00Z', '2026-08-08T00:00:00Z')`,
 		`insert into cluster_groups(id, repo_id, stable_key, stable_slug, status, created_at, updated_at) values(1, 1, 'key', 'slug', 'open', '2026-08-08T00:00:00Z', '2026-08-08T00:00:00Z')`,
 		`insert into cluster_memberships(cluster_id, thread_id, role, state, added_by, added_reason_json, created_at, updated_at) values(1, 1, 'member', 'active', 'system', '{}', '2026-08-08T00:00:00Z', '2026-08-08T00:00:00Z')`,
 		`insert into cluster_overrides(id, repo_id, cluster_id, thread_id, action, created_at) values(1, 1, 1, 1, 'exclude', '2026-08-08T00:00:00Z')`,

--- a/internal/portable/identity.go
+++ b/internal/portable/identity.go
@@ -1,0 +1,574 @@
+package portable
+
+import (
+	"context"
+	"database/sql"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const CurrentStateSemanticV1 = "current-state-semantic-v1"
+
+type identityNormalizationKind uint8
+
+const (
+	identityEmptyText identityNormalizationKind = iota + 1
+	identityNullText
+	identityPresentText
+	identityZeroInteger
+	identityOneInteger
+)
+
+type identityColumnPolicy struct {
+	Name         string
+	DeclaredType string
+	Kind         identityNormalizationKind
+}
+
+type identityTablePolicy struct {
+	Name              string
+	Columns           []identityColumnPolicy
+	CanonicalRowOrder []string
+}
+
+type artifactIdentityPolicy struct {
+	Profile         string
+	DroppedTriggers []string
+	DroppedTables   []string
+	Tables          []identityTablePolicy
+}
+
+// currentStateSemanticPolicy is deliberately an exact allowlist. Unknown
+// future tables and columns remain in the compact identity database, so a
+// schema addition cannot accidentally hide public data by matching a name
+// pattern. Known tables and columns are optional for legacy portable schemas.
+var currentStateSemanticPolicy = artifactIdentityPolicy{
+	Profile: CurrentStateSemanticV1,
+	DroppedTriggers: []string{
+		"observation_convergence_threads_insert",
+		"observation_convergence_threads_update",
+		"observation_convergence_threads_delete",
+		"observation_convergence_revisions_insert",
+		"observation_convergence_revisions_update",
+		"observation_convergence_revisions_delete",
+		"observation_convergence_pr_details_insert",
+		"observation_convergence_pr_details_update",
+		"observation_convergence_pr_details_delete",
+		"observation_convergence_children_insert",
+		"observation_convergence_children_update",
+		"observation_convergence_children_delete",
+		"observation_convergence_workflows_insert",
+		"observation_convergence_workflows_update",
+		"observation_convergence_workflows_delete",
+		"observation_convergence_allocator_insert",
+		"observation_convergence_allocator_update",
+		"observation_convergence_allocator_delete",
+	},
+	DroppedTables: []string{
+		"observation_schema_convergence",
+		"repo_pipeline_state",
+		"repo_sync_state",
+		"sqlite_stat1",
+		"sqlite_stat4",
+		"thread_observation_sequence",
+		"thread_child_observation_reservations",
+		"workflow_run_observation_reservations",
+		"pull_request_review_thread_syncs",
+	},
+	Tables: []identityTablePolicy{
+		{Name: "repositories", Columns: []identityColumnPolicy{
+			{Name: "updated_at", DeclaredType: "TEXT", Kind: identityEmptyText},
+		}},
+		{Name: "threads", Columns: []identityColumnPolicy{
+			{Name: "first_pulled_at", DeclaredType: "TEXT", Kind: identityNullText},
+			{Name: "last_pulled_at", DeclaredType: "TEXT", Kind: identityNullText},
+			{Name: "updated_at", DeclaredType: "TEXT", Kind: identityEmptyText},
+			{Name: "observation_sequence", DeclaredType: "INTEGER", Kind: identityZeroInteger},
+			{Name: "evidence_observation_sequence", DeclaredType: "INTEGER", Kind: identityZeroInteger},
+			{Name: "evidence_source_updated_at", DeclaredType: "TEXT", Kind: identityEmptyText},
+			// Preserve whether a local absence was observed, but not when it was observed.
+			{Name: "closed_at_local", DeclaredType: "TEXT", Kind: identityPresentText},
+		}},
+		{Name: "comments", Columns: []identityColumnPolicy{
+			{Name: "deleted_at", DeclaredType: "TEXT", Kind: identityPresentText},
+		}},
+		{Name: "thread_revisions", Columns: []identityColumnPolicy{
+			{Name: "observation_sequence", DeclaredType: "INTEGER", Kind: identityZeroInteger},
+			{Name: "created_at", DeclaredType: "TEXT", Kind: identityEmptyText},
+		}},
+		{
+			Name: "thread_child_observation_memberships",
+			Columns: []identityColumnPolicy{
+				{Name: "observation_sequence", DeclaredType: "INTEGER", Kind: identityOneInteger},
+			},
+			CanonicalRowOrder: []string{"thread_id", "family"},
+		},
+		{Name: "thread_fingerprints", Columns: []identityColumnPolicy{
+			{Name: "created_at", DeclaredType: "TEXT", Kind: identityEmptyText},
+		}},
+		{Name: "pull_request_details", Columns: []identityColumnPolicy{
+			{Name: "fetched_at", DeclaredType: "TEXT", Kind: identityEmptyText},
+			{Name: "updated_at", DeclaredType: "TEXT", Kind: identityEmptyText},
+		}},
+		{
+			Name: "pull_request_files",
+			Columns: []identityColumnPolicy{
+				{Name: "fetched_at", DeclaredType: "TEXT", Kind: identityEmptyText},
+			},
+			CanonicalRowOrder: []string{"thread_id", "position"},
+		},
+		{
+			Name: "pull_request_commits",
+			Columns: []identityColumnPolicy{
+				{Name: "fetched_at", DeclaredType: "TEXT", Kind: identityEmptyText},
+				{Name: "deleted_at", DeclaredType: "TEXT", Kind: identityPresentText},
+			},
+			CanonicalRowOrder: []string{"thread_id", "sha"},
+		},
+		{Name: "pull_request_checks", Columns: []identityColumnPolicy{
+			{Name: "fetched_at", DeclaredType: "TEXT", Kind: identityEmptyText},
+		}},
+		{
+			Name: "pull_request_review_threads",
+			Columns: []identityColumnPolicy{
+				{Name: "fetched_at", DeclaredType: "TEXT", Kind: identityEmptyText},
+				{Name: "deleted_at", DeclaredType: "TEXT", Kind: identityPresentText},
+			},
+			CanonicalRowOrder: []string{"thread_id", "review_thread_id"},
+		},
+		{Name: "pull_request_review_thread_revisions", Columns: []identityColumnPolicy{
+			{Name: "fetched_at", DeclaredType: "TEXT", Kind: identityEmptyText},
+			{Name: "recorded_at", DeclaredType: "TEXT", Kind: identityEmptyText},
+			{Name: "deleted_at", DeclaredType: "TEXT", Kind: identityPresentText},
+		}},
+		{
+			Name: "github_workflow_runs",
+			Columns: []identityColumnPolicy{
+				{Name: "fetched_at", DeclaredType: "TEXT", Kind: identityEmptyText},
+			},
+			CanonicalRowOrder: []string{"repo_id", "run_id"},
+		},
+		{Name: "portable_metadata", CanonicalRowOrder: []string{"key"}},
+	},
+}
+
+type artifactIdentityOptions struct {
+	TempParent     string
+	Backup         onlineBackupOptions
+	AfterSnapshot  func(string) error
+	AfterNormalize func(*sql.DB) error
+}
+
+// ComputeArtifactID returns the semantic identity for a finalized current-state
+// SQLite artifact. It never opens the artifact writable.
+func ComputeArtifactID(ctx context.Context, dbPath, profile string) (string, error) {
+	if profile != CurrentStateSemanticV1 {
+		return "", fmt.Errorf("unsupported artifact identity profile %q; supported profile: %s", profile, CurrentStateSemanticV1)
+	}
+	return computeArtifactIDWithOptions(ctx, dbPath, currentStateSemanticPolicy, artifactIdentityOptions{})
+}
+
+func computeArtifactIDWithOptions(
+	ctx context.Context,
+	dbPath string,
+	policy artifactIdentityPolicy,
+	options artifactIdentityOptions,
+) (_ string, retErr error) {
+	if err := validateArtifactIdentityPolicy(policy); err != nil {
+		return "", err
+	}
+	tempDir, err := os.MkdirTemp(options.TempParent, "gitcrawl-artifact-identity-*")
+	if err != nil {
+		return "", fmt.Errorf("create artifact identity directory: %w", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("remove artifact identity directory: %w", err))
+		}
+	}()
+
+	workingPath := filepath.Join(tempDir, "identity.db")
+	backupOptions := options.Backup
+	if backupOptions.PagesPerStep <= 0 {
+		backupOptions.PagesPerStep = onlineBackupPageChunk
+	}
+	if err := snapshotSQLiteWithOptions(ctx, dbPath, workingPath, backupOptions); err != nil {
+		return "", fmt.Errorf("snapshot artifact identity database: %w", err)
+	}
+	if options.AfterSnapshot != nil {
+		if err := options.AfterSnapshot(workingPath); err != nil {
+			return "", fmt.Errorf("prepare artifact identity database: %w", err)
+		}
+	}
+
+	db, err := sql.Open("sqlite", workingPath)
+	if err != nil {
+		return "", fmt.Errorf("open artifact identity database: %w", err)
+	}
+	closed := false
+	defer func() {
+		if !closed {
+			retErr = errors.Join(retErr, db.Close())
+		}
+	}()
+	if err := configureDisposableStore(ctx, db); err != nil {
+		return "", fmt.Errorf("configure artifact identity database: %w", err)
+	}
+	// Identity compaction scans the full disposable copy once. A bounded cache
+	// and large canonical output pages keep that pass fast without making the
+	// digest depend on the source database's page size.
+	if _, err := db.ExecContext(ctx, `pragma cache_size = -65536`); err != nil {
+		return "", fmt.Errorf("configure artifact identity cache: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `pragma page_size = 65536`); err != nil {
+		return "", fmt.Errorf("configure artifact identity page size: %w", err)
+	}
+	if err := normalizeArtifactIdentity(ctx, db, policy); err != nil {
+		return "", err
+	}
+	if options.AfterNormalize != nil {
+		if err := options.AfterNormalize(db); err != nil {
+			return "", fmt.Errorf("normalize artifact identity database: %w", err)
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return "", fmt.Errorf("artifact identity canceled before compaction: %w", err)
+	}
+	compactPath, err := createCompactDatabase(ctx, db, workingPath)
+	if err != nil {
+		return "", fmt.Errorf("compact artifact identity database: %w", err)
+	}
+	if err := db.Close(); err != nil {
+		return "", fmt.Errorf("close artifact identity database: %w", err)
+	}
+	closed = true
+	if err := removeSQLiteSidecars(workingPath); err != nil {
+		return "", err
+	}
+	if err := os.Remove(workingPath); err != nil {
+		return "", fmt.Errorf("remove uncompact artifact identity database: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return "", fmt.Errorf("artifact identity canceled before hashing: %w", err)
+	}
+	digest, err := hashArtifactIdentityFile(compactPath)
+	if err != nil {
+		return "", fmt.Errorf("hash artifact identity database: %w", err)
+	}
+	return digest, nil
+}
+
+func hashArtifactIdentityFile(filePath string) (string, error) {
+	file, err := os.OpenFile(filePath, os.O_RDWR, 0)
+	if err != nil {
+		return "", err
+	}
+	header := make([]byte, 100)
+	n, readErr := file.ReadAt(header, 0)
+	if readErr != nil {
+		_ = file.Close()
+		return "", readErr
+	}
+	if n != len(header) || string(header[:16]) != "SQLite format 3\x00" {
+		_ = file.Close()
+		return "", fmt.Errorf("artifact identity file has invalid SQLite header")
+	}
+	// SQLite's file change counter, version-valid-for counter, and writer
+	// library version describe the engine write event rather than logical
+	// database state. The identity file is closed and journal-free, so these
+	// informational header words can be canonicalized before hashing.
+	binary.BigEndian.PutUint32(header[24:28], 0)
+	binary.BigEndian.PutUint32(header[92:96], 0)
+	binary.BigEndian.PutUint32(header[96:100], 0)
+	if _, err := file.WriteAt(header, 0); err != nil {
+		_ = file.Close()
+		return "", err
+	}
+	if err := file.Close(); err != nil {
+		return "", err
+	}
+	return fileSHA256(filePath)
+}
+
+func normalizeArtifactIdentity(ctx context.Context, db *sql.DB, policy artifactIdentityPolicy) error {
+	if _, err := db.ExecContext(ctx, `pragma foreign_keys = off`); err != nil {
+		return fmt.Errorf("disable artifact identity foreign keys: %w", err)
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin artifact identity normalization: %w", err)
+	}
+	defer tx.Rollback()
+	for _, trigger := range policy.DroppedTriggers {
+		if _, err := tx.ExecContext(ctx, `drop trigger if exists `+quoteIdentifier(trigger)); err != nil {
+			return fmt.Errorf("drop artifact identity trigger %s: %w", trigger, err)
+		}
+	}
+	retainedTriggers, err := artifactIdentityTriggers(ctx, tx)
+	if err != nil {
+		return err
+	}
+	for _, trigger := range retainedTriggers {
+		if _, err := tx.ExecContext(ctx, `drop trigger `+quoteIdentifier(trigger.Name)); err != nil {
+			return fmt.Errorf("temporarily drop artifact identity trigger %s: %w", trigger.Name, err)
+		}
+	}
+	for _, table := range policy.DroppedTables {
+		var exists int
+		if err := tx.QueryRowContext(ctx, `select exists(select 1 from sqlite_schema where type = 'table' and name = ?)`, table).Scan(&exists); err != nil {
+			return fmt.Errorf("inspect artifact identity table %s: %w", table, err)
+		}
+		if exists == 0 {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, `drop table `+quoteIdentifier(table)); err != nil {
+			return fmt.Errorf("drop artifact identity table %s: %w", table, err)
+		}
+	}
+	for _, table := range policy.Tables {
+		columns, err := artifactIdentityColumns(ctx, tx, table.Name)
+		if err != nil {
+			return err
+		}
+		if columns == nil {
+			continue
+		}
+		assignments := make([]string, 0, len(table.Columns))
+		for _, column := range table.Columns {
+			declaredType, ok := columns.DeclaredTypes[column.Name]
+			if !ok {
+				continue
+			}
+			if !strings.EqualFold(strings.TrimSpace(declaredType), column.DeclaredType) {
+				return fmt.Errorf("artifact identity column %s.%s has type %q, want %s", table.Name, column.Name, declaredType, column.DeclaredType)
+			}
+			identifier := quoteIdentifier(column.Name)
+			switch column.Kind {
+			case identityEmptyText:
+				assignments = append(assignments, identifier+` = ''`)
+			case identityNullText:
+				assignments = append(assignments, identifier+` = null`)
+			case identityPresentText:
+				assignments = append(assignments, identifier+` = case when `+identifier+` is null then null else '' end`)
+			case identityZeroInteger:
+				assignments = append(assignments, identifier+` = 0`)
+			case identityOneInteger:
+				assignments = append(assignments, identifier+` = 1`)
+			default:
+				return fmt.Errorf("artifact identity column %s.%s has unknown normalization %d", table.Name, column.Name, column.Kind)
+			}
+		}
+		if len(assignments) == 0 {
+			// A table may still need hidden rowid canonicalization below.
+		} else if _, err := tx.ExecContext(ctx, `update `+quoteIdentifier(table.Name)+` set `+strings.Join(assignments, ", ")); err != nil {
+			return fmt.Errorf("normalize artifact identity table %s: %w", table.Name, err)
+		}
+		if len(table.CanonicalRowOrder) != 0 {
+			if err := canonicalizeArtifactIdentityRows(ctx, tx, table.Name, columns.Names, table.CanonicalRowOrder); err != nil {
+				return err
+			}
+		}
+		rowOrder := make(map[string]struct{})
+		for _, column := range table.CanonicalRowOrder {
+			if err := validateIdentityPolicyName(column); err != nil {
+				return err
+			}
+			if _, ok := rowOrder[column]; ok {
+				return fmt.Errorf("artifact identity policy repeats row order column %s.%s", table.Name, column)
+			}
+			rowOrder[column] = struct{}{}
+		}
+	}
+	for _, trigger := range retainedTriggers {
+		if _, err := tx.ExecContext(ctx, trigger.SQL); err != nil {
+			return fmt.Errorf("restore artifact identity trigger %s: %w", trigger.Name, err)
+		}
+	}
+	// SQLite advances its schema cookie for a transient local table even when
+	// that table is removed above. The cookie is database-engine bookkeeping,
+	// not portable schema content; canonicalize it before VACUUM rebuilds the
+	// compact identity file.
+	if _, err := tx.ExecContext(ctx, `pragma schema_version = 0`); err != nil {
+		return fmt.Errorf("normalize artifact identity schema version: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit artifact identity normalization: %w", err)
+	}
+	return nil
+}
+
+type identityTableColumns struct {
+	Names         []string
+	DeclaredTypes map[string]string
+}
+
+func artifactIdentityColumns(ctx context.Context, tx *sql.Tx, table string) (*identityTableColumns, error) {
+	var exists int
+	if err := tx.QueryRowContext(ctx, `select exists(select 1 from sqlite_schema where type = 'table' and name = ?)`, table).Scan(&exists); err != nil {
+		return nil, fmt.Errorf("inspect artifact identity table %s: %w", table, err)
+	}
+	if exists == 0 {
+		return nil, nil
+	}
+	rows, err := tx.QueryContext(ctx, `pragma table_info(`+quoteIdentifier(table)+`)`)
+	if err != nil {
+		return nil, fmt.Errorf("inspect artifact identity columns for %s: %w", table, err)
+	}
+	defer rows.Close()
+	columns := &identityTableColumns{DeclaredTypes: make(map[string]string)}
+	for rows.Next() {
+		var sequence, notNull, primaryKey int
+		var name, declaredType string
+		var defaultValue any
+		if err := rows.Scan(&sequence, &name, &declaredType, &notNull, &defaultValue, &primaryKey); err != nil {
+			return nil, fmt.Errorf("scan artifact identity columns for %s: %w", table, err)
+		}
+		columns.Names = append(columns.Names, name)
+		columns.DeclaredTypes[name] = declaredType
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read artifact identity columns for %s: %w", table, err)
+	}
+	return columns, nil
+}
+
+type identityTrigger struct {
+	Name string
+	SQL  string
+}
+
+func artifactIdentityTriggers(ctx context.Context, tx *sql.Tx) ([]identityTrigger, error) {
+	rows, err := tx.QueryContext(ctx, `
+		select name, sql
+		from sqlite_schema
+		where type = 'trigger' and sql is not null
+		order by name
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list artifact identity triggers: %w", err)
+	}
+	defer rows.Close()
+	var triggers []identityTrigger
+	for rows.Next() {
+		var trigger identityTrigger
+		if err := rows.Scan(&trigger.Name, &trigger.SQL); err != nil {
+			return nil, fmt.Errorf("scan artifact identity trigger: %w", err)
+		}
+		triggers = append(triggers, trigger)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read artifact identity triggers: %w", err)
+	}
+	return triggers, nil
+}
+
+func canonicalizeArtifactIdentityRows(
+	ctx context.Context,
+	tx *sql.Tx,
+	table string,
+	columns []string,
+	rowOrder []string,
+) error {
+	if len(columns) == 0 {
+		return nil
+	}
+	available := make(map[string]struct{}, len(columns))
+	columnSQL := make([]string, 0, len(columns))
+	for _, column := range columns {
+		available[column] = struct{}{}
+		columnSQL = append(columnSQL, quoteIdentifier(column))
+	}
+	orderSQL := make([]string, 0, len(rowOrder))
+	for _, column := range rowOrder {
+		if _, ok := available[column]; !ok {
+			return fmt.Errorf("artifact identity row order column %s.%s is missing", table, column)
+		}
+		orderSQL = append(orderSQL, quoteIdentifier(column)+` collate binary`)
+	}
+	const tempTable = "_gitcrawl_artifact_identity_rows"
+	if _, err := tx.ExecContext(ctx, `drop table if exists temp.`+quoteIdentifier(tempTable)); err != nil {
+		return fmt.Errorf("prepare artifact identity rows for %s: %w", table, err)
+	}
+	sourceSelectSQL := `select ` + strings.Join(columnSQL, ", ") + ` from ` + quoteIdentifier(table) +
+		` order by ` + strings.Join(orderSQL, ", ")
+	if _, err := tx.ExecContext(ctx, `create temp table `+quoteIdentifier(tempTable)+` as `+sourceSelectSQL); err != nil {
+		return fmt.Errorf("capture canonical artifact identity rows for %s: %w", table, err)
+	}
+	if _, err := tx.ExecContext(ctx, `delete from `+quoteIdentifier(table)); err != nil {
+		return fmt.Errorf("clear artifact identity rows for %s: %w", table, err)
+	}
+	tempSelectSQL := `select ` + strings.Join(columnSQL, ", ") + ` from temp.` + quoteIdentifier(tempTable) +
+		` order by ` + strings.Join(orderSQL, ", ")
+	if _, err := tx.ExecContext(ctx, `insert into `+quoteIdentifier(table)+` (`+strings.Join(columnSQL, ", ")+") "+tempSelectSQL); err != nil {
+		return fmt.Errorf("restore canonical artifact identity rows for %s: %w", table, err)
+	}
+	if _, err := tx.ExecContext(ctx, `drop table temp.`+quoteIdentifier(tempTable)); err != nil {
+		return fmt.Errorf("drop canonical artifact identity rows for %s: %w", table, err)
+	}
+	return nil
+}
+
+func validateArtifactIdentityPolicy(policy artifactIdentityPolicy) error {
+	if policy.Profile == "" {
+		return fmt.Errorf("artifact identity policy profile is empty")
+	}
+	seen := make(map[string]string)
+	for _, object := range policy.DroppedTriggers {
+		if err := validateIdentityPolicyName(object); err != nil {
+			return err
+		}
+		key := "trigger:" + object
+		if previous, ok := seen[key]; ok {
+			return fmt.Errorf("artifact identity policy repeats %s as %s", object, previous)
+		}
+		seen[key] = "trigger"
+	}
+	for _, object := range policy.DroppedTables {
+		if err := validateIdentityPolicyName(object); err != nil {
+			return err
+		}
+		key := "table:" + object
+		if previous, ok := seen[key]; ok {
+			return fmt.Errorf("artifact identity policy repeats %s as %s", object, previous)
+		}
+		seen[key] = "dropped table"
+	}
+	for _, table := range policy.Tables {
+		if err := validateIdentityPolicyName(table.Name); err != nil {
+			return err
+		}
+		key := "table:" + table.Name
+		if previous, ok := seen[key]; ok {
+			return fmt.Errorf("artifact identity policy repeats %s as %s and normalized table", table.Name, previous)
+		}
+		seen[key] = "normalized table"
+		columns := make(map[string]struct{})
+		for _, column := range table.Columns {
+			if err := validateIdentityPolicyName(column.Name); err != nil {
+				return err
+			}
+			if _, ok := columns[column.Name]; ok {
+				return fmt.Errorf("artifact identity policy repeats column %s.%s", table.Name, column.Name)
+			}
+			columns[column.Name] = struct{}{}
+			if column.DeclaredType != "TEXT" && column.DeclaredType != "INTEGER" {
+				return fmt.Errorf("artifact identity column %s.%s has unsupported type %q", table.Name, column.Name, column.DeclaredType)
+			}
+			if column.Kind < identityEmptyText || column.Kind > identityOneInteger {
+				return fmt.Errorf("artifact identity column %s.%s has unknown normalization %d", table.Name, column.Name, column.Kind)
+			}
+		}
+	}
+	return nil
+}
+
+func validateIdentityPolicyName(name string) error {
+	if name == "" || strings.ContainsAny(name, "\x00\"") {
+		return fmt.Errorf("artifact identity policy has unsafe name %q", name)
+	}
+	return nil
+}

--- a/internal/portable/identity_test.go
+++ b/internal/portable/identity_test.go
@@ -1,0 +1,456 @@
+package portable
+
+import (
+	"context"
+	"database/sql"
+	"encoding/binary"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestSemanticArtifactIdentityIgnoresExplicitLocalBookkeeping(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	defer st.Close()
+	baseline, err := Export(ctx, testExportOptions(sourcePath, filepath.Join(dir, "baseline")))
+	if err != nil {
+		t.Fatalf("export baseline: %v", err)
+	}
+	baselineDB := openRawDB(t, baseline.DatabasePath)
+	if _, err := baselineDB.ExecContext(ctx, `
+		update threads set closed_at_local = '2026-08-08T00:00:00Z', close_reason_local = 'not returned by source';
+		insert into comments(id, thread_id, github_id, comment_type, body, raw_json, deleted_at, deletion_reason)
+		values(2, 1, 'C2', 'issue_comment', 'tombstoned comment', '', '2026-08-08T00:00:00Z', 'not returned by source');
+	`); err != nil {
+		t.Fatalf("seed local timestamp presence: %v", err)
+	}
+	if err := baselineDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	baselineExactSHA := hashFile(t, baseline.DatabasePath)
+	baselineArtifactID, err := ComputeArtifactID(ctx, baseline.DatabasePath, CurrentStateSemanticV1)
+	if err != nil {
+		t.Fatalf("compute local policy baseline: %v", err)
+	}
+
+	mutations := []struct {
+		name string
+		sql  string
+	}{
+		{name: "observation convergence", sql: `update observation_schema_convergence set checked_observation_sequence = 42`},
+		{name: "pipeline state", sql: `create table repo_pipeline_state(repo_id integer, phase text, updated_at text); insert into repo_pipeline_state values(1, 'sync', 'later')`},
+		{name: "repository sync state", sql: `update repo_sync_state set updated_at = 'later'`},
+		{name: "observation allocator", sql: `update thread_observation_sequence set value = 42, last_started_at = 'later'`},
+		{name: "child reservation", sql: `update thread_child_observation_reservations set source_updated_at = 'later', observation_sequence = 42`},
+		{name: "workflow reservation", sql: `update workflow_run_observation_reservations set source_updated_at = 'later', observation_sequence = 42`},
+		{name: "review sync marker", sql: `update pull_request_review_thread_syncs set fetched_at = 'later'`},
+		{name: "SQLite planner statistics", sql: `analyze`},
+		{name: "repository updated at", sql: `update repositories set updated_at = 'later'`},
+		{name: "thread first pulled", sql: `update threads set first_pulled_at = 'later'`},
+		{name: "thread last pulled", sql: `update threads set last_pulled_at = 'later'`},
+		{name: "thread updated at", sql: `update threads set updated_at = 'later'`},
+		{name: "thread observation sequence", sql: `update threads set observation_sequence = 42`},
+		{name: "thread evidence sequence", sql: `update threads set evidence_observation_sequence = 42`},
+		{name: "thread evidence source time", sql: `update threads set evidence_source_updated_at = 'later'`},
+		{name: "thread local closure time", sql: `update threads set closed_at_local = 'later'`},
+		{name: "comment tombstone time", sql: `update comments set deleted_at = 'later' where id = 2`},
+		{name: "revision observation sequence", sql: `update thread_revisions set observation_sequence = 42`},
+		{name: "revision record time", sql: `update thread_revisions set created_at = 'later'`},
+		{name: "membership observation sequence", sql: `update thread_child_observation_memberships set observation_sequence = 42`},
+		{name: "fingerprint record time", sql: `update thread_fingerprints set created_at = 'later'`},
+		{name: "PR detail fetch time", sql: `update pull_request_details set fetched_at = 'later'`},
+		{name: "PR detail local update time", sql: `update pull_request_details set updated_at = 'later'`},
+		{name: "PR file fetch time", sql: `update pull_request_files set fetched_at = 'later'`},
+		{name: "PR commit fetch time", sql: `update pull_request_commits set fetched_at = 'later'`},
+		{name: "PR commit tombstone time", sql: `update pull_request_commits set deleted_at = 'later'`},
+		{name: "PR check fetch time", sql: `update pull_request_checks set fetched_at = 'later'`},
+		{name: "review thread fetch time", sql: `update pull_request_review_threads set fetched_at = 'later'`},
+		{name: "review thread tombstone time", sql: `update pull_request_review_threads set deleted_at = 'later'`},
+		{name: "review revision fetch time", sql: `update pull_request_review_thread_revisions set fetched_at = 'later'`},
+		{name: "review revision record time", sql: `update pull_request_review_thread_revisions set recorded_at = 'later'`},
+		{name: "review revision tombstone time", sql: `update pull_request_review_thread_revisions set deleted_at = 'later'`},
+		{name: "workflow fetch time", sql: `update github_workflow_runs set fetched_at = 'later'`},
+	}
+	for _, mutation := range mutations {
+		t.Run(mutation.name, func(t *testing.T) {
+			mutatedPath := copyIdentityTestDatabase(t, baseline.DatabasePath, filepath.Join(dir, "local-"+strings.ReplaceAll(mutation.name, " ", "-")+".db"))
+			db := openRawDB(t, mutatedPath)
+			if _, err := db.ExecContext(ctx, mutation.sql); err != nil {
+				t.Fatalf("apply local mutation: %v", err)
+			}
+			if err := db.Close(); err != nil {
+				t.Fatalf("close locally mutated database: %v", err)
+			}
+			if got := hashFile(t, mutatedPath); got == baselineExactSHA {
+				t.Fatal("local mutation did not change exact file SHA")
+			}
+			got, err := ComputeArtifactID(ctx, mutatedPath, CurrentStateSemanticV1)
+			if err != nil {
+				t.Fatalf("compute local mutation identity: %v", err)
+			}
+			if got != baselineArtifactID {
+				t.Fatalf("local mutation identity = %s, want %s", got, baselineArtifactID)
+			}
+		})
+	}
+}
+
+func TestSemanticArtifactIdentityIncludesMeaningfulState(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	defer st.Close()
+	baseline, err := Export(ctx, testExportOptions(sourcePath, filepath.Join(dir, "baseline")))
+	if err != nil {
+		t.Fatalf("export baseline: %v", err)
+	}
+
+	mutations := []struct {
+		name string
+		sql  string
+	}{
+		{name: "thread title", sql: `update threads set title = 'meaningfully changed'`},
+		{name: "thread body excerpt and length", sql: `update threads set body = 'changed body', body_excerpt = 'changed body', body_length = 12`},
+		{name: "thread labels", sql: `update threads set labels_json = '["changed"]'`},
+		{name: "thread assignees", sql: `update threads set assignees_json = '["octocat"]'`},
+		{name: "thread state", sql: `update threads set state = 'closed'`},
+		{name: "thread URL", sql: `update threads set html_url = 'https://github.com/openclaw/gitcrawl/pull/700'`},
+		{name: "thread content hash", sql: `update threads set content_hash = 'meaningfully changed'`},
+		{name: "comment body", sql: `update comments set body = 'meaningfully changed'`},
+		{name: "new row", sql: `insert into comments(id, thread_id, github_id, comment_type, body, raw_json) values(2, 1, 'C2', 'issue_comment', 'new comment', '')`},
+		{name: "membership IDs", sql: `update thread_child_observation_memberships set member_ids_json = '["C1","C2"]'`},
+		{name: "revision content", sql: `update thread_revisions set content_hash = 'meaningfully changed'`},
+		{name: "fingerprint content", sql: `update thread_fingerprints set fingerprint_hash = 'meaningfully changed'`},
+		{name: "PR field", sql: `update pull_request_details set base_sha = 'meaningfully-changed'`},
+		{name: "workflow public state", sql: `update github_workflow_runs set status = 'in_progress'`},
+		{name: "public timestamp", sql: `update threads set updated_at_gh = '2026-08-09T00:00:00Z'`},
+		{name: "repository identity", sql: `update repositories set full_name = 'openclaw/renamed'`},
+		{name: "unknown future column", sql: `alter table threads add column future_public_value text; update threads set future_public_value = 'retained'`},
+	}
+	for _, mutation := range mutations {
+		t.Run(mutation.name, func(t *testing.T) {
+			mutatedPath := copyIdentityTestDatabase(t, baseline.DatabasePath, filepath.Join(dir, "public-"+strings.ReplaceAll(mutation.name, " ", "-")+".db"))
+			db := openRawDB(t, mutatedPath)
+			if _, err := db.ExecContext(ctx, mutation.sql); err != nil {
+				t.Fatalf("apply meaningful mutation: %v", err)
+			}
+			if err := db.Close(); err != nil {
+				t.Fatalf("close meaningfully mutated database: %v", err)
+			}
+			got, err := ComputeArtifactID(ctx, mutatedPath, CurrentStateSemanticV1)
+			if err != nil {
+				t.Fatalf("compute meaningful mutation identity: %v", err)
+			}
+			if got == baseline.ArtifactID {
+				t.Fatalf("meaningful mutation retained artifact identity %s", got)
+			}
+		})
+	}
+}
+
+func TestSemanticArtifactIdentityCanonicalizesCompositeKeyRowids(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	create := func(name string, order []int) string {
+		t.Helper()
+		path := filepath.Join(dir, name+".db")
+		db := openRawDB(t, path)
+		if _, err := db.Exec(`
+			create table pull_request_files(
+				thread_id integer not null,
+				position integer not null,
+				path text not null,
+				fetched_at text not null,
+				primary key(thread_id, position)
+			)
+		`); err != nil {
+			t.Fatal(err)
+		}
+		for _, position := range order {
+			if _, err := db.Exec(`insert into pull_request_files values(1, ?, ?, ?)`, position, strings.Repeat("x", position+1), "local-time"); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	forward := create("forward", []int{0, 1})
+	reverse := create("reverse", []int{1, 0})
+	if hashFile(t, forward) == hashFile(t, reverse) {
+		t.Fatal("fixture insertion order did not change SQLite bytes")
+	}
+	forwardID, err := ComputeArtifactID(ctx, forward, CurrentStateSemanticV1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reverseID, err := ComputeArtifactID(ctx, reverse, CurrentStateSemanticV1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if forwardID != reverseID {
+		t.Fatalf("composite-key insertion order changed semantic identity: forward=%s reverse=%s", forwardID, reverseID)
+	}
+}
+
+func TestArtifactIdentityHashCanonicalizesSQLiteWriterHeader(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.db")
+	db := openRawDB(t, basePath)
+	if _, err := db.Exec(`create table payload(id integer primary key, value text); insert into payload values(1, 'public')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	firstPath := copyIdentityTestDatabase(t, basePath, filepath.Join(dir, "first.db"))
+	secondPath := copyIdentityTestDatabase(t, basePath, filepath.Join(dir, "second.db"))
+	writeHeader := func(path string, changeCounter, validFor, writerVersion uint32) {
+		t.Helper()
+		file, err := os.OpenFile(path, os.O_RDWR, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		header := make([]byte, 100)
+		if _, err := file.ReadAt(header, 0); err != nil {
+			_ = file.Close()
+			t.Fatal(err)
+		}
+		binary.BigEndian.PutUint32(header[24:28], changeCounter)
+		binary.BigEndian.PutUint32(header[92:96], validFor)
+		binary.BigEndian.PutUint32(header[96:100], writerVersion)
+		if _, err := file.WriteAt(header, 0); err != nil {
+			_ = file.Close()
+			t.Fatal(err)
+		}
+		if err := file.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeHeader(firstPath, 1, 1, 3049000)
+	writeHeader(secondPath, 99, 99, 3050000)
+	if hashFile(t, firstPath) == hashFile(t, secondPath) {
+		t.Fatal("fixture writer headers did not change exact file hashes")
+	}
+	firstHash, err := hashArtifactIdentityFile(firstPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondHash, err := hashArtifactIdentityFile(secondPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstHash != secondHash {
+		t.Fatalf("SQLite writer header changed semantic file hash: first=%s second=%s", firstHash, secondHash)
+	}
+	for _, path := range []string{firstPath, secondPath} {
+		db := openRawDB(t, path)
+		if got, err := checkPragma(ctx, db, "quick_check"); err != nil || got != "ok" {
+			_ = db.Close()
+			t.Fatalf("canonical identity header quick_check = %q, %v", got, err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	invalidPath := filepath.Join(dir, "invalid.db")
+	if err := os.WriteFile(invalidPath, make([]byte, 100), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := hashArtifactIdentityFile(invalidPath); err == nil || !strings.Contains(err.Error(), "invalid SQLite header") {
+		t.Fatalf("invalid identity header error = %v", err)
+	}
+}
+
+func TestSemanticArtifactIdentityOptionalSchemaAndTypeSafety(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	minimalPath := filepath.Join(dir, "minimal.db")
+	db := openRawDB(t, minimalPath)
+	if _, err := db.Exec(`create table repositories(id integer primary key, future_public text); insert into repositories values(1, 'one')`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	first, err := ComputeArtifactID(ctx, minimalPath, CurrentStateSemanticV1)
+	if err != nil {
+		t.Fatalf("compute minimal optional-schema identity: %v", err)
+	}
+	db = openRawDB(t, minimalPath)
+	if _, err := db.Exec(`update repositories set future_public = 'two'`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	second, err := ComputeArtifactID(ctx, minimalPath, CurrentStateSemanticV1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Fatal("unknown future column was excluded from semantic identity")
+	}
+
+	wrongTypePath := filepath.Join(dir, "wrong-type.db")
+	db = openRawDB(t, wrongTypePath)
+	if _, err := db.Exec(`create table repositories(id integer primary key, updated_at integer); insert into repositories values(1, 7)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ComputeArtifactID(ctx, wrongTypePath, CurrentStateSemanticV1); err == nil || !strings.Contains(err.Error(), `repositories.updated_at has type "INTEGER", want TEXT`) {
+		t.Fatalf("wrong-type identity error = %v", err)
+	}
+}
+
+func TestSemanticArtifactIdentityCleanupCancellationAndFailure(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	defer st.Close()
+	baseline, err := Export(ctx, testExportOptions(sourcePath, filepath.Join(dir, "baseline")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	exactBefore := hashFile(t, baseline.DatabasePath)
+
+	t.Run("cancel backup", func(t *testing.T) {
+		tempParent := t.TempDir()
+		cancelCtx, cancel := context.WithCancel(context.Background())
+		_, err := computeArtifactIDWithOptions(cancelCtx, baseline.DatabasePath, currentStateSemanticPolicy, artifactIdentityOptions{
+			TempParent: tempParent,
+			Backup: onlineBackupOptions{PagesPerStep: 1, AfterStep: func(remaining, _ int) {
+				if remaining > 0 {
+					cancel()
+				}
+			}},
+		})
+		if err == nil || !errors.Is(err, context.Canceled) {
+			t.Fatalf("canceled artifact identity error = %v", err)
+		}
+		assertNoIdentityTemps(t, tempParent)
+	})
+
+	t.Run("cancel after normalization", func(t *testing.T) {
+		tempParent := t.TempDir()
+		cancelCtx, cancel := context.WithCancel(context.Background())
+		_, err := computeArtifactIDWithOptions(cancelCtx, baseline.DatabasePath, currentStateSemanticPolicy, artifactIdentityOptions{
+			TempParent: tempParent,
+			AfterNormalize: func(*sql.DB) error {
+				cancel()
+				return nil
+			},
+		})
+		if err == nil || !errors.Is(err, context.Canceled) {
+			t.Fatalf("post-normalization cancellation error = %v", err)
+		}
+		assertNoIdentityTemps(t, tempParent)
+	})
+
+	t.Run("injected failure", func(t *testing.T) {
+		tempParent := t.TempDir()
+		marker := errors.New("identity hook failed")
+		_, err := computeArtifactIDWithOptions(ctx, baseline.DatabasePath, currentStateSemanticPolicy, artifactIdentityOptions{
+			TempParent: tempParent,
+			AfterSnapshot: func(string) error {
+				return marker
+			},
+		})
+		if !errors.Is(err, marker) {
+			t.Fatalf("injected artifact identity error = %v", err)
+		}
+		assertNoIdentityTemps(t, tempParent)
+	})
+
+	if exactAfter := hashFile(t, baseline.DatabasePath); exactAfter != exactBefore {
+		t.Fatalf("artifact identity computation mutated finalized database: before=%s after=%s", exactBefore, exactAfter)
+	}
+	if _, err := ComputeArtifactID(ctx, baseline.DatabasePath, "future-semantic-v2"); err == nil || !strings.Contains(err.Error(), "unsupported artifact identity profile") {
+		t.Fatalf("unknown artifact identity profile error = %v", err)
+	}
+}
+
+func TestCurrentStateSemanticPolicyIsExplicitAndValid(t *testing.T) {
+	if err := validateArtifactIdentityPolicy(currentStateSemanticPolicy); err != nil {
+		t.Fatalf("current semantic identity policy: %v", err)
+	}
+	wantDropped := []string{
+		"observation_schema_convergence",
+		"pull_request_review_thread_syncs",
+		"repo_pipeline_state",
+		"repo_sync_state",
+		"sqlite_stat1",
+		"sqlite_stat4",
+		"thread_child_observation_reservations",
+		"thread_observation_sequence",
+		"workflow_run_observation_reservations",
+	}
+	got := append([]string(nil), currentStateSemanticPolicy.DroppedTables...)
+	sort.Strings(got)
+	if !slices.Equal(got, wantDropped) {
+		t.Fatalf("dropped identity tables = %v, want %v", got, wantDropped)
+	}
+	bad := currentStateSemanticPolicy
+	bad.Tables = append([]identityTablePolicy(nil), bad.Tables...)
+	bad.Tables = append(bad.Tables, bad.Tables[0])
+	if err := validateArtifactIdentityPolicy(bad); err == nil || !strings.Contains(err.Error(), "repeats") {
+		t.Fatalf("duplicate identity policy error = %v", err)
+	}
+}
+
+func BenchmarkSemanticArtifactIdentity92MB(b *testing.B) {
+	ctx := context.Background()
+	dbPath := filepath.Join(b.TempDir(), "artifact.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if _, err := db.Exec(`create table public_payload(id integer primary key, payload blob not null); insert into public_payload values(1, zeroblob(?))`, 92*1024*1024); err != nil {
+		b.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for range b.N {
+		if _, err := ComputeArtifactID(ctx, dbPath, CurrentStateSemanticV1); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func copyIdentityTestDatabase(t *testing.T, source, target string) string {
+	t.Helper()
+	data, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return target
+}
+
+func assertNoIdentityTemps(t *testing.T, parent string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(parent, "gitcrawl-artifact-identity-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("artifact identity temporary files remain: %v", matches)
+	}
+}


### PR DESCRIPTION
## Summary

- keep exact SQLite `sha256` as byte-integrity identity
- add semantic `artifactId` profile `current-state-semantic-v1` for publication no-op decisions
- normalize only explicit local ingestion/observation bookkeeping in a disposable compact copy
- recompute and validate semantic identity when loading manifests

## Why

ClawSweeper sync updates local observation counters, pull timestamps, reservations, and pipeline state for re-pulled threads even when public GitHub state is unchanged. Exact DB bytes must reflect those changes, but using the file SHA for publisher no-op decisions creates large commits from local-only churn.

The semantic identity retains public content, states, GitHub timestamps, memberships, revisions, fingerprints, PR/workflow data, URLs, and repository identity. Unknown future fields remain included by default.

## Verification

- local-only field/table mutations change file SHA but preserve semantic artifact ID
- meaningful content, row, membership, revision, fingerprint, and PR changes alter artifact ID
- insertion order, SQLite header counters, planner statistics, and export time do not alter identity
- identity temp cleanup and cancellation/failure paths covered
- real 92 MB ClawSweeper artifacts computed in ~1.34 seconds each
- real published/probe artifacts with public additions produced different semantic IDs
- `make test-coverage`: 85.0%
- full uncached tests and `make test`
- Windows amd64 compile-only tests
- clean autoreview
