### PR TITLE
fix: report portable-store reset recovery failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.9.4 - Unreleased
 
+- Report the actual reset failure when portable-store initialization cannot recover from a dirty merge. Thanks @SebTardif.
+
 ## 0.9.3 - 2026-08-29
 
 - Fix repeated gzip-only portable initialization and add a locked, bounded, preservation-first `portable refresh` subscriber command with automatic Git maintenance disabled across portable operations.

--- a/docs/portable-stores.md
+++ b/docs/portable-stores.md
@@ -59,6 +59,9 @@ Initialization validates portable arguments before invoking Git and validates
 the artifact before saving configuration. Repeated initialization and a
 publisher's raw-to-gzip transition do not require a raw `.db` in the checkout.
 Use `init` for setup; it still regenerates configuration on success.
+If a dirty merge triggers legacy reset recovery and that reset fails, `init`
+reports the reset failure with the same credential-safe Git diagnostics used
+elsewhere, so the error identifies the recovery step that needs attention.
 
 ## Routine subscriber refresh
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -3756,7 +3756,7 @@ func syncPortableStore(ctx context.Context, remoteURL, dir string) (string, erro
 				return "", err
 			}
 			if resetErr := runGit(ctx, "", "-C", dir, "reset", "--hard", "HEAD"); resetErr != nil {
-				return "", err
+				return "", resetErr
 			}
 			if retryErr := fastForwardGitCheckout(ctx, dir, false); retryErr != nil {
 				return "", retryErr

--- a/internal/cli/portable_safety_unix_test.go
+++ b/internal/cli/portable_safety_unix_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -130,6 +131,56 @@ func TestPortableGitFailureDiagnostics(t *testing.T) {
 			}
 			if strings.Contains(err.Error(), "synthetic-private-path") {
 				t.Fatal("Git failure exposed raw diagnostics")
+			}
+		})
+	}
+}
+
+func TestSyncPortableStoreReturnsResetFailure(t *testing.T) {
+	for _, dirtyBeforePull := range []bool{false, true} {
+		t.Run(fmt.Sprintf("dirty-before-pull=%t", dirtyBeforePull), func(t *testing.T) {
+			fixture := newPortableRefreshFixture(t, false)
+			if err := os.WriteFile(filepath.Join(fixture.remote, "incoming.txt"), []byte("remote data\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			portableTestCommit(t, fixture.remote)
+			localPath := filepath.Join(fixture.checkout, "incoming.txt")
+			if dirtyBeforePull {
+				localPath = filepath.Join(fixture.checkout, fixture.relative)
+			}
+			if err := os.WriteFile(localPath, []byte("local data\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if clean := gitWorktreeClean(context.Background(), fixture.checkout); clean == dirtyBeforePull {
+				t.Fatalf("unexpected tracked worktree cleanliness: %t", clean)
+			}
+
+			realGit, err := exec.LookPath("git")
+			if err != nil {
+				t.Fatal(err)
+			}
+			wrapper := filepath.Join(t.TempDir(), "git")
+			script := `#!/bin/sh
+for arg in "$@"; do
+  if [ "$arg" = reset ]; then
+    echo 'synthetic-private-path: No space left on device' >&2
+    exit 79
+  fi
+done
+exec "$GITCRAWL_TEST_REAL_GIT" "$@"
+`
+			if err := os.WriteFile(wrapper, []byte(script), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("GITCRAWL_TEST_REAL_GIT", realGit)
+			t.Setenv("GITCRAWL_PORTABLE_GIT", wrapper)
+			_, err = syncPortableStore(context.Background(), fixture.remote, fixture.checkout)
+			var exit *exec.ExitError
+			if !errors.As(err, &exit) || exit.ExitCode() != 79 || !strings.Contains(err.Error(), "insufficient disk space for Git") {
+				t.Fatalf("expected reset failure with exit 79 and disk-space guidance, got %v", err)
+			}
+			if strings.Contains(err.Error(), "synthetic-private-path") || isDirtyPortablePullError(err) {
+				t.Fatalf("reset error exposed raw diagnostics or retained the earlier merge failure: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `gitcrawl init --portable-store` repeats a dirty-merge error when the subsequent reset actually fails. The reported error now comes from the failed recovery operation, preserving the existing credential-safe Git diagnostics and underlying exit status.

## Why This Change Was Made

This is the current-main diagnostic correction from #164, with regression coverage for both reset paths. The original PR conflicts with the portable-store rewrite; its additional clone timer is omitted because current main already bounds the entire operation to two minutes. Thanks @SebTardif; contributor credit is retained in the commit and changelog.

## User Impact

Operators get the actual reset failure, including existing disk-space guidance when applicable, instead of being directed back to the preceding merge conflict. Clone, reset, and data-preservation policies are unchanged.

## Evidence

Built and ran the real CLI on macOS against a synthetic SQLite archive and real Git, with no Git executable wrapper in the live proof. A new upstream file collides with a local untracked file; an immutable checkout index prevents the subsequent reset.

Paths are normalized in the command excerpt below. Save the reproducer as `proof-reset.py`.

```console
$ GOWORK=off go build -o /tmp/gitcrawl-after ./cmd/gitcrawl
$ python3 proof-reset.py /tmp/gitcrawl-after
initial CLI init: cloned
tracked worktree status: ''
CLI exit: 1
CLI stderr: portable git failed: Git command failed; verify Git version, repository state and remote access: exit status 128
untracked data preserved: True
config preserved: True
```

The equivalent current-main binary instead reported `Your local changes would be overwritten by merge: exit status 1`. The regression test fails on that baseline and checks that both reset paths retain the reset exit code, classified disk-space guidance, and diagnostic redaction.

`go vet ./...` passes. Codex autoreview of the complete change is clean, with no actionable findings. The exact candidate commit passed the full Linux and macOS CI gates, including `go test ./... -covermode=atomic`, coverage enforcement, formatting, module tidiness, vet, vulnerability scan, deadcode, build, CLI smoke, release-script tests, and snapshot packaging: https://github.com/openclaw/gitcrawl/actions/runs/33362738281

A separate live smart-HTTP test confirmed that current main cancels a stalled initial clone after 121.18 seconds but leaves a partial checkout that prevents retry. That existing clone-ownership/recovery issue is documented for a separate maintainer decision; this diagnostic-only change does not alter it.

<details>
<summary>macOS real-Git reproducer</summary>

```python
import json, os, pathlib, sqlite3, stat, subprocess, sys, tempfile

binary = pathlib.Path(sys.argv[1]).resolve()
root = pathlib.Path(tempfile.mkdtemp(prefix='reset-', dir=pathlib.Path(__file__).parent))
env = dict(os.environ, GIT_CONFIG_GLOBAL=os.devnull, GIT_CONFIG_SYSTEM=os.devnull, GIT_CONFIG_NOSYSTEM='1', GIT_TERMINAL_PROMPT='0')
for key in ('GITCRAWL_PORTABLE_GIT', 'GITCRAWL_CONFIG', 'GITCRAWL_DB_PATH'):
    env.pop(key, None)
publisher, subscriber = root / 'publisher', root / 'subscriber'
publisher.mkdir()
(publisher / 'data').mkdir()
with sqlite3.connect(publisher / 'data/archive.db') as db:
    db.execute('create table fixture(value text)')
    db.execute("insert into fixture values('synthetic archive')")

def git(where, *args):
    p = subprocess.run(['git', '-C', str(where), *args], env=env, capture_output=True, text=True)
    if p.returncode:
        raise RuntimeError(p.stderr)
    return p.stdout.strip()

def commit():
    git(publisher, 'add', '--all')
    git(publisher, '-c', 'commit.gpgsign=false', 'commit', '-m', 'test: seed synthetic portable archive')

git(publisher, 'init', '-b', 'main')
git(publisher, 'config', 'user.name', 'Peter Steinberger')
git(publisher, 'config', 'user.email', 'steipete@gmail.com')
commit()
args = [str(binary), '--config', str(root/'config.toml'), 'init', '--portable-store', str(publisher), '--store-dir', str(subscriber), '--portable-db', 'data/archive.db', '--json']
first = subprocess.run(args, env=env, capture_output=True, text=True, timeout=90)
assert first.returncode == 0, first.stderr
print('initial CLI init:', json.loads(first.stdout)['portable_store'])
saved_config = (root/'config.toml').read_bytes()
(publisher/'incoming.txt').write_text('incoming remote data\n')
commit()
(subscriber/'incoming.txt').write_text('local untracked data\n')
print('tracked worktree status:', repr(git(subscriber, 'status', '--porcelain', '--untracked-files=no')))
index = subscriber/'.git/index'
os.chflags(index, stat.UF_IMMUTABLE)
try:
    result = subprocess.run(args, env=env, capture_output=True, text=True, timeout=90)
    print('CLI exit:', result.returncode)
    print('CLI stderr:', result.stderr.strip())
    print('untracked data preserved:', (subscriber/'incoming.txt').read_text() == 'local untracked data\n')
    print('config preserved:', (root/'config.toml').read_bytes() == saved_config)
finally:
    os.chflags(index, 0)
print('fixture:', root)

```
</details>
