### PR TITLE
fix(github): cap rate-limit retry waits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## Unreleased
-
-- Cap GitHub `Retry-After` and `X-RateLimit-Reset` retry waits at five minutes so a huge rate-limit header cannot hang sync.
-
 ## v0.9.2 - 2026-08-14
 
 - Update the minimum Go toolchain to 1.26.6 to resolve GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Cap GitHub `Retry-After` and `X-RateLimit-Reset` retry waits at five minutes so a huge rate-limit header cannot hang sync.
+
 ## v0.9.2 - 2026-08-14
 
 - Update the minimum Go toolchain to 1.26.6 to resolve GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218.

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -663,8 +663,8 @@ func rateLimitWait(err error) (time.Duration, bool) {
 		return 0, false
 	}
 	if v := strings.TrimSpace(reqErr.Headers.Get("Retry-After")); v != "" {
-		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
-			return capRateLimitWait(time.Duration(secs) * time.Second), true
+		if wait, ok := retryAfterWait(v); ok {
+			return wait, true
 		}
 	}
 	if reqErr.Headers.Get("X-RateLimit-Remaining") != "0" {
@@ -678,6 +678,23 @@ func rateLimitWait(err error) (time.Duration, bool) {
 		return capRateLimitWait(wait), true
 	}
 	return time.Second, true
+}
+
+func retryAfterWait(value string) (time.Duration, bool) {
+	seconds, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		if errors.Is(err, strconv.ErrRange) {
+			return maxRateLimitWait, true
+		}
+		return 0, false
+	}
+	if seconds == 0 {
+		return 0, false
+	}
+	if seconds >= uint64(maxRateLimitWait/time.Second) {
+		return maxRateLimitWait, true
+	}
+	return time.Duration(seconds) * time.Second, true
 }
 
 func capRateLimitWait(wait time.Duration) time.Duration {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -650,6 +650,10 @@ func rateLimitHostForBaseURL(baseURL string) string {
 	return parsed.Host
 }
 
+// maxRateLimitWait bounds GitHub Retry-After and X-RateLimit-Reset sleeps so a
+// huge or malicious header cannot hang sync indefinitely.
+const maxRateLimitWait = 5 * time.Minute
+
 func rateLimitWait(err error) (time.Duration, bool) {
 	reqErr, ok := err.(*RequestError)
 	if !ok {
@@ -660,7 +664,7 @@ func rateLimitWait(err error) (time.Duration, bool) {
 	}
 	if v := strings.TrimSpace(reqErr.Headers.Get("Retry-After")); v != "" {
 		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
-			return time.Duration(secs) * time.Second, true
+			return capRateLimitWait(time.Duration(secs) * time.Second), true
 		}
 	}
 	if reqErr.Headers.Get("X-RateLimit-Remaining") != "0" {
@@ -671,9 +675,16 @@ func rateLimitWait(err error) (time.Duration, bool) {
 		return 0, false
 	}
 	if wait := time.Until(time.Unix(secs, 0)); wait > 0 {
-		return wait, true
+		return capRateLimitWait(wait), true
 	}
 	return time.Second, true
+}
+
+func capRateLimitWait(wait time.Duration) time.Duration {
+	if wait > maxRateLimitWait || wait < 0 {
+		return maxRateLimitWait
+	}
+	return wait
 }
 
 func nextPage(linkHeader, baseURL string) string {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1109,7 +1109,7 @@ func TestRateLimitWaitCapsHugeRetryAfter(t *testing.T) {
 	wait, ok := rateLimitWait(&RequestError{
 		Status: http.StatusTooManyRequests,
 		Headers: http.Header{
-			"Retry-After": []string{"999999999"},
+			"Retry-After": []string{"18446744074"},
 		},
 	})
 	if !ok {
@@ -1118,6 +1118,33 @@ func TestRateLimitWaitCapsHugeRetryAfter(t *testing.T) {
 	if wait != maxRateLimitWait {
 		t.Fatalf("wait = %s, want %s cap", wait, maxRateLimitWait)
 	}
+}
+
+func TestRateLimitClientCapsOverflowingRetryAfter(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Retry-After", "18446744074")
+		http.Error(w, "slow down", http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	var messages []string
+	reporter := Reporter(func(message string) { messages = append(messages, message) })
+	client := New(Options{BaseURL: server.URL, PageDelay: -1})
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := client.GetRepo(ctx, "openclaw", "gitcrawl", reporter)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want context deadline", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("requests = %d, want 1 before capped wait", got)
+	}
+	if got := strings.Join(messages, "\n"); !strings.Contains(got, "rate-limit retry wait=5m0s") {
+		t.Fatalf("reporter output = %q, want capped wait", got)
+	}
+	t.Logf("client trace: requests=%d reporter=%q result=%v", calls.Load(), messages, err)
 }
 
 func TestRateLimitWaitCapsHugeRateLimitReset(t *testing.T) {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1105,6 +1105,37 @@ func TestRateLimitRetriesOn429WithRetryAfter(t *testing.T) {
 	}
 }
 
+func TestRateLimitWaitCapsHugeRetryAfter(t *testing.T) {
+	wait, ok := rateLimitWait(&RequestError{
+		Status: http.StatusTooManyRequests,
+		Headers: http.Header{
+			"Retry-After": []string{"999999999"},
+		},
+	})
+	if !ok {
+		t.Fatal("expected rate-limit wait")
+	}
+	if wait != maxRateLimitWait {
+		t.Fatalf("wait = %s, want %s cap", wait, maxRateLimitWait)
+	}
+}
+
+func TestRateLimitWaitCapsHugeRateLimitReset(t *testing.T) {
+	headers := make(http.Header)
+	headers.Set("X-RateLimit-Remaining", "0")
+	headers.Set("X-RateLimit-Reset", strconv.FormatInt(time.Now().Add(48*time.Hour).Unix(), 10))
+	wait, ok := rateLimitWait(&RequestError{
+		Status:  http.StatusForbidden,
+		Headers: headers,
+	})
+	if !ok {
+		t.Fatal("expected rate-limit wait")
+	}
+	if wait != maxRateLimitWait {
+		t.Fatalf("wait = %s, want %s cap", wait, maxRateLimitWait)
+	}
+}
+
 func TestRateLimitRespectsContextCancellation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-RateLimit-Remaining", "0")


### PR DESCRIPTION
## What Problem This Solves

`rateLimitWait` treated GitHub `Retry-After` and `X-RateLimit-Reset` as unbounded. `Retry-After: 999999999` becomes a multi-year sleep and hangs `gitcrawl sync`. Rate limits are still honored, just capped at five minutes.

## Evidence

```console
Red:  wait = 277777h46m39s, want 5m cap
Green: GOWORK=off go test ./internal/github/ -count=1 -run TestRateLimit
```

## Real behavior proof
Behavior addressed: Huge Retry-After / rate-limit reset headers sleep at most five minutes.
Real environment tested: macOS, Go from the worktree, gitcrawl `/tmp/oc-impl-gitcrawl` head `1343dd4`.
Exact steps or command run after this patch: `GOWORK=off go test ./internal/github/ -count=1 -run TestRateLimit`
Evidence after fix: red/green recorded above.
Observed result after fix: `Retry-After: 999999999` and a far-future reset both return 5m.
What was not tested: A live GitHub 429 with a real Retry-After.
