### PR TITLE
feat(auth): support managed GitHub credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.9.5 - Unreleased
 
+- Add `--github-token-command` for managed, rotating GitHub credentials during long synchronizations on Unix. Requests and quota reservations use the current credential without changing static authentication or remote-store sessions.
+
 - Stop review-thread GraphQL pagination when GitHub returns an empty or repeated endCursor. Thanks @SebTardif.
 - Raise the source-build minimum to Go 1.27.1 for CrawlKit v0.14.8 and align the Docker builder; newly built macOS binaries require macOS 13 Ventura or newer.
 - Update SQLite to v1.58.0, compatible Go dependency patches, the Dockerfile frontend to 1.27, and TruffleHog to v3.97.4; retain SQLite's required libc v1.75.6.

--- a/docs/capture.md
+++ b/docs/capture.md
@@ -19,6 +19,12 @@ local tool.
 `capture` reads the local database. It does not call GitHub or fill missing
 comments.
 
+`capture` does not support `--github-token-command`. It rejects this selection
+before opening the store or writing output, without invoking the command.
+Offline quota provenance across managed-credential invocations is not yet
+supported; repeating the sync does not resolve this limitation. Static-token
+capture is unchanged.
+
 Run a successful sync before each capture:
 
 ```bash

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -20,6 +20,7 @@ These work on every command.
 | Flag | Default | Description |
 | --- | --- | --- |
 | `--config <path>` | `$GITCRAWL_CONFIG` or default | Override config path |
+| `--github-token-command <path>` | _(off)_ | Absolute executable for managed GitHub credentials; Unix only |
 | `--format text\|json\|log` | `text` | Output format |
 | `--json` | _(off)_ | Shorthand for `--format json` |
 | `--no-color` | _(off)_ | Suppress ANSI color |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -182,12 +182,44 @@ These flags work on every command:
 | Flag | Default | Description |
 | --- | --- | --- |
 | `--config <path>` | `$GITCRAWL_CONFIG` or default | Override config path for this invocation |
+| `--github-token-command <path>` | _(off)_ | Use an absolute executable for managed GitHub credentials |
 | `--format text\|json\|log` | `text` | Output format |
 | `--json` | _(off)_ | Shorthand for `--format json` |
 | `--no-color` | _(off)_ | Suppress ANSI color codes |
 | `--version` | _(off)_ | Print version and exit (global only) |
 
 `--json` overrides `--format`. Both are honored on subcommands that produce output.
+
+### Managed GitHub credentials
+
+For long synchronizations with expiring credentials, select a trusted executable:
+
+```bash
+gitcrawl --github-token-command /usr/local/bin/github-token sync owner/repo --state all
+```
+
+The executable receives no arguments and inherits the process environment. It
+must print exactly one nonempty token line to stdout. Gitcrawl invokes it before
+each GitHub HTTP dispatch, including after rate-limit waits. The executable owns
+credential caching and renewal; Gitcrawl does not persist its output. Selection
+is exclusive: command failure never falls back to environment, config, or `gh`
+credentials. Remote-store login and session authentication are unchanged.
+
+This mode supports Unix only. Windows returns an unsupported-platform error
+before running a synchronization; static credentials remain supported. Helper
+execution is limited to 30 seconds or parent cancellation, with at most two
+seconds of pipe cleanup. Stdout is capped at 4096 bytes; stderr is discarded.
+Use a trusted executable that manages its own credential storage securely.
+
+The same selection covers `sync`, `refresh`, `fill-pr-details`, and
+`search --sync-if-stale`. Help, status, doctor, and `refresh --no-sync` do not
+execute it. Doctor reports the selected source without asserting credentials
+are available. Quota metadata is unavailable until this invocation observes
+the selected token's response. Provider-mode requests do not follow redirects.
+If credentials rotate during quota reservation, Gitcrawl makes at most one
+replacement quota probe, then stops if the token changes again.
+`capture` rejects this option: offline quota provenance across managed-credential
+invocations is not yet supported. Repeating a sync does not resolve that limitation.
 
 ## `gitcrawl configure`
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -64,8 +64,11 @@ type referenceEvidence struct {
 }
 
 type App struct {
-	Stdout io.Writer
-	Stderr io.Writer
+	githubTokenCommand  *string
+	githubTokenMu       sync.Mutex
+	observedGitHubToken string
+	Stdout              io.Writer
+	Stderr              io.Writer
 
 	configPath            string
 	format                OutputFormat
@@ -109,7 +112,7 @@ func New() *App {
 }
 
 func (a *App) Run(ctx context.Context, args []string) error {
-	if len(args) == 0 || rootHelpRequested(args, "config", "format") {
+	if len(args) == 0 || rootHelpRequested(args, "config", "format", "github-token-command") {
 		a.printUsage()
 		return nil
 	}
@@ -124,6 +127,8 @@ func (a *App) Run(ctx context.Context, args []string) error {
 	}
 	a.configPath = strings.TrimSpace(global.Config)
 	a.format = resolvedFormat
+	a.githubTokenCommand = global.GitHubTokenCommand
+	a.observedGitHubToken = ""
 
 	rest := global.Args
 	if global.Version {
@@ -139,6 +144,9 @@ func (a *App) Run(ctx context.Context, args []string) error {
 		}
 		a.printUsage()
 		return nil
+	}
+	if a.githubTokenCommand != nil && rest[0] == "capture" {
+		return usageErr(fmt.Errorf("capture does not support --github-token-command: offline quota provenance for managed credentials is unavailable"))
 	}
 	if releaseNotificationAllowed(rest) {
 		a.maybeNotifyRelease(ctx, rest)
@@ -239,12 +247,13 @@ func (a *App) Run(ctx context.Context, args []string) error {
 }
 
 type gitcrawlRootArgs struct {
-	Config  string   `help:"Config path."`
-	Format  string   `default:"text" help:"Output format: text, json, or log."`
-	JSON    bool     `name:"json" help:"Write JSON output."`
-	Version bool     `help:"Print version."`
-	NoColor bool     `name:"no-color" help:"Disable color output."`
-	Args    []string `arg:"" optional:"" passthrough:"partial" name:"command" help:"Command and arguments."`
+	GitHubTokenCommand *string  `name:"github-token-command" help:"Absolute executable supplying managed GitHub tokens (not supported on Windows)."`
+	Config             string   `help:"Config path."`
+	Format             string   `default:"text" help:"Output format: text, json, or log."`
+	JSON               bool     `name:"json" help:"Write JSON output."`
+	Version            bool     `help:"Print version."`
+	NoColor            bool     `name:"no-color" help:"Disable color output."`
+	Args               []string `arg:"" optional:"" passthrough:"partial" name:"command" help:"Command and arguments."`
 }
 
 func rootHelpRequested(args []string, valueFlags ...string) bool {
@@ -3231,7 +3240,21 @@ func (a *App) syncRepository(ctx context.Context, owner, repo string, options sy
 		return syncer.Stats{}, dbTargetInfo{}, err
 	}
 	token := a.resolveGitHubToken(ctx, cfg)
-	if token.Value == "" {
+	var provider func(context.Context) (string, error)
+	if a.githubTokenCommand != nil {
+		var command func(context.Context) (string, error)
+		command, err = githubTokenProvider(*a.githubTokenCommand)
+		if err != nil {
+			return syncer.Stats{}, dbTargetInfo{}, err
+		}
+		provider = func(ctx context.Context) (string, error) {
+			a.githubTokenMu.Lock()
+			a.observedGitHubToken = ""
+			a.githubTokenMu.Unlock()
+			return command(ctx)
+		}
+	}
+	if provider == nil && token.Value == "" {
 		return syncer.Stats{}, dbTargetInfo{}, fmt.Errorf("missing GitHub token: set %s or authenticate gh", cfg.GitHub.TokenEnv)
 	}
 	if err := config.EnsureRuntimeDirs(cfg); err != nil {
@@ -3255,8 +3278,9 @@ func (a *App) syncRepository(ctx context.Context, owner, repo string, options sy
 	baseURL := githubBaseURL()
 	client := gh.New(gh.Options{
 		Token:            token.Value,
+		TokenProvider:    provider,
 		BaseURL:          baseURL,
-		RateLimit:        a.observeGitHubRateLimit(ctx, token.Value),
+		RateLimit:        a.observeGitHubRateLimit(ctx),
 		RateLimitReserve: options.RateLimitReserve,
 	})
 	service := syncer.New(client, rt.Store)
@@ -5301,6 +5325,7 @@ Usage:
   gitcrawl help <command>
 
 Global flags:
+  --github-token-command <path>  absolute GitHub credential executable (Unix only)
   --config <path>       config path
   --format <mode>      output format: text|json|log
   --json               write JSON output
@@ -5452,6 +5477,8 @@ Usage:
   gitcrawl threads owner/repo [--include-closed] [--numbers refs] [--limit N] [--json]
 `,
 	"capture": `gitcrawl capture exports a stable code-free conversation snapshot.
+
+Managed --github-token-command credentials are not supported by offline capture.
 
 Usage:
   gitcrawl capture owner/repo [--schema gitcrawl.capture.v1] [--since RFC3339] [--output path] [--json]

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -6624,6 +6624,11 @@ func TestSyncCommandPublishesSanitizedFailureProgress(t *testing.T) {
 }
 
 func TestFillPRDetailsHydratesMissingPullRequestDetails(t *testing.T) {
+	testFillPRDetailsHydratesMissingPullRequestDetails(t, "")
+}
+
+func testFillPRDetailsHydratesMissingPullRequestDetails(t *testing.T, tokenCommand string) {
+	t.Helper()
 	ctx := context.Background()
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.toml")
@@ -6655,8 +6660,12 @@ func TestFillPRDetailsHydratesMissingPullRequestDetails(t *testing.T) {
 		t.Fatalf("close seed store: %v", err)
 	}
 
+	expectedToken := "test-gh-token"
+	if tokenCommand != "" {
+		expectedToken = "managed-fill-token"
+	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := r.Header.Get("Authorization"); got != "Bearer test-gh-token" {
+		if got := r.Header.Get("Authorization"); got != "Bearer "+expectedToken {
 			t.Fatalf("authorization mismatch: present=%t length=%d", got != "", len(got))
 		}
 		w.Header().Set("X-RateLimit-Limit", "5000")
@@ -6725,7 +6734,11 @@ func TestFillPRDetailsHydratesMissingPullRequestDetails(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	run.Stdout = &stdout
 	run.Stderr = &stderr
-	if err := run.Run(ctx, []string{"--config", configPath, "fill-pr-details", "openclaw/gitcrawl", "--limit", "1", "--batch-size", "1", "--reserve-rate-limit", "10", "--json-progress", "--json"}); err != nil {
+	args := []string{"--config", configPath, "fill-pr-details", "openclaw/gitcrawl", "--limit", "1", "--batch-size", "1", "--reserve-rate-limit", "10", "--json-progress", "--json"}
+	if tokenCommand != "" {
+		args = append([]string{"--github-token-command", tokenCommand}, args...)
+	}
+	if err := run.Run(ctx, args); err != nil {
 		t.Fatalf("fill-pr-details: %v\nstderr=%s", err, stderr.String())
 	}
 	var result struct {

--- a/internal/cli/gh_rate_limit.go
+++ b/internal/cli/gh_rate_limit.go
@@ -32,8 +32,11 @@ type ghSharedRateLimitState struct {
 	Threshold int       `json:"threshold"`
 }
 
-func (a *App) observeGitHubRateLimit(ctx context.Context, token string) gh.RateLimitObserver {
-	return func(snapshot gh.RateLimitSnapshot) {
+func (a *App) observeGitHubRateLimit(ctx context.Context) gh.RateLimitObserver {
+	return func(token string, snapshot gh.RateLimitSnapshot) {
+		a.githubTokenMu.Lock()
+		a.observedGitHubToken = token
+		a.githubTokenMu.Unlock()
 		_ = a.writeSharedRateLimit(ctx, token, snapshot, "syncer")
 	}
 }

--- a/internal/cli/gh_rate_limit_test.go
+++ b/internal/cli/gh_rate_limit_test.go
@@ -61,8 +61,8 @@ func TestSharedRateLimitStateRoundTrip(t *testing.T) {
 	if state, ok := app.sharedRateLimitLow(ctx); !ok || state.Remaining != 5 {
 		t.Fatalf("shared low = %#v ok=%v", state, ok)
 	}
-	observer := app.observeGitHubRateLimit(ctx, "gh-token")
-	observer(gh.RateLimitSnapshot{Host: "github.com", Limit: 5000, Remaining: 6, ResetAt: resetAt, Resource: "core"})
+	observer := app.observeGitHubRateLimit(ctx)
+	observer("gh-token", gh.RateLimitSnapshot{Host: "github.com", Limit: 5000, Remaining: 6, ResetAt: resetAt, Resource: "core"})
 	if state, ok := app.sharedRateLimitStateForTokenHost("gh-token", "github.com"); !ok || state.Remaining != 6 {
 		t.Fatalf("observed state = %#v ok=%v", state, ok)
 	}

--- a/internal/cli/github_token.go
+++ b/internal/cli/github_token.go
@@ -1,17 +1,29 @@
 package cli
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/openclaw/gitcrawl/internal/config"
 )
 
 func (a *App) resolveGitHubToken(ctx context.Context, cfg config.Config) config.TokenResolution {
+	if a.githubTokenCommand != nil {
+		a.githubTokenMu.Lock()
+		defer a.githubTokenMu.Unlock()
+		return config.TokenResolution{Value: a.observedGitHubToken, Source: "github-token-command"}
+	}
 	token := config.ResolveGitHubToken(cfg)
 	if token.Value != "" {
 		return token
@@ -24,6 +36,59 @@ func (a *App) resolveGitHubToken(ctx context.Context, cfg config.Config) config.
 		return config.TokenResolution{Value: value, Source: "gh auth token"}
 	}
 	return token
+}
+
+func githubTokenProvider(path string) (func(context.Context) (string, error), error) {
+	if runtime.GOOS == "windows" {
+		return nil, errors.New("--github-token-command is not supported on Windows")
+	}
+	info, err := os.Stat(path)
+	if !filepath.IsAbs(path) || err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
+		return nil, errors.New("--github-token-command requires an absolute executable file")
+	}
+	return func(ctx context.Context) (string, error) {
+		tokenCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(tokenCtx, path)
+		configureCommandGroup(cmd)
+		cmd.Cancel = func() error { killCommandGroup(cmd); return nil }
+		cmd.WaitDelay = 2 * time.Second
+		output := &githubTokenOutput{cancel: cancel}
+		cmd.Stdout, cmd.Stderr = output, io.Discard
+		err := cmd.Run()
+		// A successful helper may still have left descendants behind.
+		killCommandGroup(cmd)
+		cleanupCommandGroup(cmd)
+		if output.overflow {
+			return "", errors.New("GitHub token command output exceeded 4096 bytes")
+		}
+		if tokenCtx.Err() != nil {
+			return "", errors.New("GitHub token command canceled or timed out")
+		}
+		if err != nil {
+			return "", errors.New("GitHub token command failed")
+		}
+		token := strings.TrimSuffix(strings.TrimSuffix(output.buffer.String(), "\n"), "\r")
+		if token == "" || !utf8.ValidString(token) || strings.IndexFunc(token, func(r rune) bool { return unicode.IsSpace(r) || unicode.IsControl(r) }) >= 0 {
+			return "", errors.New("GitHub token command must return one nonempty token line")
+		}
+		return token, nil
+	}, nil
+}
+
+type githubTokenOutput struct {
+	buffer   bytes.Buffer
+	cancel   context.CancelFunc
+	overflow bool
+}
+
+func (w *githubTokenOutput) Write(p []byte) (int, error) {
+	if len(p) > 4096-w.buffer.Len() {
+		w.overflow = true
+		w.cancel()
+		return 0, errors.New("token output limit")
+	}
+	return w.buffer.Write(p)
 }
 
 func (a *App) githubAuthToken(ctx context.Context) (string, error) {

--- a/internal/cli/github_token_command_test.go
+++ b/internal/cli/github_token_command_test.go
@@ -1,0 +1,254 @@
+//go:build !windows
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/openclaw/gitcrawl/internal/config"
+	"github.com/openclaw/gitcrawl/internal/store"
+)
+
+func tokenCommandFixture(t *testing.T, script string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "token command")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script+"\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestGitHubTokenCommandCaptureRejectedBeforeSideEffects(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "provider-ran")
+	t.Setenv("TOKEN_TEST_MARKER", marker)
+	path := tokenCommandFixture(t, "echo called > \"$TOKEN_TEST_MARKER\"\nprintf managed-token")
+	output := filepath.Join(dir, "capture.json")
+	prior := []byte("preserved capture")
+	if err := os.WriteFile(output, prior, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	app := New()
+	var stdout bytes.Buffer
+	app.Stdout, app.Stderr = &stdout, io.Discard
+	configDir := filepath.Join(dir, "uncreated")
+	err := app.Run(context.Background(), []string{
+		"--config", filepath.Join(configDir, "config.toml"),
+		"--github-token-command", path, "capture", "owner/repo", "--output", output,
+	})
+	if err == nil || !strings.Contains(err.Error(), "capture does not support --github-token-command") ||
+		strings.Contains(err.Error(), "run sync") || stdout.Len() != 0 {
+		t.Fatalf("unsupported capture: err=%v output bytes=%d", err, stdout.Len())
+	}
+	for _, absent := range []string{marker, configDir} {
+		if _, err := os.Stat(absent); !os.IsNotExist(err) {
+			t.Fatalf("unexpected side effect at %s", filepath.Base(absent))
+		}
+	}
+	if got, err := os.ReadFile(output); err != nil || !bytes.Equal(got, prior) {
+		t.Fatal("capture output changed")
+	}
+}
+
+func TestGitHubTokenCommandFillPRDetailsHydratesMissing(t *testing.T) {
+	path := tokenCommandFixture(t, "printf managed-fill-token")
+	testFillPRDetailsHydratesMissingPullRequestDetails(t, path)
+}
+
+func TestGitHubTokenCommandOutputBoundary(t *testing.T) {
+	for _, tc := range []struct{ name, script, want string }{
+		{"token", "printf 'fixture-token\\n'", "fixture-token"},
+		{"crlf", "printf 'fixture-token\\r\\n'", "fixture-token"},
+		{"no-newline", "printf fixture-token", "fixture-token"},
+		{"empty", "true", ""},
+		{"multiline", "printf 'one\\ntwo\\n'", ""},
+		{"space", "printf 'secret token\\n'", ""},
+		{"control", "printf 'secret\\001token\\n'", ""},
+		{"invalid-utf8", "printf '\\377'", ""},
+		{"failure", "printf secret-output; printf secret-stderr >&2; exit 1", ""},
+		{"overflow", "while :; do printf secret-output; done", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := tokenCommandFixture(t, tc.script)
+			provider, err := githubTokenProvider(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := provider(context.Background())
+			if tc.want != "" {
+				if err != nil || got != tc.want {
+					t.Fatalf("valid token err=%v", err)
+				}
+				return
+			}
+			if err == nil || got != "" {
+				t.Fatal("invalid output accepted")
+			}
+			for _, poison := range []string{"secret", path} {
+				if strings.Contains(err.Error(), poison) {
+					t.Fatal("private provider data leaked")
+				}
+			}
+		})
+	}
+	for _, path := range []string{"", "relative", t.TempDir(), filepath.Join(t.TempDir(), "missing")} {
+		if _, err := githubTokenProvider(path); err == nil {
+			t.Fatal("invalid executable accepted")
+		}
+	}
+	path := tokenCommandFixture(t, "true")
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := githubTokenProvider(path); err == nil {
+		t.Fatal("non-executable accepted")
+	}
+}
+
+func TestGitHubTokenCommandCancellationKillsDescendants(t *testing.T) {
+	for _, deadline := range []bool{false, true} {
+		t.Run(fmt.Sprint(deadline), func(t *testing.T) {
+			pidPath := filepath.Join(t.TempDir(), "child.pid")
+			t.Setenv("TOKEN_TEST_PID", pidPath)
+			path := tokenCommandFixture(t, "(trap '' TERM; while :; do sleep 1; done) &\necho $! > \"$TOKEN_TEST_PID\"\nwait")
+			provider, err := githubTokenProvider(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			if deadline {
+				ctx, cancel = context.WithTimeout(context.Background(), 500*time.Millisecond)
+			}
+			defer cancel()
+			result := make(chan error, 1)
+			go func() { _, err := provider(ctx); result <- err }()
+			var pid int
+			for until := time.Now().Add(3 * time.Second); time.Now().Before(until); {
+				if data, err := os.ReadFile(pidPath); err == nil {
+					pid, _ = strconv.Atoi(strings.TrimSpace(string(data)))
+					if pid > 0 {
+						break
+					}
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			if pid == 0 {
+				cancel()
+				<-result
+				t.Fatal("descendant did not start")
+			}
+			start := time.Now()
+			if !deadline {
+				cancel()
+			}
+			select {
+			case err := <-result:
+				if err == nil {
+					t.Fatal("cancellation succeeded")
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatal("provider cancellation exceeded cleanup bound")
+			}
+			if time.Since(start) > 3*time.Second {
+				t.Fatal("unbounded cancellation")
+			}
+			// Linux may retain a dead orphan as a zombie until init reaps it.
+			for until := time.Now().Add(2 * time.Second); time.Now().Before(until); {
+				if syscall.Kill(pid, 0) != nil {
+					return
+				}
+				if data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid)); err == nil {
+					if tail := strings.LastIndex(string(data), ") "); tail >= 0 && strings.HasPrefix(string(data)[tail+2:], "Z ") {
+						return
+					}
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			t.Fatal("provider descendant remained running")
+		})
+	}
+}
+
+func TestGitHubTokenCommandSharedSyncOwnerAndInspection(t *testing.T) {
+	dir := t.TempDir()
+	cfg := config.Default()
+	cfg.DBPath, cfg.CacheDir = filepath.Join(dir, "archive.db"), filepath.Join(dir, "cache")
+	cfgPath := filepath.Join(dir, "config.toml")
+	if err := config.Save(cfgPath, cfg); err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.Open(context.Background(), cfg.DBPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(dir, "provider-ran")
+	t.Setenv("TOKEN_TEST_MARKER", marker)
+	t.Setenv("GITHUB_TOKEN", "ambient-must-not-win")
+	path := tokenCommandFixture(t, "echo called >> \"$TOKEN_TEST_MARKER\"\nprintf managed-fixture")
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Header.Get("Authorization") != "Bearer managed-fixture" {
+			t.Error("static credential won")
+		}
+		switch r.URL.Path {
+		case "/repos/owner/repo":
+			fmt.Fprint(w, `{"id":1,"full_name":"owner/repo","name":"repo","owner":{"login":"owner"}}`)
+		case "/repos/owner/repo/issues":
+			fmt.Fprint(w, `[]`)
+		default:
+			t.Errorf("unexpected request %s", r.URL.Path)
+			w.WriteHeader(404)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("GITCRAWL_GITHUB_BASE_URL", server.URL)
+	for _, args := range [][]string{
+		{"sync", "owner/repo", "--state", "all", "--json"},
+		{"refresh", "owner/repo", "--no-embed", "--no-cluster", "--json"},
+		{"search", "issues", "missing", "-R", "owner/repo", "--sync-if-stale", "1ns", "--json", "number"},
+	} {
+		app := New()
+		app.Stdout, app.Stderr = io.Discard, io.Discard
+		if err := app.Run(context.Background(), append([]string{"--config", cfgPath, "--github-token-command", path}, args...)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if requests != 6 {
+		t.Fatalf("sync requests=%d", requests)
+	}
+	before, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"status", "--json"}, {"doctor", "--json"}, {"metadata", "--json"},
+		{"refresh", "owner/repo", "--no-sync", "--no-embed", "--json"},
+		{"fill-pr-details", "owner/repo", "--json"},
+	} {
+		app := New()
+		app.Stdout, app.Stderr = io.Discard, io.Discard
+		if err := app.Run(context.Background(), append([]string{"--config", cfgPath, "--github-token-command", path}, args...)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	after, err := os.ReadFile(marker)
+	if err != nil || !bytes.Equal(before, after) {
+		t.Fatal("read-only/no-sync/empty-fill invoked provider")
+	}
+}

--- a/internal/cli/github_token_command_windows_test.go
+++ b/internal/cli/github_token_command_windows_test.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGitHubTokenCommandUnsupportedWindows(t *testing.T) {
+	provider, err := githubTokenProvider(`C:\unused\provider.exe`)
+	if provider != nil || err == nil || !strings.Contains(err.Error(), "not supported on Windows") {
+		t.Fatalf("managed credential eligibility: %v", err)
+	}
+}

--- a/internal/cli/github_token_test.go
+++ b/internal/cli/github_token_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/openclaw/gitcrawl/internal/config"
@@ -22,6 +23,70 @@ func TestResolveGitHubTokenFallsBackToGHAuthToken(t *testing.T) {
 	token := app.resolveGitHubToken(context.Background(), config.Default())
 	if token.Value != "gh-fallback-token" || token.Source != "gh auth token" {
 		t.Fatalf("token mismatch: source=%q value_present=%t value_length=%d", token.Source, token.Value != "", len(token.Value))
+	}
+}
+
+func TestGitHubTokenCommandRootParsingAndHelp(t *testing.T) {
+	for _, args := range [][]string{
+		{"--github-token-command", "/unused/provider", "version"},
+		{"--github-token-command=/unused/provider", "version"},
+	} {
+		app := New()
+		var stdout bytes.Buffer
+		app.Stdout = &stdout
+		if err := app.Run(context.Background(), args); err != nil {
+			t.Fatal(err)
+		}
+		if app.githubTokenCommand == nil || *app.githubTokenCommand != "/unused/provider" {
+			t.Fatal("credential command not parsed")
+		}
+	}
+	for _, args := range [][]string{
+		{"--github-token-command", "/unused/provider", "--help"},
+		{"--github-token-command=/unused/provider", "--help"},
+	} {
+		app := New()
+		var stdout bytes.Buffer
+		app.Stdout = &stdout
+		if err := app.Run(context.Background(), args); err != nil || !strings.Contains(stdout.String(), "--github-token-command") {
+			t.Fatalf("help err=%v output=%s", err, stdout.String())
+		}
+	}
+	var parsed gitcrawlRootArgs
+	if err := parseKongArgs(&parsed, []string{"--github-token-command=", "version"}, "gitcrawl", &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	if parsed.GitHubTokenCommand == nil || *parsed.GitHubTokenCommand != "" {
+		t.Fatal("explicit empty selection became static authentication")
+	}
+}
+
+func TestGitHubTokenCommandInspectionDoesNotResolveAmbientCredentials(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(configPath, []byte("version = 1\ndb_path = "+strconv.Quote(filepath.Join(dir, "gitcrawl.db"))+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GITHUB_TOKEN", "ambient-must-not-win")
+	app := New()
+	app.githubAuthTokenLookup = func(context.Context) (string, error) {
+		t.Fatal("managed metadata used gh fallback")
+		return "", nil
+	}
+	var stdout bytes.Buffer
+	app.Stdout = &stdout
+	if err := app.Run(context.Background(), []string{"--config", configPath, "--github-token-command", "/does-not-exist", "doctor", "--json"}); err != nil {
+		t.Fatal(err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result["github_token_present"] != false || result["github_token_source"] != "github-token-command" {
+		t.Fatalf("credential metadata=%v/%v", result["github_token_present"], result["github_token_source"])
+	}
+	if _, ok := app.sharedRateLimitState(context.Background()); ok {
+		t.Fatal("unobserved managed quota reported available")
 	}
 }
 

--- a/internal/cli/portable_safety_unix_test.go
+++ b/internal/cli/portable_safety_unix_test.go
@@ -36,9 +36,20 @@ func TestPortableConfigScopeIsolationAndRefusal(t *testing.T) {
 	t.Setenv("GITCRAWL_TEST_MARKER", marker)
 	t.Setenv("GITCRAWL_TEST_REAL_GIT", realGit)
 	// An operator-selected wrapper supplies a synthetic system scope without
-	// modifying the machine's Git configuration or reading its values.
+	// reading machine or Apple Git Xcode configuration. Keep /dev/null isolation.
 	wrapper := filepath.Join(dir, "git")
-	script := "#!/bin/sh\nexport GIT_CONFIG_SYSTEM=\"${GIT_CONFIG_SYSTEM:-$GITCRAWL_TEST_SYSTEM_CONFIG}\"\nexec \"$GITCRAWL_TEST_REAL_GIT\" \"$@\"\n"
+	script := `#!/bin/sh
+export GIT_CONFIG_NOSYSTEM=1
+case "$*" in
+  *" config --null --list --show-scope")
+    if [ -n "$GITCRAWL_TEST_SYSTEM_CONFIG" ] && [ "${GIT_CONFIG_SYSTEM:-}" != /dev/null ]; then
+      printf 'system\000filter.fixture.smudge\n'
+      "$GITCRAWL_TEST_REAL_GIT" config --file "$GITCRAWL_TEST_SYSTEM_CONFIG" --null --get filter.fixture.smudge || exit $?
+    fi
+    ;;
+esac
+exec "$GITCRAWL_TEST_REAL_GIT" "$@"
+`
 	if err := os.WriteFile(wrapper, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/runtime_extra_test.go
+++ b/internal/cli/runtime_extra_test.go
@@ -618,6 +618,9 @@ func TestPublishPortableCheckoutPairPreservesCheckoutMode(t *testing.T) {
 	if err := os.WriteFile(checkoutManifest, []byte("old manifest"), 0o640); err != nil {
 		t.Fatalf("write old checkout manifest: %v", err)
 	}
+	if err := os.Chmod(checkoutManifest, 0o640); err != nil {
+		t.Fatalf("chmod old checkout manifest: %v", err)
+	}
 
 	if err := publishPortableCheckoutPair(ctx, mirrorDB, mirrorManifest, checkoutDB, checkoutManifest); err != nil {
 		t.Fatalf("publish portable checkout pair: %v", err)
@@ -1122,6 +1125,14 @@ func TestPortableRuntimeUtilityBranches(t *testing.T) {
 	if err := os.Chtimes(lockPath, oldLock, oldLock); err != nil {
 		t.Fatalf("age index lock: %v", err)
 	}
+	fakeBin := filepath.Join(dir, "fake-bin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatalf("mkdir fake bin: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(fakeBin, "lsof"), []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write no-holder lsof: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
 	removed, err := removeStaleGitIndexLock(context.Background(), lockRoot, staleGitIndexLockAge)
 	if err != nil || !removed {
 		t.Fatalf("remove stale index lock removed=%v err=%v", removed, err)
@@ -1136,14 +1147,9 @@ func TestPortableRuntimeUtilityBranches(t *testing.T) {
 	if err := os.Chtimes(lockPath, oldLock, oldLock); err != nil {
 		t.Fatalf("age index lock with failing lsof: %v", err)
 	}
-	fakeBin := filepath.Join(dir, "fake-bin")
-	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
-		t.Fatalf("mkdir fake bin: %v", err)
-	}
 	if err := os.WriteFile(filepath.Join(fakeBin, "lsof"), []byte("#!/bin/sh\nexit 2\n"), 0o755); err != nil {
 		t.Fatalf("write fake lsof: %v", err)
 	}
-	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
 	removed, err = removeStaleGitIndexLock(context.Background(), lockRoot, staleGitIndexLockAge)
 	if err != nil || removed {
 		t.Fatalf("failing lsof should not remove lock, removed=%v err=%v", removed, err)

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -20,23 +20,26 @@ import (
 type Reporter func(message string)
 
 type Client struct {
-	httpClient *http.Client
-	baseURL    string
-	graphQLURL string
-	token      string
-	userAgent  string
-	pageDelay  time.Duration
-	rateLimit  RateLimitObserver
-	reserve    *rateLimitReserve
+	httpClient    *http.Client
+	baseURL       string
+	graphQLURL    string
+	token         string
+	tokenProvider func(context.Context) (string, error)
+	userAgent     string
+	pageDelay     time.Duration
+	rateLimit     RateLimitObserver
+	reserve       *rateLimitReserve
 }
 
 type Options struct {
-	Token      string
-	BaseURL    string
-	UserAgent  string
-	HTTPClient *http.Client
-	PageDelay  time.Duration
-	RateLimit  RateLimitObserver
+	Token string
+	// TokenProvider exclusively selects credentials immediately before dispatch.
+	TokenProvider func(context.Context) (string, error)
+	BaseURL       string
+	UserAgent     string
+	HTTPClient    *http.Client
+	PageDelay     time.Duration
+	RateLimit     RateLimitObserver
 	// RateLimitReserve preserves a best-effort observed floor for the shared
 	// token. Guarded requests refresh /rate_limit before dispatch so other token
 	// consumers are observed, but unrelated consumers cannot be locked between
@@ -47,7 +50,7 @@ type Options struct {
 
 // RateLimitObserver receives synchronous quota snapshots. An observer used by
 // a reserve-guarded client must not call back into that same Client.
-type RateLimitObserver func(RateLimitSnapshot)
+type RateLimitObserver func(token string, snapshot RateLimitSnapshot)
 
 type RateLimitSnapshot struct {
 	Host      string
@@ -130,13 +133,14 @@ func New(options Options) *Client {
 		userAgent = "gitcrawl"
 	}
 	client := &Client{
-		httpClient: httpClient,
-		baseURL:    baseURL,
-		graphQLURL: graphQLURLForBaseURL(baseURL),
-		token:      options.Token,
-		userAgent:  userAgent,
-		pageDelay:  options.PageDelay,
-		rateLimit:  options.RateLimit,
+		httpClient:    httpClient,
+		baseURL:       baseURL,
+		graphQLURL:    graphQLURLForBaseURL(baseURL),
+		token:         options.Token,
+		tokenProvider: options.TokenProvider,
+		userAgent:     userAgent,
+		pageDelay:     options.PageDelay,
+		rateLimit:     options.RateLimit,
 	}
 	if options.RateLimitReserve > 0 {
 		client.reserve = newRateLimitReserve(options.RateLimitReserve, options.InitialRateLimits)
@@ -216,6 +220,11 @@ func (c *Client) GetRepo(ctx context.Context, owner, repo string, reporter Repor
 }
 
 func (c *Client) GetRateLimits(ctx context.Context, reporter Reporter) ([]RateLimitSnapshot, error) {
+	snapshots, _, err := c.getRateLimits(ctx, reporter, nil)
+	return snapshots, err
+}
+
+func (c *Client) getRateLimits(ctx context.Context, reporter Reporter, selectedToken *string) ([]RateLimitSnapshot, string, error) {
 	if c.reserve != nil {
 		lockedReserve, _ := ctx.Value(rateLimitRequestLockKey{}).(*rateLimitReserve)
 		if lockedReserve != c.reserve {
@@ -231,9 +240,15 @@ func (c *Client) GetRateLimits(ctx context.Context, reporter Reporter) ([]RateLi
 			Reset     int64 `json:"reset"`
 		} `json:"resources"`
 	}
-	if err := c.doJSON(ctx, http.MethodGet, "/rate_limit", nil, reporter, &payload); err != nil {
-		return nil, err
+	resp, err := c.doWithToken(ctx, http.MethodGet, "/rate_limit", nil, reporter, selectedToken)
+	if err != nil {
+		return nil, "", err
 	}
+	defer resp.Body.Close()
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, "", fmt.Errorf("decode github response: %w", err)
+	}
+	token := strings.TrimPrefix(resp.Request.Header.Get("Authorization"), "Bearer ")
 	host := rateLimitHostForBaseURL(c.baseURL)
 	out := make([]RateLimitSnapshot, 0, len(payload.Resources))
 	for resource, value := range payload.Resources {
@@ -252,12 +267,12 @@ func (c *Client) GetRateLimits(ctx context.Context, reporter Reporter) ([]RateLi
 	if c.rateLimit != nil {
 		for _, snapshot := range out {
 			if snapshot.Resource == "core" {
-				c.rateLimit(snapshot)
+				c.rateLimit(token, snapshot)
 				break
 			}
 		}
 	}
-	return out, nil
+	return out, token, nil
 }
 
 func (c *Client) GetIssue(ctx context.Context, owner, repo string, number int, reporter Reporter) (map[string]any, error) {
@@ -450,6 +465,10 @@ func (c *Client) doJSON(ctx context.Context, method, path string, body io.Reader
 }
 
 func (c *Client) do(ctx context.Context, method, path string, body io.Reader, reporter Reporter) (*http.Response, error) {
+	return c.doWithToken(ctx, method, path, body, reporter, nil)
+}
+
+func (c *Client) doWithToken(ctx context.Context, method, path string, body io.Reader, reporter Reporter, selectedToken *string) (*http.Response, error) {
 	var bodyBytes []byte
 	if body != nil {
 		var err error
@@ -464,7 +483,7 @@ func (c *Client) do(ctx context.Context, method, path string, body io.Reader, re
 		}
 		return bytes.NewReader(bodyBytes)
 	}
-	resp, err := c.doOnce(ctx, method, path, bodyReader(), reporter)
+	resp, err := c.doOnce(ctx, method, path, bodyReader(), reporter, selectedToken)
 	if err == nil {
 		return resp, nil
 	}
@@ -480,13 +499,22 @@ func (c *Client) do(ctx context.Context, method, path string, body io.Reader, re
 		return nil, ctx.Err()
 	case <-timer.C:
 	}
-	return c.doOnce(ctx, method, path, bodyReader(), reporter)
+	return c.doOnce(ctx, method, path, bodyReader(), reporter, nil)
 }
 
-func (c *Client) doOnce(ctx context.Context, method, path string, body io.Reader, reporter Reporter) (*http.Response, error) {
+func (c *Client) doOnce(ctx context.Context, method, path string, body io.Reader, reporter Reporter, selectedToken *string) (*http.Response, error) {
 	fullURL := path
 	if !isAbsoluteURL(path) {
 		fullURL = c.baseURL + path
+	}
+	if c.tokenProvider != nil {
+		target, targetErr := url.Parse(fullURL)
+		origin, originErr := url.Parse(c.baseURL)
+		if targetErr != nil || originErr != nil || target.User != nil || origin.Host == "" ||
+			(target.Scheme != "https" && target.Scheme != "http") ||
+			!strings.EqualFold(target.Scheme, origin.Scheme) || !strings.EqualFold(target.Host, origin.Host) {
+			return nil, errors.New("GitHub token provider requires the configured API origin")
+		}
 	}
 	resource, cost := c.requestRateLimit(method, fullURL)
 	if c.reserve != nil {
@@ -497,14 +525,42 @@ func (c *Client) doOnce(ctx context.Context, method, path string, body io.Reader
 			ctx = context.WithValue(ctx, rateLimitRequestLockKey{}, c.reserve)
 		}
 	}
+	var probeToken string
 	if c.reserve != nil && cost > 0 {
-		if _, err := c.GetRateLimits(ctx, reporter); err != nil {
+		var err error
+		_, probeToken, err = c.getRateLimits(ctx, reporter, nil)
+		if err != nil {
 			return nil, fmt.Errorf("refresh GitHub rate limit status: %w", err)
+		}
+	}
+	token := c.token
+	if selectedToken != nil {
+		token = *selectedToken
+	} else {
+		var err error
+		token, err = c.requestToken(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if c.tokenProvider != nil && c.reserve != nil && cost > 0 && token != probeToken {
+		// A new token cannot spend the previous token's quota. Allow one new
+		// probe, then reject further rotation before the protected request.
+		_, probeToken, err := c.getRateLimits(ctx, reporter, &token)
+		if err != nil {
+			return nil, fmt.Errorf("refresh GitHub rate limit status: %w", err)
+		}
+		token, err = c.requestToken(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if token != probeToken {
+			return nil, errors.New("GitHub token changed during rate limit reservation")
 		}
 	}
 	if err := c.reserve.beforeRequest(resource, cost); err != nil {
 		var expired *rateLimitStatusExpiredError
-		if !errors.As(err, &expired) {
+		if c.tokenProvider != nil || !errors.As(err, &expired) {
 			return nil, err
 		}
 		_, refreshErr := c.GetRateLimits(ctx, reporter)
@@ -525,8 +581,8 @@ func (c *Client) doOnce(ctx context.Context, method, path string, body io.Reader
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	if c.token != "" {
-		req.Header.Set("Authorization", "Bearer "+c.token)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
 	reporter.Printf("[github] request %s %s", method, path)
 	resp, err := c.guardedHTTPClient().Do(req)
@@ -534,8 +590,9 @@ func (c *Client) doOnce(ctx context.Context, method, path string, body io.Reader
 		return nil, fmt.Errorf("github request: %w", err)
 	}
 	responseResource, responseCost := c.requestRateLimit(resp.Request.Method, resp.Request.URL.String())
-	if responseCost > 0 && !c.observeRateLimit(resp.Header, responseResource) {
-		c.observeReservedRateLimit(responseResource)
+	responseToken := strings.TrimPrefix(resp.Request.Header.Get("Authorization"), "Bearer ")
+	if responseCost > 0 && !c.observeRateLimit(responseToken, resp.Header, responseResource) {
+		c.observeReservedRateLimit(responseToken, responseResource)
 	}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return resp, nil
@@ -552,12 +609,15 @@ func (c *Client) doOnce(ctx context.Context, method, path string, body io.Reader
 }
 
 func (c *Client) guardedHTTPClient() *http.Client {
-	if c.reserve == nil {
+	if c.reserve == nil && c.tokenProvider == nil {
 		return c.httpClient
 	}
 	client := *c.httpClient
 	checkRedirect := client.CheckRedirect
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if c.tokenProvider != nil {
+			return http.ErrUseLastResponse
+		}
 		if checkRedirect != nil {
 			if err := checkRedirect(req, via); err != nil {
 				return err
@@ -566,6 +626,20 @@ func (c *Client) guardedHTTPClient() *http.Client {
 		return http.ErrUseLastResponse
 	}
 	return &client
+}
+
+func (c *Client) requestToken(ctx context.Context) (string, error) {
+	if c.tokenProvider == nil {
+		return c.token, nil
+	}
+	token, err := c.tokenProvider(ctx)
+	if err != nil || token == "" {
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+		return "", errors.New("GitHub token provider failed")
+	}
+	return token, nil
 }
 
 func (c *Client) requestRateLimit(method, fullURL string) (string, int) {
@@ -600,7 +674,7 @@ func graphQLURLForBaseURL(baseURL string) string {
 	return parsed.String()
 }
 
-func (c *Client) observeRateLimit(header http.Header, fallbackResource string) bool {
+func (c *Client) observeRateLimit(token string, header http.Header, fallbackResource string) bool {
 	remaining, err := strconv.Atoi(strings.TrimSpace(header.Get("X-RateLimit-Remaining")))
 	if err != nil {
 		return false
@@ -625,18 +699,18 @@ func (c *Client) observeRateLimit(header http.Header, fallbackResource string) b
 	}
 	c.reserve.observe(snapshot)
 	if c.rateLimit != nil {
-		c.rateLimit(snapshot)
+		c.rateLimit(token, snapshot)
 	}
 	return true
 }
 
-func (c *Client) observeReservedRateLimit(resource string) {
+func (c *Client) observeReservedRateLimit(token, resource string) {
 	snapshot, ok := c.reserve.snapshot(resource)
 	if !ok || c.rateLimit == nil {
 		return
 	}
 	snapshot.Host = rateLimitHostForBaseURL(c.baseURL)
-	c.rateLimit(snapshot)
+	c.rateLimit(token, snapshot)
 }
 
 func rateLimitHostForBaseURL(baseURL string) string {

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -936,7 +936,7 @@ func TestRateLimitReserveSerializesConcurrentRateStatus(t *testing.T) {
 		InitialRateLimits: []RateLimitSnapshot{{
 			Limit: 5000, Remaining: 11, ResetAt: resetAt, Resource: "core",
 		}},
-		RateLimit: func(snapshot RateLimitSnapshot) {
+		RateLimit: func(_ string, snapshot RateLimitSnapshot) {
 			observedMu.Lock()
 			defer observedMu.Unlock()
 			observed = append(observed, snapshot.Remaining)
@@ -1086,7 +1086,7 @@ func TestRateLimitObserverUsesFinalRedirectResource(t *testing.T) {
 
 	client := New(Options{
 		BaseURL: server.URL,
-		RateLimit: func(value RateLimitSnapshot) {
+		RateLimit: func(_ string, value RateLimitSnapshot) {
 			snapshot = value
 		},
 	})
@@ -1240,7 +1240,7 @@ func TestRateLimitObserverIncludesAPIHost(t *testing.T) {
 	client := New(Options{
 		BaseURL:   server.URL,
 		PageDelay: -1,
-		RateLimit: func(value RateLimitSnapshot) {
+		RateLimit: func(_ string, value RateLimitSnapshot) {
 			snapshot = value
 		},
 	})

--- a/internal/github/token_provider_test.go
+++ b/internal/github/token_provider_test.go
@@ -1,0 +1,286 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func sequenceTokenProvider(t *testing.T, tokens ...string) func(context.Context) (string, error) {
+	t.Helper()
+	i := 0
+	return func(context.Context) (string, error) {
+		if i >= len(tokens) {
+			t.Fatal("unexpected credential invocation")
+		}
+		token := tokens[i]
+		i++
+		return token, nil
+	}
+}
+
+func TestTokenProviderRefreshesRESTPagesAndGraphQL(t *testing.T) {
+	var seen, observed []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.Header.Get("Authorization"))
+		w.Header().Set("X-RateLimit-Remaining", "100")
+		switch r.URL.Path {
+		case "/pages":
+			w.Header().Set("Link", `</second>; rel="next"`)
+			fmt.Fprint(w, `[{"id":1}]`)
+		case "/second":
+			fmt.Fprint(w, `[{"id":2}]`)
+		case "/graphql":
+			fmt.Fprint(w, `{"data":{}}`)
+		default:
+			t.Errorf("unexpected request %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	client := New(Options{
+		BaseURL: server.URL, Token: "unused-static",
+		TokenProvider: sequenceTokenProvider(t, "first", "second", "third"),
+		RateLimit:     func(token string, _ RateLimitSnapshot) { observed = append(observed, token) },
+	})
+	rows, err := client.paginate(context.Background(), "/pages", 0, 0, nil)
+	if err != nil || len(rows) != 2 {
+		t.Fatalf("pages: count=%d err=%v", len(rows), err)
+	}
+	var result map[string]any
+	if err := client.doJSON(context.Background(), http.MethodPost, client.graphQLURL, strings.NewReader(`{"query":"query { viewer { login } }"}`), nil, &result); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(seen, []string{"Bearer first", "Bearer second", "Bearer third"}) ||
+		!reflect.DeepEqual(observed, []string{"first", "second", "third"}) {
+		t.Fatalf("request/observation credentials differ: %v %v", seen, observed)
+	}
+}
+
+func TestTokenProviderRefreshesAfterRateLimitWait(t *testing.T) {
+	var seen []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.Header.Get("Authorization"))
+		if len(seen) == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		fmt.Fprint(w, `{"id":1}`)
+	}))
+	defer server.Close()
+	client := New(Options{BaseURL: server.URL, TokenProvider: sequenceTokenProvider(t, "before", "after")})
+	if _, err := client.GetRepo(context.Background(), "owner", "repo", nil); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(seen, []string{"Bearer before", "Bearer after"}) {
+		t.Fatalf("credentials after wait: %v", seen)
+	}
+}
+
+func TestTokenProviderRefreshesGraphQLPages(t *testing.T) {
+	var seen []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.Header.Get("Authorization"))
+		var request graphqlEnvelope
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Error(err)
+			return
+		}
+		page := len(seen)
+		if page == 2 && request.Variables["cursor"] != "next" {
+			t.Error("GraphQL cursor changed during credential rotation")
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"repository": map[string]any{"pullRequest": map[string]any{
+			"reviewThreads": map[string]any{
+				"nodes":    []map[string]any{{"id": fmt.Sprint(page)}},
+				"pageInfo": map[string]any{"hasNextPage": page == 1, "endCursor": "next"},
+			},
+		}}}})
+	}))
+	defer server.Close()
+	client := New(Options{BaseURL: server.URL, TokenProvider: sequenceTokenProvider(t, "first", "second")})
+	rows, err := client.ListPullReviewThreads(context.Background(), "owner", "repo", 1, nil)
+	if err != nil || len(rows) != 2 || !reflect.DeepEqual(seen, []string{"Bearer first", "Bearer second"}) {
+		t.Fatalf("GraphQL pages count=%d credentials=%v err=%v", len(rows), seen, err)
+	}
+}
+
+func TestTokenProviderBindsQuotaToReplacementCredential(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		tokens       []string
+		remaining    int
+		wantRequests int
+		wantError    string
+	}{
+		{"rotated", []string{"a", "b", "b"}, 11, 1, ""},
+		{"new-token-low", []string{"a", "b", "b"}, 10, 0, "reserve"},
+		{"unstable", []string{"a", "b", "c"}, 11, 0, "changed during"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var probes, requests, observed []string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				token := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+				if r.URL.Path == "/rate_limit" {
+					probes = append(probes, token)
+					remaining := 100
+					if token == "b" {
+						remaining = tc.remaining
+					}
+					writeRateLimits(t, w, time.Now().Add(time.Hour), remaining, remaining)
+					return
+				}
+				requests = append(requests, token)
+				fmt.Fprint(w, `{"id":1}`)
+			}))
+			defer server.Close()
+			client := New(Options{
+				BaseURL: server.URL, RateLimitReserve: 10,
+				TokenProvider: sequenceTokenProvider(t, tc.tokens...),
+				RateLimit:     func(token string, _ RateLimitSnapshot) { observed = append(observed, token) },
+			})
+			_, err := client.GetRepo(context.Background(), "owner", "repo", nil)
+			if tc.wantError == "" && err != nil || tc.wantError != "" && (err == nil || !strings.Contains(err.Error(), tc.wantError)) {
+				t.Fatalf("error = %v", err)
+			}
+			if !reflect.DeepEqual(probes, []string{"a", "b"}) || len(requests) != tc.wantRequests {
+				t.Fatalf("probes=%v requests=%v", probes, requests)
+			}
+			if len(requests) > 0 && requests[0] != "b" || len(observed) < 2 || observed[1] != "b" {
+				t.Fatalf("wrong quota identity: requests=%v observed=%v", requests, observed)
+			}
+		})
+	}
+}
+
+func TestTokenProviderRejectsForeignOriginBeforeExecutionAndRedirects(t *testing.T) {
+	calls := 0
+	targetCalls := 0
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { targetCalls++ }))
+	defer target.Close()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer server.Close()
+	client := New(Options{
+		BaseURL:       server.URL,
+		TokenProvider: func(context.Context) (string, error) { calls++; return "managed", nil },
+		HTTPClient: &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+			t.Fatal("provider redirect bypassed dispatch boundary")
+			return nil
+		}},
+	})
+	var out map[string]any
+	if err := client.doJSON(context.Background(), http.MethodGet, target.URL, nil, nil, &out); err == nil || calls != 0 {
+		t.Fatalf("foreign request error=%v provider calls=%d", err, calls)
+	}
+	if _, err := client.GetRepo(context.Background(), "owner", "repo", nil); err == nil {
+		t.Fatal("redirect succeeded")
+	}
+	if calls != 1 || targetCalls != 0 {
+		t.Fatalf("provider=%d target=%d", calls, targetCalls)
+	}
+}
+
+func TestTokenProviderFailureDoesNotLeakOrFallBack(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { requests++ }))
+	defer server.Close()
+	for _, provider := range []func(context.Context) (string, error){
+		func(context.Context) (string, error) { return "", errors.New("secret-output-and-path") },
+		func(context.Context) (string, error) { return "", nil },
+		func(ctx context.Context) (string, error) {
+			child, cancel := context.WithCancel(ctx)
+			cancel()
+			return "", fmt.Errorf("secret-helper-path: %w", child.Err())
+		},
+		func(ctx context.Context) (string, error) {
+			child, cancel := context.WithDeadline(ctx, time.Unix(0, 0))
+			defer cancel()
+			return "", fmt.Errorf("secret-helper-path: %w", child.Err())
+		},
+	} {
+		client := New(Options{BaseURL: server.URL, Token: "static", TokenProvider: provider})
+		_, err := client.GetRepo(context.Background(), "owner", "repo", nil)
+		if err == nil || err.Error() != "GitHub token provider failed" || requests != 0 ||
+			errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("failure = %v requests=%d", err, requests)
+		}
+	}
+}
+
+func TestTokenProviderPreservesParentContextErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ctx  func() (context.Context, context.CancelFunc)
+		want error
+	}{
+		{"canceled", func() (context.Context, context.CancelFunc) {
+			return context.WithCancel(context.Background())
+		}, context.Canceled},
+		{"deadline", func() (context.Context, context.CancelFunc) {
+			return context.WithDeadline(context.Background(), time.Unix(0, 0))
+		}, context.DeadlineExceeded},
+	} {
+		for _, method := range []string{http.MethodGet, http.MethodPost} {
+			t.Run(tc.name+"/"+method, func(t *testing.T) {
+				ctx, cancel := tc.ctx()
+				defer cancel()
+				requests := 0
+				server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+					requests++
+				}))
+				defer server.Close()
+				client := New(Options{
+					BaseURL: server.URL,
+					TokenProvider: func(providerCtx context.Context) (string, error) {
+						cancel()
+						<-providerCtx.Done()
+						return "", errors.New("secret-provider-output-and-path")
+					},
+				})
+				path := "/repos/owner/repo"
+				if method == http.MethodPost {
+					path = client.graphQLURL
+				}
+				var out map[string]any
+				err := client.doJSON(ctx, method, path, nil, nil, &out)
+				if !errors.Is(err, tc.want) || err.Error() != tc.want.Error() || requests != 0 {
+					t.Fatalf("error = %v, want %v; requests=%d", err, tc.want, requests)
+				}
+			})
+		}
+	}
+}
+
+func TestTokenProviderRateLimitResponseUsesActualTokenAfterWait(t *testing.T) {
+	var observed []string
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"resources": map[string]any{"core": map[string]int{"remaining": 100, "limit": 5000}}})
+	}))
+	defer server.Close()
+	client := New(Options{
+		BaseURL: server.URL, TokenProvider: sequenceTokenProvider(t, "before", "after"),
+		RateLimit: func(token string, _ RateLimitSnapshot) { observed = append(observed, token) },
+	})
+	if _, err := client.GetRateLimits(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(observed, []string{"after"}) {
+		t.Fatalf("quota observation=%v", observed)
+	}
+}


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users running long GitHub syncs with expiring GitHub App credentials could not renew the credential without restarting the process.

The client retained its initial token throughout the sync. The motivating run stopped at an operator-enforced credential-lifetime deadline; it did not establish an expired-token rejection from GitHub.

## Why This Change Was Made

Add explicit `--github-token-command <absolute-executable>` support through the shared GitHub client. It obtains the current credential immediately before each dispatch, including after rate-limit waits, and attributes quota observations and reservations to the credential actually used.

The trusted executable owns credential caching and renewal. Gitcrawl bounds its execution and output, preserves parent cancellation, sanitizes helper failures, does not persist token output, and refuses provider-mode redirects. Static-token behavior and remote-store authentication remain unchanged; there is no new dependency, ambient configuration setting, or storage schema.

## User Impact

- Renewable credentials work across `sync`, `refresh`, `fill-pr-details`, and `search --sync-if-stale`.
- Managed mode is explicit and exclusive: helper failure does not fall back to environment, config, or `gh` credentials.
- Help, status, doctor, and `refresh --no-sync` do not invoke the credential helper. Doctor reports the selected source without claiming credentials are available.
- Managed credentials are unsupported on Windows and for offline `capture`. Both reject without invoking the helper; static mode is unchanged. Managed capture requires a separate offline quota-provenance design.

## Evidence

Committed head: `3b9f9c387c1b425766bb62caed043c5213163653`. Its source is byte-identical to the validated v6 snapshot.

Completed proof:

- Fresh committed-head P0/P1/P2 autoreview for `3b9f9c387c1b425766bb62caed043c5213163653`: no findings; all 17 changed files included in one scanner-qualified pass.
- Exact-head [CI on Ubuntu and macOS](https://github.com/openclaw/gitcrawl/actions/runs/34213301399), [Docker validation](https://github.com/openclaw/gitcrawl/actions/runs/34213301506), secret scanning, and CodeQL passed.
- [ClawSweeper's exact-head review](https://github.com/openclaw/gitcrawl/pull/172#issuecomment-5583361549) reported no findings or security findings, with no before-merge actions.
- Go 1.27.1, v6: `TestPortableConfigScopeIsolationAndRefusal` and `TestPortableConfigProtocolFailsClosed` passed.
- The v6 full `internal/cli` suite passed in 365.619 seconds with 86.3% coverage. The preceding v5 run passed `internal/github` and `internal/syncer`; those package bytes are unchanged in v6. This is three freshly run packages across separate runs plus twelve retained passing packages, not a fresh full-suite run.
- Reconciled statement coverage is 85.7%, above the 85% floor. Failed v5 CLI coverage was discarded and replaced by passing v6 coverage.
- Fake-provider and local HTTP tests cover credential rotation, dispatch-time selection, token-specific quota accounting, parent cancellation, and privacy boundaries. The corrected scope fixture retains its refusal, byte-preservation, isolated-success, and helper-not-executed assertions.
- Offline module verification, Linux cross-builds of the CLI and GitHub/CLI test binaries, `go vet -p=1 ./...`, module tidy verification, formatting, and whitespace checks passed.

Exact-head CI and review are complete. No production deployment or report refresh is claimed.

Diff classification against the parent commit: production **+222/-53, net +169**; tests **+664/-14, net +650**; docs/changelog **+41/-0**. Production growth provides the explicit renewable-credential capability and its shared dispatch/quota security boundary. The v6-only delta is test-only: **+13/-2**.

Named, unfixed follow-ups:

- **Bound portable archive process inspection:** Git-lock recovery and doctor process inspection call `lsof` without an owner-defined deadline or output cap. This PR controls their test fixtures, not those production paths. A separate repair must preserve fail-closed lock safety and bounded descendant cleanup.
- **Apple Git Xcode-scope compatibility:** strict portable refresh still rejects unknown configuration scopes. This PR isolates the synthetic test; it does not add production support for Apple's additional scope or weaken the allowlist.
