### PR TITLE
fix(portable): export gzip artifact generations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ producing spuriously different exports.
 
 - Add streamlined `portable export` generations with single-pass sanitized compatibility tables and compact final files. Artifact identity now ignores explicit local ingestion churn while retaining exact SQLite SHA-256 integrity, so re-exporting unchanged data yields the same identity. Includes granular progress reporting and clean interruption handling.
 - Preserve the full schema in current-state exports, so a restored database matches the source structure rather than only its rows.
+- Let `portable export` atomically produce manifest-backed gzip generations with a separate archive byte budget, so growing portable databases stay publishable without moving compression into downstream scripts.
 
 ### Dependencies and maintenance
 

--- a/docs/portable-stores.md
+++ b/docs/portable-stores.md
@@ -143,7 +143,8 @@ gitcrawl --config /path/to/config.toml portable export \
   --database-name openclaw__openclaw.sync.db \
   --public-path data/openclaw__openclaw.sync.db \
   --repository openclaw/openclaw \
-  --max-bytes 99999999 \
+  --compression gzip \
+  --max-archive-bytes 99999999 \
   --json
 ```
 
@@ -153,9 +154,11 @@ renames the complete pair into place only after validation. The database name
 defaults to `gitcrawl.db` and must be a safe basename. `--public-path` defaults
 to that name and is a clean relative slash path recorded in the manifest and
 `portable_metadata`; it is a logical consumer path, never the source or output
-host path. `--body-chars` defaults to `256`. `--max-bytes` is optional and
-inclusive, so a deployment requiring a database smaller than 100,000,000 bytes
-should pass `99999999` rather than relying on a Gitcrawl-specific hosting limit.
+host path. `--body-chars` defaults to `256`. `--max-bytes` is an optional,
+inclusive limit for raw database generations. `--compression gzip` instead
+commits only the gzip archive and manifest in the generation. Pair it with
+`--max-archive-bytes`; a Git host requiring an artifact smaller than
+100,000,000 bytes should pass `99999999`.
 The optional `--repository owner/repo` is semantic export behavior: Gitcrawl
 removes all other repositories and their dependent rows from the disposable
 snapshot, verifies the exact remaining identity, and records it in the manifest.
@@ -174,6 +177,10 @@ normalized compact copy and is identified by
 `artifact_id_profile`). Publishers should use `artifactId` for no-op decisions
 and `sha256` for file integrity: repeated ingestion may legitimately change the
 file SHA while retaining the same meaningful portable state.
+For gzip generations, the manifest also records `compression`, `archivePath`,
+`archiveBytes`, `archiveSha256`, and `maxArchiveBytes`. Gitcrawl validates the
+archive against both compressed and expanded identities before atomically
+committing the generation.
 Destructive `portable prune` continues to record its operation time as
 `portable_metadata.exported_at`.
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -3441,10 +3441,13 @@ func (a *App) runPortableExport(ctx context.Context, args []string) error {
 	publicPath := fs.String("public-path", "", "logical portable database path")
 	repositoryRaw := fs.String("repository", "", "restrict the artifact to one owner/repo")
 	maxBytesRaw := fs.String("max-bytes", "", "maximum finalized database bytes")
+	compression := fs.String("compression", "", "artifact compression (gzip)")
+	maxArchiveBytesRaw := fs.String("max-archive-bytes", "", "maximum finalized archive bytes")
 	jsonOut := fs.Bool("json", false, "write JSON output")
 	valueFlags := map[string]bool{
 		"profile": true, "body-chars": true, "output-dir": true,
 		"database-name": true, "public-path": true, "repository": true, "max-bytes": true,
+		"compression": true, "max-archive-bytes": true,
 	}
 	if err := fs.Parse(normalizeCommandArgs(args, valueFlags)); err != nil {
 		return usageErr(err)
@@ -3473,6 +3476,20 @@ func (a *App) runPortableExport(ctx context.Context, args []string) error {
 			return usageErr(fmt.Errorf("--max-bytes must be a positive integer"))
 		}
 		maxBytes = &parsed
+	}
+	var maxArchiveBytes *int64
+	if strings.TrimSpace(*maxArchiveBytesRaw) != "" {
+		parsed, err := strconv.ParseInt(strings.TrimSpace(*maxArchiveBytesRaw), 10, 64)
+		if err != nil || parsed <= 0 {
+			return usageErr(fmt.Errorf("--max-archive-bytes must be a positive integer"))
+		}
+		maxArchiveBytes = &parsed
+	}
+	if *compression != "" && *compression != portableexport.CompressionGzip {
+		return usageErr(fmt.Errorf("--compression must be %q", portableexport.CompressionGzip))
+	}
+	if maxArchiveBytes != nil && *compression == "" {
+		return usageErr(fmt.Errorf("--max-archive-bytes requires --compression"))
 	}
 	logicalPath := *publicPath
 	if logicalPath == "" {
@@ -3509,14 +3526,16 @@ func (a *App) runPortableExport(ctx context.Context, args []string) error {
 	progressStarted := time.Now()
 	progressPrevious := progressStarted
 	result, err := portableexport.Export(ctx, portableexport.ExportOptions{
-		SourceDBPath: sourceDBPath,
-		OutputDir:    *outputDir,
-		DatabaseName: *databaseName,
-		PublicPath:   logicalPath,
-		Profile:      *profile,
-		Repository:   repository,
-		BodyChars:    bodyChars,
-		MaxBytes:     maxBytes,
+		SourceDBPath:    sourceDBPath,
+		OutputDir:       *outputDir,
+		DatabaseName:    *databaseName,
+		PublicPath:      logicalPath,
+		Profile:         *profile,
+		Repository:      repository,
+		BodyChars:       bodyChars,
+		MaxBytes:        maxBytes,
+		Compression:     *compression,
+		MaxArchiveBytes: maxArchiveBytes,
 		Progress: func(stage portableexport.Stage) {
 			now := time.Now()
 			fmt.Fprintf(
@@ -5510,7 +5529,7 @@ const portableUsageText = `gitcrawl portable manages local portable-store snapsh
 
 Usage:
   gitcrawl portable prune [--body-chars N] [--no-vacuum] [--include-sync-failures] [--no-publish] [--json]
