### PR TITLE
chore(release): prepare v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## Unreleased
+## v0.9.2 - 2026-08-14
 
+- Update the minimum Go toolchain to 1.26.6 to resolve GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218.
 ## 0.9.1 - 2026-08-10
 
 **Highlight:** `portable export` now produces stable artifact identities — local


### PR DESCRIPTION
Stamps the changelog for v0.9.2.