### PR TITLE
fix(portable): preserve schema in current-state exports

### DIFF
--- a/internal/portable/export.go
+++ b/internal/portable/export.go
@@ -38,7 +38,7 @@ const (
 type Profile struct {
 	Name          string
 	Version       int
-	DroppedTables []string
+	ClearedTables []string
 	Capabilities  []string
 	Excluded      []string
 	IndexProfile  string
@@ -48,7 +48,7 @@ type Profile struct {
 var currentStateProfile = Profile{
 	Name:    CurrentStateV1,
 	Version: currentProfileVersion,
-	DroppedTables: []string{
+	ClearedTables: []string{
 		"comment_revisions",
 		"thread_key_summaries",
 		"cluster_closures",
@@ -320,13 +320,9 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 		return result, err
 	}
 	var droppedTables []string
-	for _, table := range profile.DroppedTables {
-		dropped, err := dropTableIfPresent(ctx, st.DB(), table)
-		if err != nil {
-			return result, err
-		}
-		if dropped {
-			droppedTables = appendUnique(droppedTables, table)
+	for _, table := range profile.ClearedTables {
+		if _, err := st.DB().ExecContext(ctx, `delete from `+quoteIdentifier(table)); err != nil {
+			return result, fmt.Errorf("clear portable table %s: %w", table, err)
 		}
 	}
 	if err := reportProgress(ctx, options.Progress, StageCanonicalShaping); err != nil {
@@ -874,20 +870,6 @@ func verifyRepository(ctx context.Context, db *sql.DB, expected Repository) erro
 		return fmt.Errorf("portable repository restriction did not preserve exactly %s", expected.FullName)
 	}
 	return nil
-}
-
-func dropTableIfPresent(ctx context.Context, db *sql.DB, table string) (bool, error) {
-	var exists int
-	if err := db.QueryRowContext(ctx, `select exists(select 1 from sqlite_schema where type = 'table' and name = ?)`, table).Scan(&exists); err != nil {
-		return false, fmt.Errorf("inspect portable table %s: %w", table, err)
-	}
-	if exists == 0 {
-		return false, nil
-	}
-	if _, err := db.ExecContext(ctx, `drop table `+quoteIdentifier(table)); err != nil {
-		return false, fmt.Errorf("drop portable table %s: %w", table, err)
-	}
-	return true, nil
 }
 
 func quoteIdentifier(value string) string {

--- a/internal/portable/export_failure_paths_test.go
+++ b/internal/portable/export_failure_paths_test.go
@@ -439,32 +439,6 @@ func TestPortableFileHelpersRejectUnsafeDestinations(t *testing.T) {
 	}
 }
 
-func TestPortableTableDropFailsClosedOnForeignKeyConstraint(t *testing.T) {
-	ctx := context.Background()
-	db := openRawDB(t, filepath.Join(t.TempDir(), "drop.db"))
-	defer db.Close()
-	db.SetMaxOpenConns(1)
-	if _, err := db.ExecContext(ctx, `
-		pragma foreign_keys = on;
-		create table parent(id integer primary key);
-		create table child(parent_id integer references parent(id));
-		insert into parent values(1);
-		insert into child values(1);
-	`); err != nil {
-		t.Fatal(err)
-	}
-	dropped, err := dropTableIfPresent(ctx, db, "parent")
-	if err == nil || dropped || !strings.Contains(err.Error(), "drop portable table parent") {
-		t.Fatalf("foreign-key constrained drop = %v, %v", dropped, err)
-	}
-	if !tableExists(t, db, "parent") {
-		t.Fatal("failed constrained drop removed parent table")
-	}
-	if dropped, err := dropTableIfPresent(ctx, db, "missing"); err != nil || dropped {
-		t.Fatalf("missing table drop = %v, %v", dropped, err)
-	}
-}
-
 func TestCompactReplacementRejectsRetainedSidecars(t *testing.T) {
 	ctx := context.Background()
 	for _, target := range []string{"candidate", "working"} {
@@ -533,7 +507,6 @@ func TestPortableDatabaseHelpersPropagateCancellation(t *testing.T) {
 		{name: "table stats", run: func() error { _, err := databaseTableStats(ctx, db); return err }},
 		{name: "repository", run: func() error { _, err := singleRepository(ctx, db); return err }},
 		{name: "verify repository", run: func() error { return verifyRepository(ctx, db, Repository{FullName: "openclaw/gitcrawl"}) }},
-		{name: "drop table", run: func() error { _, err := dropTableIfPresent(ctx, db, "disposable"); return err }},
 		{name: "metadata", run: func() error { return writeMetadata(ctx, db, map[string]string{"schema": "portable-v1"}) }},
 		{name: "pragma", run: func() error { _, err := checkPragma(ctx, db, "quick_check"); return err }},
 	}

--- a/internal/portable/export_test.go
+++ b/internal/portable/export_test.go
@@ -71,9 +71,12 @@ func TestExportCurrentStateV1SnapshotsLiveWALWithoutMutatingSource(t *testing.T)
 	if journalMode != "delete" {
 		t.Fatalf("artifact journal mode = %q, want delete", journalMode)
 	}
-	for _, table := range currentStateProfile.DroppedTables {
-		if tableExists(t, db, table) {
-			t.Fatalf("omitted table %s still exists", table)
+	for _, table := range currentStateProfile.ClearedTables {
+		if !tableExists(t, db, table) {
+			t.Fatalf("cleared table %s is missing", table)
+		}
+		if got := rowCount(t, db, table); got != 0 {
+			t.Fatalf("cleared table %s row count = %d, want 0", table, got)
 		}
 	}
 	for _, table := range []string{
@@ -131,11 +134,13 @@ func TestExportCurrentStateV1SnapshotsLiveWALWithoutMutatingSource(t *testing.T)
 	if slices.Contains(result.DroppedIndexes, "unique_threads_github_id") || !indexExists(t, db, "unique_threads_github_id") {
 		t.Fatalf("explicit unique threads index was not preserved: dropped=%v exists=%v", result.DroppedIndexes, indexExists(t, db, "unique_threads_github_id"))
 	}
-	if slices.Contains(result.DroppedIndexes, "idx_comment_revisions_comment") || slices.Contains(result.DroppedIndexes, "custom_comment_revisions_body") {
-		t.Fatalf("implicitly removed indexes were reported as explicitly dropped: %v", result.DroppedIndexes)
+	if !slices.Contains(result.DroppedIndexes, "idx_comment_revisions_comment") || !slices.Contains(result.DroppedIndexes, "custom_comment_revisions_body") {
+		t.Fatalf("cleared-table indexes were not removed explicitly: %v", result.DroppedIndexes)
 	}
-	if len(result.DroppedTables) < len(currentStateProfile.DroppedTables) || !slices.Equal(result.DroppedTables[:len(currentStateProfile.DroppedTables)], currentStateProfile.DroppedTables) {
-		t.Fatalf("profile tables were not dropped first: %v", result.DroppedTables)
+	for _, table := range currentStateProfile.ClearedTables {
+		if slices.Contains(result.DroppedTables, table) {
+			t.Fatalf("cleared table %s reported as dropped: %v", table, result.DroppedTables)
+		}
 	}
 	seenDroppedTables := make(map[string]bool)
 	for _, table := range result.DroppedTables {
@@ -165,6 +170,31 @@ func TestExportCurrentStateV1SnapshotsLiveWALWithoutMutatingSource(t *testing.T)
 	assertManifestTableCounts(t, db, manifest.Tables)
 	if violations, err := testForeignKeyViolationCount(ctx, db); err != nil || violations != 0 {
 		t.Fatalf("independent final artifact FK violations=%d err=%v", violations, err)
+	}
+}
+
+func TestExportedDatabaseReportsStatusReadOnly(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	defer st.Close()
+
+	result, err := Export(ctx, testExportOptions(sourcePath, filepath.Join(dir, "artifact")))
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	exported, err := store.OpenReadOnly(ctx, result.DatabasePath)
+	if err != nil {
+		t.Fatalf("open exported database read-only: %v", err)
+	}
+	defer exported.Close()
+	status, err := exported.Status(ctx)
+	if err != nil {
+		t.Fatalf("read exported database status: %v", err)
+	}
+	if status.RepositoryCount != 1 || status.ThreadCount != 1 || status.ClusterCount != 0 {
+		t.Fatalf("exported database status = %+v", status)
 	}
 }
 
@@ -392,8 +422,8 @@ func TestExportScopedRepositoryKeepsOnlyRequestedDependentData(t *testing.T) {
 		t.Fatalf("scoped manifest repository = %+v, result = %+v", manifest.Repository, result.Repository)
 	}
 	assertManifestTableCounts(t, db, manifest.Tables)
-	if slices.Contains(result.DroppedIndexes, "idx_comment_revisions_comment") || slices.Contains(result.DroppedIndexes, "custom_comment_revisions_body") {
-		t.Fatalf("dropped indexes include indexes removed with a table: %v", result.DroppedIndexes)
+	if !slices.Contains(result.DroppedIndexes, "idx_comment_revisions_comment") || !slices.Contains(result.DroppedIndexes, "custom_comment_revisions_body") {
+		t.Fatalf("cleared-table indexes were not removed explicitly: %v", result.DroppedIndexes)
 	}
 }
 
@@ -825,7 +855,7 @@ func TestRemoveSQLiteSidecarsFailsClosed(t *testing.T) {
 	}
 }
 
-func TestExportedDatabaseReopensWritableAndRecreatesOmittedSchema(t *testing.T) {
+func TestExportedDatabaseReopensWritableWithInvariantSchema(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
 	sourcePath := filepath.Join(dir, "source.db")
@@ -848,13 +878,13 @@ func TestExportedDatabaseReopensWritableAndRecreatesOmittedSchema(t *testing.T) 
 			t.Fatalf("writable reopen did not restore %s.%s", column.table, column.name)
 		}
 	}
-	for _, table := range currentStateProfile.DroppedTables {
+	for _, table := range currentStateProfile.ClearedTables {
 		if !tableExists(t, writable.DB(), table) {
-			t.Fatalf("migration did not recreate %s", table)
+			t.Fatalf("writable reopen lost %s", table)
 		}
 		if table != "comment_revisions" && rowCount(t, writable.DB(), table) != 0 {
 			got := rowCount(t, writable.DB(), table)
-			t.Fatalf("recreated history table %s has %d rows", table, got)
+			t.Fatalf("cleared table %s has %d rows", table, got)
 		}
 	}
 	var historicalComments int


### PR DESCRIPTION
## Problem

The exporter deleted empty tables to save space, but `gitcrawl status` still queries one of those tables. Read-only clients cannot recreate it, so status failed with `no such table: cluster_groups`.

## Fix

- keep the current-state SQLite schema intact
- clear excluded rows instead of dropping their tables
- remove the obsolete table-drop path

## Regression proof

The new read-only status test fails on `origin/main`:

```text
read exported database status: count clusters: SQL logic error: no such table: cluster_groups (1)
```

The same test passes on this branch.

## Real behavior proof

Built the current client from `28d2aed1e73e`, then generated a fresh current-state export from a 55,808-thread archive. Export validation reported `quick_check: ok`, `integrity_check: ok`, zero foreign-key violations, and 93,102,080 bytes against the 99,999,999-byte budget.

The artifact was made filesystem read-only before either status command. Paths are redacted; JSON is narrowed to status fields.

```console
$ stat -c 'mode=%a bytes=%s' ARTIFACT/gitcrawl.db
mode=444 bytes=93102080
$ sha256sum ARTIFACT/gitcrawl.db
33635324e628b007db3b85e1a266156327367bf04a19fa776f05ecb48fa78edf  ARTIFACT/gitcrawl.db

$ gitcrawl-v0.8.4 --version
0.8.4
$ gitcrawl-v0.8.4 status --json | jq '{state,summary,database_bytes,counts}'
{
  "state": "current",
  "summary": "55808 threads across 1 repositories",
  "database_bytes": 93102080,
  "counts": [
    {"id":"repositories","label":"Repositories","value":1},
    {"id":"threads","label":"Threads","value":55808},
    {"id":"open_threads","label":"Open threads","value":18012},
    {"id":"clusters","label":"Clusters","value":0}
  ]
}

$ gitcrawl-current status --json | jq '{state,summary,database_bytes,counts}'
{
  "state": "current",
  "summary": "55808 threads across 1 repositories",
  "database_bytes": 93102080,
  "counts": [
    {"id":"repositories","label":"Repositories","value":1},
    {"id":"threads","label":"Threads","value":55808},
    {"id":"open_threads","label":"Open threads","value":18012},
    {"id":"clusters","label":"Clusters","value":0}
  ]
}

$ sha256sum ARTIFACT/gitcrawl.db
33635324e628b007db3b85e1a266156327367bf04a19fa776f05ecb48fa78edf  ARTIFACT/gitcrawl.db
```

The unchanged hash proves both clients opened the fresh export without migration.

## Validation

- `GOWORK=off go test ./internal/portable ./internal/store -count=1`
- `GOWORK=off go vet ./internal/portable`
- `git diff --check`

The full suite reaches two pre-existing stale-index-lock failures; both reproduce on untouched `origin/main`.