-  gitcrawl portable export --profile current-state-v1 --output-dir PATH [--repository owner/repo] [--database-name NAME] [--public-path PATH] [--body-chars N] [--max-bytes N] [--json]
+  gitcrawl portable export --profile current-state-v1 --output-dir PATH [--repository owner/repo] [--database-name NAME] [--public-path PATH] [--body-chars N] [--max-bytes N] [--compression gzip] [--max-archive-bytes N] [--json]
 
 Subcommands:
   prune               prune volatile payloads from the configured portable store
@@ -5523,5 +5542,7 @@ For a portable checkout, prune publishes the database and manifest back into
 the checkout by default. --no-publish leaves them only in the runtime mirror.
 Export never changes the active database or publishes the artifact. It creates
 a complete database and manifest generation at a previously nonexistent path.
+With --compression gzip, it commits the gzip archive and manifest without the
+uncompressed database; --max-archive-bytes applies to that published archive.
 --repository semantically restricts the disposable snapshot to one owner/repo.
 `

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -4836,7 +4836,8 @@ func TestPortableExportCommandCreatesCurrentStateGenerationFromLiveWAL(t *testin
 		"--database-name", "openclaw__openclaw.sync.db",
 		"--public-path", "data/openclaw__openclaw.sync.db",
 		"--repository", "openclaw/openclaw",
-		"--max-bytes", "99999999",
+		"--compression", "gzip",
+		"--max-archive-bytes", "99999999",
 		"--json",
 	}); err != nil {
 		t.Fatalf("portable export: %v", err)
@@ -4857,7 +4858,11 @@ func TestPortableExportCommandCreatesCurrentStateGenerationFromLiveWAL(t *testin
 		} `json:"repository"`
 		BodyChars            int    `json:"body_chars"`
 		BytesAfter           int64  `json:"bytes_after"`
-		MaxBytes             int64  `json:"max_bytes"`
+		Compression          string `json:"compression"`
+		ArchivePath          string `json:"archive_path"`
+		ArchiveBytes         int64  `json:"archive_bytes"`
+		MaxArchiveBytes      int64  `json:"max_archive_bytes"`
+		ArchiveByteBudgetOK  bool   `json:"archive_byte_budget_ok"`
 		ArtifactID           string `json:"artifact_id"`
 		ArtifactIDProfile    string `json:"artifact_id_profile"`
 		SHA256               string `json:"sha256"`
@@ -4873,13 +4878,25 @@ func TestPortableExportCommandCreatesCurrentStateGenerationFromLiveWAL(t *testin
 	if payload.Profile != "current-state-v1" || payload.PortableSchema != "gitcrawl-portable-sync-v2" ||
 		payload.SourceDBPath != dbPath || payload.OutputDir != outputDir || payload.PublicPath != "data/openclaw__openclaw.sync.db" ||
 		payload.Repository.Owner != "openclaw" || payload.Repository.Name != "openclaw" || payload.Repository.FullName != "openclaw/openclaw" ||
-		payload.BodyChars != 32 || payload.MaxBytes != 99999999 || payload.BytesAfter <= 0 || payload.ArtifactID == payload.SHA256 ||
+		payload.BodyChars != 32 || payload.Compression != "gzip" || payload.ArchiveBytes <= 0 || payload.MaxArchiveBytes != 99999999 || !payload.ArchiveByteBudgetOK ||
+		payload.BytesAfter <= 0 || payload.ArtifactID == payload.SHA256 ||
 		payload.ArtifactIDProfile != portableexport.CurrentStateSemanticV1 ||
 		payload.QuickCheck != "ok" || payload.IntegrityCheck != "ok" || payload.ForeignKeyViolations != 0 || !payload.ArtifactCommitted ||
 		payload.ColumnProfile != store.PortableColumnProfileSanitizedCompatibility {
 		t.Fatalf("portable export payload = %+v", payload)
 	}
-	artifact, err := sql.Open("sqlite", payload.DatabasePath)
+	if _, err := os.Stat(payload.DatabasePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("compressed export retained raw database: %v", err)
+	}
+	if _, err := os.Stat(payload.ArchivePath); err != nil {
+		t.Fatalf("compressed export archive missing: %v", err)
+	}
+	materializedPath, err := stagePortableSQLiteSourceTemp(payload.DatabasePath, filepath.Join(dir, "materialized.db"), 0o600)
+	if err != nil {
+		t.Fatalf("materialize compressed export through portable reader: %v", err)
+	}
+	defer os.Remove(materializedPath)
+	artifact, err := sql.Open("sqlite", materializedPath)
 	if err != nil {
 		t.Fatalf("open artifact: %v", err)
 	}
@@ -4911,7 +4928,7 @@ func TestPortableExportCommandCreatesCurrentStateGenerationFromLiveWAL(t *testin
 		"canonical shaping: threads rebuild: compact copy",
 		"canonical shaping: threads rebuild: schema swap",
 		"canonical shaping: threads rebuild: schema restore",
-		"index removal", "final vacuum", "validation", "artifact identity", "manifest", "artifact commit", "complete",
+		"index removal", "final vacuum", "validation", "artifact identity", "compression", "manifest", "artifact commit", "complete",
 	} {
 		prefix := "gitcrawl: portable export: stage=" + stage + " "
 		var progressLine string
@@ -4952,6 +4969,20 @@ func TestPortableExportCommandValidatesProfileBeforeOpeningSource(t *testing.T) 
 	})
 	if err == nil || !strings.Contains(err.Error(), `repository: expected owner/repo, got "openclaw /gitcrawl"`) {
 		t.Fatalf("non-canonical repository error = %v", err)
+	}
+	err = app.Run(context.Background(), []string{
+		"--config", filepath.Join(t.TempDir(), "missing.toml"),
+		"portable", "export", "--profile", "current-state-v1", "--output-dir", filepath.Join(t.TempDir(), "out"), "--compression", "brotli",
+	})
+	if err == nil || !strings.Contains(err.Error(), `--compression must be "gzip"`) {
+		t.Fatalf("unsupported compression error = %v", err)
+	}
+	err = app.Run(context.Background(), []string{
+		"--config", filepath.Join(t.TempDir(), "missing.toml"),
+		"portable", "export", "--profile", "current-state-v1", "--output-dir", filepath.Join(t.TempDir(), "out"), "--max-archive-bytes", "99999999",
+	})
+	if err == nil || !strings.Contains(err.Error(), "--max-archive-bytes requires --compression") {
+		t.Fatalf("archive budget without compression error = %v", err)
 	}
 }
 

--- a/internal/portable/export.go
+++ b/internal/portable/export.go
@@ -1,6 +1,7 @@
 package portable
 
 import (
+	"compress/gzip"
 	"context"
 	"crypto/sha256"
 	"database/sql"
@@ -26,6 +27,7 @@ import (
 
 const (
 	CurrentStateV1        = "current-state-v1"
+	CompressionGzip       = "gzip"
 	portableSchema        = "gitcrawl-portable-sync-v2"
 	currentProfileVersion = 1
 	defaultBodyChars      = 256
@@ -105,15 +107,17 @@ func ResolveProfile(name string) (Profile, error) {
 }
 
 type ExportOptions struct {
-	SourceDBPath string
-	OutputDir    string
-	DatabaseName string
-	PublicPath   string
-	Profile      string
-	Repository   string
-	BodyChars    int
-	MaxBytes     *int64
-	Progress     ProgressFunc
+	SourceDBPath    string
+	OutputDir       string
+	DatabaseName    string
+	PublicPath      string
+	Profile         string
+	Repository      string
+	BodyChars       int
+	MaxBytes        *int64
+	Compression     string
+	MaxArchiveBytes *int64
+	Progress        ProgressFunc
 }
 
 type Stage string
@@ -127,6 +131,7 @@ const (
 	StageFinalVacuum      Stage = "final vacuum"
 	StageValidation       Stage = "validation"
 	StageArtifactIdentity Stage = "artifact identity"
+	StageCompression      Stage = "compression"
 	StageManifest         Stage = "manifest"
 	StageArtifactCommit   Stage = "artifact commit"
 	StageComplete         Stage = "complete"
@@ -169,6 +174,11 @@ type Manifest struct {
 	Repository           *Repository `json:"repository,omitempty"`
 	BodyChars            int         `json:"bodyChars"`
 	MaxBytes             *int64      `json:"maxBytes,omitempty"`
+	Compression          string      `json:"compression,omitempty"`
+	ArchivePath          string      `json:"archivePath,omitempty"`
+	ArchiveBytes         int64       `json:"archiveBytes,omitempty"`
+	ArchiveSHA256        string      `json:"archiveSha256,omitempty"`
+	MaxArchiveBytes      *int64      `json:"maxArchiveBytes,omitempty"`
 	Tables               []Table     `json:"tables"`
 	Excluded             []string    `json:"excluded"`
 	ValidationOK         bool        `json:"validationOk"`
@@ -196,6 +206,12 @@ type ExportResult struct {
 	BytesAfter           int64       `json:"bytes_after"`
 	MaxBytes             *int64      `json:"max_bytes,omitempty"`
 	ByteBudgetOK         bool        `json:"byte_budget_ok"`
+	Compression          string      `json:"compression,omitempty"`
+	ArchivePath          string      `json:"archive_path,omitempty"`
+	ArchiveBytes         int64       `json:"archive_bytes,omitempty"`
+	ArchiveSHA256        string      `json:"archive_sha256,omitempty"`
+	MaxArchiveBytes      *int64      `json:"max_archive_bytes,omitempty"`
+	ArchiveByteBudgetOK  bool        `json:"archive_byte_budget_ok"`
 	ArtifactID           string      `json:"artifact_id"`
 	ArtifactIDProfile    string      `json:"artifact_id_profile"`
 	SHA256               string      `json:"sha256"`
@@ -236,6 +252,17 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 	if options.MaxBytes != nil && *options.MaxBytes <= 0 {
 		return result, fmt.Errorf("max-bytes must be a positive integer")
 	}
+	if options.Compression != "" && options.Compression != CompressionGzip {
+		return result, fmt.Errorf("unsupported compression %q; supported compression: %s", options.Compression, CompressionGzip)
+	}
+	if options.MaxArchiveBytes != nil {
+		if *options.MaxArchiveBytes <= 0 {
+			return result, fmt.Errorf("max-archive-bytes must be a positive integer")
+		}
+		if options.Compression == "" {
+			return result, fmt.Errorf("max-archive-bytes requires compression")
+		}
+	}
 	sourcePath, err := filepath.Abs(options.SourceDBPath)
 	if err != nil {
 		return result, fmt.Errorf("resolve source database path: %w", err)
@@ -270,20 +297,30 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 	}()
 	dbPath := filepath.Join(stageDir, options.DatabaseName)
 	manifestPath := dbPath + ".manifest.json"
+	archivePath := ""
+	if options.Compression == CompressionGzip {
+		archivePath = dbPath + ".gz"
+	}
 	result = ExportResult{
-		Profile:        profile.Name,
-		PortableSchema: portableSchema,
-		Schema:         portableSchema,
-		SourceDBPath:   sourcePath,
-		OutputDir:      outputDir,
-		DatabasePath:   filepath.Join(outputDir, options.DatabaseName),
-		ManifestPath:   filepath.Join(outputDir, options.DatabaseName+".manifest.json"),
-		PublicPath:     options.PublicPath,
-		BodyChars:      options.BodyChars,
-		BytesBefore:    sourceInfo.Size(),
-		MaxBytes:       options.MaxBytes,
-		ByteBudgetOK:   true,
-		ColumnProfile:  profile.ColumnProfile,
+		Profile:             profile.Name,
+		PortableSchema:      portableSchema,
+		Schema:              portableSchema,
+		SourceDBPath:        sourcePath,
+		OutputDir:           outputDir,
+		DatabasePath:        filepath.Join(outputDir, options.DatabaseName),
+		ManifestPath:        filepath.Join(outputDir, options.DatabaseName+".manifest.json"),
+		PublicPath:          options.PublicPath,
+		BodyChars:           options.BodyChars,
+		BytesBefore:         sourceInfo.Size(),
+		MaxBytes:            options.MaxBytes,
+		ByteBudgetOK:        true,
+		Compression:         options.Compression,
+		MaxArchiveBytes:     options.MaxArchiveBytes,
+		ArchiveByteBudgetOK: true,
+		ColumnProfile:       profile.ColumnProfile,
+	}
+	if archivePath != "" {
+		result.ArchivePath = filepath.Join(outputDir, filepath.Base(archivePath))
 	}
 	if err := reportProgress(ctx, options.Progress, StageSnapshot); err != nil {
 		return result, err
@@ -488,6 +525,27 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 	result.ArtifactID = artifactID
 	result.DroppedTables = droppedTables
 	result.DroppedIndexes = droppedIndexes
+	if options.Compression == CompressionGzip {
+		if err := reportProgress(ctx, options.Progress, StageCompression); err != nil {
+			return result, err
+		}
+		if err := writeGzipArchive(dbPath, archivePath); err != nil {
+			return result, fmt.Errorf("compress portable database: %w", err)
+		}
+		archiveInfo, err := os.Stat(archivePath)
+		if err != nil {
+			return result, fmt.Errorf("stat portable archive: %w", err)
+		}
+		result.ArchiveBytes = archiveInfo.Size()
+		if options.MaxArchiveBytes != nil && archiveInfo.Size() > *options.MaxArchiveBytes {
+			result.ArchiveByteBudgetOK = false
+			return result, fmt.Errorf("portable archive size %d exceeds max-archive-bytes %d", archiveInfo.Size(), *options.MaxArchiveBytes)
+		}
+		result.ArchiveSHA256, err = fileSHA256(archivePath)
+		if err != nil {
+			return result, fmt.Errorf("hash portable archive: %w", err)
+		}
+	}
 	if err := reportProgress(ctx, options.Progress, StageManifest); err != nil {
 		return result, err
 	}
@@ -505,6 +563,10 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 		Repository:           result.Repository,
 		BodyChars:            options.BodyChars,
 		MaxBytes:             options.MaxBytes,
+		Compression:          options.Compression,
+		ArchiveBytes:         result.ArchiveBytes,
+		ArchiveSHA256:        result.ArchiveSHA256,
+		MaxArchiveBytes:      options.MaxArchiveBytes,
 		Tables:               tables,
 		Excluded:             append([]string(nil), profile.Excluded...),
 		ValidationOK:         true,
@@ -515,6 +577,9 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 		DroppedIndexes:       droppedIndexes,
 		IndexProfile:         profile.IndexProfile,
 		ColumnProfile:        profile.ColumnProfile,
+	}
+	if archivePath != "" {
+		manifest.ArchivePath = filepath.Base(archivePath)
 	}
 	if e.beforeManifest != nil {
 		if err := e.beforeManifest(); err != nil {
@@ -531,6 +596,11 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 	if err := syncRegularFile(dbPath); err != nil {
 		return result, fmt.Errorf("sync portable database: %w", err)
 	}
+	if archivePath != "" {
+		if err := syncRegularFile(archivePath); err != nil {
+			return result, fmt.Errorf("sync portable archive: %w", err)
+		}
+	}
 	if err := validateManifestPair(ctx, dbPath, manifestPath, manifest); err != nil {
 		return result, err
 	}
@@ -541,6 +611,11 @@ func (e exporter) export(ctx context.Context, options ExportOptions) (result Exp
 		return result, fmt.Errorf("re-hash portable database after validation: %w", err)
 	} else if finalSHA != sha {
 		return result, fmt.Errorf("portable database changed during manifest validation")
+	}
+	if archivePath != "" {
+		if err := os.Remove(dbPath); err != nil {
+			return result, fmt.Errorf("remove unpackaged portable database: %w", err)
+		}
 	}
 	bestEffortSyncDir(stageDir)
 	if e.beforeCommit != nil {
@@ -995,6 +1070,85 @@ func fileSHA256(filePath string) (string, error) {
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
+func writeGzipArchive(sourcePath, archivePath string) (retErr error) {
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+	archive, err := os.OpenFile(archivePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return err
+	}
+	complete := false
+	defer func() {
+		if closeErr := archive.Close(); closeErr != nil {
+			retErr = errors.Join(retErr, closeErr)
+		}
+		if !complete {
+			_ = os.Remove(archivePath)
+		}
+	}()
+	writer, err := gzip.NewWriterLevel(archive, gzip.BestCompression)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(writer, source); err != nil {
+		_ = writer.Close()
+		return err
+	}
+	if err := writer.Close(); err != nil {
+		return err
+	}
+	if err := archive.Sync(); err != nil {
+		return err
+	}
+	complete = true
+	return nil
+}
+
+func validateGzipArchive(archivePath string, expectedArchiveBytes int64, expectedArchiveSHA string, expectedOutputBytes int64, expectedOutputSHA string) error {
+	info, err := os.Stat(archivePath)
+	if err != nil {
+		return fmt.Errorf("re-stat portable archive: %w", err)
+	}
+	if info.Size() != expectedArchiveBytes {
+		return fmt.Errorf("portable manifest archiveBytes %d does not match archive size %d", expectedArchiveBytes, info.Size())
+	}
+	archiveSHA, err := fileSHA256(archivePath)
+	if err != nil {
+		return fmt.Errorf("re-hash portable archive: %w", err)
+	}
+	if archiveSHA != expectedArchiveSHA {
+		return fmt.Errorf("portable manifest archiveSha256 does not match archive")
+	}
+	archive, err := os.Open(archivePath)
+	if err != nil {
+		return fmt.Errorf("open portable archive: %w", err)
+	}
+	defer archive.Close()
+	reader, err := gzip.NewReader(archive)
+	if err != nil {
+		return fmt.Errorf("open portable gzip stream: %w", err)
+	}
+	hash := sha256.New()
+	written, copyErr := io.Copy(hash, io.LimitReader(reader, expectedOutputBytes+1))
+	closeErr := reader.Close()
+	if copyErr != nil {
+		return fmt.Errorf("read portable gzip stream: %w", copyErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close portable gzip stream: %w", closeErr)
+	}
+	if written != expectedOutputBytes {
+		return fmt.Errorf("portable archive expands to %d bytes, expected %d", written, expectedOutputBytes)
+	}
+	if hex.EncodeToString(hash.Sum(nil)) != expectedOutputSHA {
+		return fmt.Errorf("portable archive contents do not match database sha256")
+	}
+	return nil
+}
+
 func writeSyncedFile(filePath string, data []byte, mode os.FileMode) error {
 	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
 	if err != nil {
@@ -1077,6 +1231,20 @@ func validateManifestPair(ctx context.Context, dbPath, manifestPath string, expe
 	}
 	if sha != actual.SHA256 {
 		return fmt.Errorf("portable manifest sha256 does not match database")
+	}
+	if actual.Compression != "" {
+		if actual.Compression != CompressionGzip {
+			return fmt.Errorf("portable manifest compression %q is unsupported", actual.Compression)
+		}
+		if actual.ArchivePath == "" || filepath.Base(actual.ArchivePath) != actual.ArchivePath {
+			return fmt.Errorf("portable manifest archivePath must be a basename")
+		}
+		if actual.ArchiveBytes <= 0 || actual.ArchiveSHA256 == "" {
+			return fmt.Errorf("portable manifest archive metadata is incomplete")
+		}
+		if err := validateGzipArchive(filepath.Join(filepath.Dir(manifestPath), actual.ArchivePath), actual.ArchiveBytes, actual.ArchiveSHA256, actual.OutputBytes, actual.SHA256); err != nil {
+			return err
+		}
 	}
 	if actual.Profile != CurrentStateV1 {
 		return fmt.Errorf("portable manifest profile %q does not support semantic artifact identity", actual.Profile)

--- a/internal/portable/export_failure_paths_test.go
+++ b/internal/portable/export_failure_paths_test.go
@@ -612,6 +612,25 @@ func TestExportRejectsInvalidSourcesBudgetsAndOutputParents(t *testing.T) {
 			wantError: "max-bytes must be a positive integer",
 		},
 		{
+			name: "unknown compression",
+			options: func() ExportOptions {
+				options := testExportOptions(validSource, filepath.Join(dir, "unknown-compression"))
+				options.Compression = "brotli"
+				return options
+			}(),
+			wantError: "unsupported compression",
+		},
+		{
+			name: "archive budget without compression",
+			options: func() ExportOptions {
+				options := testExportOptions(validSource, filepath.Join(dir, "archive-budget-without-compression"))
+				budget := int64(1)
+				options.MaxArchiveBytes = &budget
+				return options
+			}(),
+			wantError: "max-archive-bytes requires compression",
+		},
+		{
 			name:      "missing source",
 			options:   testExportOptions(filepath.Join(dir, "missing.db"), filepath.Join(dir, "missing-source")),
 			wantError: "stat source database",

--- a/internal/portable/export_test.go
+++ b/internal/portable/export_test.go
@@ -2,12 +2,14 @@ package portable
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -526,6 +528,81 @@ func TestExportByteBudgetExactAndOneByteOver(t *testing.T) {
 	}
 	if _, err := os.Stat(failingDir); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("failed budget left target: %v", err)
+	}
+	assertNoExportTemps(t, dir)
+}
+
+func TestExportGzipUsesArchiveBudgetAndCommitsManifestBackedArchive(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	st := seedExportSource(t, ctx, sourcePath)
+	defer st.Close()
+
+	baseline, err := Export(ctx, testExportOptions(sourcePath, filepath.Join(dir, "baseline")))
+	if err != nil {
+		t.Fatalf("baseline export: %v", err)
+	}
+	archiveBudget := baseline.BytesAfter - 1
+	options := testExportOptions(sourcePath, filepath.Join(dir, "compressed"))
+	options.Compression = CompressionGzip
+	options.MaxArchiveBytes = &archiveBudget
+	compressed, err := Export(ctx, options)
+	if err != nil {
+		t.Fatalf("compressed export under archive budget: %v", err)
+	}
+	if compressed.Compression != CompressionGzip || !compressed.ArchiveByteBudgetOK || compressed.ArchiveBytes <= 0 || compressed.ArchiveBytes > archiveBudget {
+		t.Fatalf("compressed result = %+v", compressed)
+	}
+	if _, err := os.Stat(compressed.DatabasePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("compressed export retained raw database: %v", err)
+	}
+	if _, err := os.Stat(compressed.ArchivePath); err != nil {
+		t.Fatalf("compressed archive missing: %v", err)
+	}
+	manifest := readManifest(t, compressed.ManifestPath)
+	if manifest.Compression != CompressionGzip || manifest.ArchivePath != filepath.Base(compressed.ArchivePath) ||
+		manifest.ArchiveBytes != compressed.ArchiveBytes || manifest.ArchiveSHA256 != compressed.ArchiveSHA256 ||
+		manifest.MaxArchiveBytes == nil || *manifest.MaxArchiveBytes != archiveBudget {
+		t.Fatalf("compressed manifest/result mismatch: manifest=%+v result=%+v", manifest, compressed)
+	}
+	archive, err := os.Open(compressed.ArchivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, err := gzip.NewReader(archive)
+	if err != nil {
+		archive.Close()
+		t.Fatal(err)
+	}
+	unpackedPath := filepath.Join(dir, "unpacked.db")
+	unpacked, err := os.Create(unpackedPath)
+	if err != nil {
+		reader.Close()
+		archive.Close()
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(unpacked, reader); err != nil {
+		t.Fatal(err)
+	}
+	if err := errors.Join(unpacked.Close(), reader.Close(), archive.Close()); err != nil {
+		t.Fatal(err)
+	}
+	if got := hashFile(t, unpackedPath); got != compressed.SHA256 {
+		t.Fatalf("unpacked database hash = %s, want %s", got, compressed.SHA256)
+	}
+
+	tooSmall := compressed.ArchiveBytes - 1
+	failingDir := filepath.Join(dir, "too-large")
+	failingOptions := testExportOptions(sourcePath, failingDir)
+	failingOptions.Compression = CompressionGzip
+	failingOptions.MaxArchiveBytes = &tooSmall
+	failed, err := Export(ctx, failingOptions)
+	if err == nil || !strings.Contains(err.Error(), "exceeds max-archive-bytes") || failed.ArchiveByteBudgetOK {
+		t.Fatalf("archive over budget result=%+v err=%v", failed, err)
+	}
+	if _, err := os.Stat(failingDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("failed archive budget left target: %v", err)
 	}
 	assertNoExportTemps(t, dir)
 }


### PR DESCRIPTION
## Summary

- add atomic gzip generation output to `gitcrawl portable export`
- record and verify compressed and expanded identities plus archive budget
- preserve raw export behavior and prove the existing reader consumes the exact gzip output

## Root cause

The published current-state database grows as bounded PR-detail hydration fills tables that were empty in the seed artifact. The exporter only enforced a raw SQLite budget, although Gitcrawl already reads manifest-backed gzip stores. Once the raw database crossed GitHub’s 100 MB blob limit, publication failed after a successful export.

## Real behavior proof

[`openclaw/gitcrawl-store#23` exact-head CI](https://github.com/openclaw/gitcrawl-store/actions/runs/31774600377/job/94687330055) checks out and builds this exact producer SHA (`39adcfd3ecd3ac43f5038cbd16a90e7c5b877c87`). Its `portable-roundtrip` job:

1. exports a manifest-backed gzip generation through the real CLI;
2. verifies archive size/SHA-256 and expanded size/SHA-256;
3. materializes that same generation through the production store reader;
4. opens the SQLite database, checks its contents, and exercises the writable-runtime migration path.

Result: `current-state-v1 synthetic roundtrip ok`; job passed in 2m1s.

The linked consumer PR also commits the real seed artifact: 93,081,600-byte SQLite database → 27,052,754-byte gzip archive, unchanged semantic artifact ID, SQLite `quick_check`: `ok`.

## Testing

- `GOTMPDIR=/var/tmp/gitcrawl-go-build go test ./internal/portable -count=1`
- targeted CLI producer/reader and validation tests
- exact producer-to-production-reader consumer CI above
- local autoreview: clean

The two unrelated existing failures in the full `internal/cli` suite are `TestRefreshPortableStoreRecoversFromStaleIndexLock` and `TestPortableRuntimeUtilityBranches`; changed-path tests pass.

Current Go CI failure is independent of this diff: `govulncheck` now reports Go 1.26.5 standard-library advisories fixed in Go 1.26.6; both Linux and macOS stop at that gate.