### PR TITLE
fix(ci): update Go to 1.26.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ producing spuriously different exports.
 ### Dependencies and maintenance
 
 - Update Kong to v1.16.1.
+- Update the minimum Go toolchain to 1.26.6 for the latest standard-library security fixes.
 
 ## 0.9.0 - 2026-08-08
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-ARG GO_VERSION=1.26.5
+ARG GO_VERSION=1.26.6
 ARG ALPINE_VERSION=3.24
 
 FROM golang:${GO_VERSION}-alpine AS build

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Homebrew is the smallest install on macOS and Linux:
 brew install openclaw/tap/gitcrawl
 ```
 
-Prebuilt archives for macOS, Linux, and Windows are available from [GitHub Releases](https://github.com/openclaw/gitcrawl/releases/latest). The [installation guide](docs/installation.md) also covers source builds and update checks; source builds require Go 1.26.5 or newer. A [Docker source build](docs/docker.md) keeps its runtime state under one mounted directory.
+Prebuilt archives for macOS, Linux, and Windows are available from [GitHub Releases](https://github.com/openclaw/gitcrawl/releases/latest). The [installation guide](docs/installation.md) also covers source builds and update checks; source builds require Go 1.26.6 or newer. A [Docker source build](docs/docker.md) keeps its runtime state under one mounted directory.
 
 Sync needs a GitHub token from `GITHUB_TOKEN` or `gh auth token`. Generating summaries and embeddings also needs `OPENAI_API_KEY`; semantic search and clustering use those stored embeddings, while ordinary sync and keyword search do not.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openclaw/gitcrawl
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/alecthomas/kong v1.16.1

--- a/internal/portable/export_test.go
+++ b/internal/portable/export_test.go
@@ -607,6 +607,63 @@ func TestExportGzipUsesArchiveBudgetAndCommitsManifestBackedArchive(t *testing.T
 	assertNoExportTemps(t, dir)
 }
 
+func TestValidateGzipArchiveRejectsMismatchedMetadataAndContents(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	archivePath := filepath.Join(dir, "source.db.gz")
+	contents := bytes.Repeat([]byte("portable sqlite payload"), 32)
+	if err := os.WriteFile(sourcePath, contents, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeGzipArchive(sourcePath, archivePath); err != nil {
+		t.Fatalf("write gzip archive: %v", err)
+	}
+	archiveInfo, err := os.Stat(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contentsSHA := sha256.Sum256(contents)
+	archiveSHA := hashFile(t, archivePath)
+	if err := validateGzipArchive(archivePath, archiveInfo.Size(), archiveSHA, int64(len(contents)), hex.EncodeToString(contentsSHA[:])); err != nil {
+		t.Fatalf("validate gzip archive: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		archiveBytes int64
+		archiveSHA   string
+		outputBytes  int64
+		outputSHA    string
+		wantError    string
+	}{
+		{name: "archive size", archiveBytes: archiveInfo.Size() + 1, archiveSHA: archiveSHA, outputBytes: int64(len(contents)), outputSHA: hex.EncodeToString(contentsSHA[:]), wantError: "does not match archive size"},
+		{name: "archive sha", archiveBytes: archiveInfo.Size(), archiveSHA: strings.Repeat("0", 64), outputBytes: int64(len(contents)), outputSHA: hex.EncodeToString(contentsSHA[:]), wantError: "archiveSha256 does not match"},
+		{name: "expanded size", archiveBytes: archiveInfo.Size(), archiveSHA: archiveSHA, outputBytes: int64(len(contents)) - 1, outputSHA: hex.EncodeToString(contentsSHA[:]), wantError: "expected"},
+		{name: "expanded sha", archiveBytes: archiveInfo.Size(), archiveSHA: archiveSHA, outputBytes: int64(len(contents)), outputSHA: strings.Repeat("0", 64), wantError: "contents do not match"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateGzipArchive(archivePath, test.archiveBytes, test.archiveSHA, test.outputBytes, test.outputSHA)
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("validateGzipArchive error = %v, want %q", err, test.wantError)
+			}
+		})
+	}
+
+	corruptPath := filepath.Join(dir, "corrupt.gz")
+	if err := os.WriteFile(corruptPath, []byte("not a gzip stream"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	corruptInfo, err := os.Stat(corruptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = validateGzipArchive(corruptPath, corruptInfo.Size(), hashFile(t, corruptPath), int64(len(contents)), hex.EncodeToString(contentsSHA[:]))
+	if err == nil || !strings.Contains(err.Error(), "open portable gzip stream") {
+		t.Fatalf("corrupt archive error = %v", err)
+	}
+}
+
 func TestExportRejectsUnsafeInputsAndExistingOutput(t *testing.T) {
 	for _, name := range []string{"", ".", "..", "a/b.db", `a\b.db`, "bad\x00.db", "bad?.db", "gitcrawl.db-wal", "gitcrawl.db-shm", "gitcrawl.db.manifest.json"} {
 		if err := ValidateDatabaseName(name); err == nil {


### PR DESCRIPTION
## Summary

- update the project minimum and Docker builder from Go 1.26.5 to 1.26.6
- cover gzip archive metadata and content validation failure paths introduced by #151
- restore the repository coverage floor after the gzip export change

## Root cause

Both Go jobs on #151 and its merge commit stopped in govulncheck because four newly published standard-library advisories affect Go 1.26.5 and are fixed in 1.26.6. Once that gate was repaired, the merged gzip code exposed a second latent failure: aggregate coverage was 84.9%, below CI's 85.0% floor.

## Proof

- GOWORK=off go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...: No vulnerabilities found
- exact local CI sequence: pass, including vet, deadcode, 85.0% coverage, release-script tests, and GoReleaser snapshot
- Docker build using golang:1.26.6-alpine: pass
- built container version and metadata smoke: pass
- autoreview: clean, no accepted or actionable findings
