### PR TITLE
feat(sync): add selective PR metadata hydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.9.5 - Unreleased
 
+- Add `sync` and `refresh --with pr-metadata` to hydrate PR metadata without fetching unrelated child collections or claiming their coverage.
+
 - Add `--github-token-command` for managed, rotating GitHub credentials during long synchronizations on Unix. Requests and quota reservations use the current credential without changing static authentication or remote-store sessions.
 
 - Stop review-thread GraphQL pagination when GitHub returns an empty or repeated endCursor. Thanks @SebTardif.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -80,11 +80,25 @@ issue or pull request URLs.
 | Flag | What it adds |
 | --- | --- |
 | `--include-comments` | Issue comments, PR review comments, reviews |
-| `--include-pr-details` | PR files, commits, status checks, workflow runs |
+| `--with pr-metadata` | PR object, including merge attribution, head/base references, and diff counts |
+| `--include-pr-details` | PR object, files, commits, status checks, workflow runs, review threads |
 | `--with pr-details` | Same as `--include-pr-details` (gh-style flag) |
 | `--progress-file <absolute-path>` | Atomically publish sanitized machine-readable activity |
 
-PR details land in `pr_files`, `pr_commits`, `pr_checks`, and `pr_runs` tables for local review, search, clustering, and TUI workflows.
+`pr-metadata` writes only `pull_request_details`, using the normal per-thread
+observation ordering. It does not fetch, clear, or mark files, commits, checks,
+workflow runs, or review-thread resolution as fresh. Comments remain independent:
+add `--include-comments` when needed. Selecting both hydration modes uses full
+`pr-details` hydration. Metadata-only hydration does not create full PR revisions
+or fingerprints, and it resolves only earlier metadata-fetch failures.
+
+Full PR details also populate `pull_request_files`, `pull_request_commits`,
+`pull_request_checks`, and `github_workflow_runs` for local review and search.
+
+`fill-pr-details` selects PRs without a metadata row; it does not upgrade existing
+metadata-only rows. To upgrade them, use
+`gitcrawl sync owner/repo --numbers 123,456 --with pr-details`
+(and `--include-comments` for full revision evidence).
 
 Review-thread and nested-comment pagination fails if GitHub claims another page
 but returns an empty or previously followed `endCursor`. Sync reports a

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -380,7 +380,7 @@ func (a *App) runRefresh(ctx context.Context, args []string) error {
 	noCluster := fs.Bool("no-cluster", false, "skip clustering stage")
 	includeComments := fs.Bool("include-comments", false, "hydrate comments during sync")
 	includePRDetails := fs.Bool("include-pr-details", false, "hydrate PR files, commits, checks, workflow runs, and review threads")
-	withRaw := fs.String("with", "", "additional sync hydration: pr-details")
+	withRaw := fs.String("with", "", "additional sync hydration: pr-metadata, pr-details")
 	fs.Bool("include-code", false, "accepted for compatibility; code hydration is not implemented yet")
 	since := fs.String("since", "", "GitHub since timestamp")
 	state := fs.String("state", "", "GitHub issue state: open|closed|all; default open")
@@ -444,11 +444,12 @@ func (a *App) runRefresh(ctx context.Context, args []string) error {
 	if !*noSync {
 		fmt.Fprintln(a.Stderr, "[refresh] sync")
 		stats, target, err := a.syncRepository(ctx, owner, repoName, syncOptions{
-			Since:            strings.TrimSpace(*since),
-			State:            strings.TrimSpace(*state),
-			Limit:            limit,
-			IncludeComments:  *includeComments,
-			IncludePRDetails: *includePRDetails || with["pr-details"],
+			Since:             strings.TrimSpace(*since),
+			State:             strings.TrimSpace(*state),
+			Limit:             limit,
+			IncludeComments:   *includeComments,
+			IncludePRMetadata: with["pr-metadata"],
+			IncludePRDetails:  *includePRDetails || with["pr-details"],
 		})
 		if err != nil {
 			return err
@@ -2901,7 +2902,7 @@ func (a *App) runSync(ctx context.Context, args []string) error {
 	jsonOut := fs.Bool("json", false, "write JSON output")
 	includeComments := fs.Bool("include-comments", false, "hydrate issue comments, PR reviews, and PR review comments")
 	includePRDetails := fs.Bool("include-pr-details", false, "hydrate PR files, commits, checks, and workflow runs")
-	withRaw := fs.String("with", "", "extra hydration: pr-details")
+	withRaw := fs.String("with", "", "extra hydration: pr-metadata, pr-details")
 	progressFile := fs.String("progress-file", "", "write an atomic sanitized sync progress snapshot")
 	fs.Bool("include-code", false, "accepted for compatibility; code hydration is not implemented yet")
 	if err := fs.Parse(normalizeCommandArgs(args, map[string]bool{"numbers": true, "since": true, "state": true, "limit": true, "with": true, "progress-file": true})); err != nil {
@@ -2941,13 +2942,14 @@ func (a *App) runSync(ctx context.Context, args []string) error {
 	}
 
 	stats, target, err := a.syncRepository(ctx, owner, repo, syncOptions{
-		Since:            strings.TrimSpace(*since),
-		State:            strings.TrimSpace(*state),
-		Limit:            limit,
-		Numbers:          numbers,
-		IncludeComments:  *includeComments,
-		IncludePRDetails: *includePRDetails || with["pr-details"],
-		Progress:         progress.report,
+		Since:             strings.TrimSpace(*since),
+		State:             strings.TrimSpace(*state),
+		Limit:             limit,
+		Numbers:           numbers,
+		IncludeComments:   *includeComments,
+		IncludePRMetadata: with["pr-metadata"],
+		IncludePRDetails:  *includePRDetails || with["pr-details"],
+		Progress:          progress.report,
 	})
 	if err != nil {
 		if progressErr := progress.finish(syncProgressFailed); progressErr != nil {
@@ -2966,15 +2968,16 @@ func (a *App) runSync(ctx context.Context, args []string) error {
 }
 
 type syncOptions struct {
-	Since            string
-	State            string
-	Limit            int
-	Numbers          []int
-	IncludeComments  bool
-	IncludePRDetails bool
-	Quiet            bool
-	RateLimitReserve int
-	Progress         syncer.SyncProgressReporter
+	Since             string
+	State             string
+	Limit             int
+	Numbers           []int
+	IncludeComments   bool
+	IncludePRMetadata bool
+	IncludePRDetails  bool
+	Quiet             bool
+	RateLimitReserve  int
+	Progress          syncer.SyncProgressReporter
 }
 
 type fillPRDetailsResult struct {
@@ -3225,7 +3228,7 @@ func parseSyncWith(value string) (map[string]bool, error) {
 			continue
 		}
 		switch name {
-		case "pr-details":
+		case "pr-metadata", "pr-details":
 			out[name] = true
 		default:
 			return nil, fmt.Errorf("unsupported --with value %q", name)
@@ -3285,17 +3288,18 @@ func (a *App) syncRepository(ctx context.Context, owner, repo string, options sy
 	})
 	service := syncer.New(client, rt.Store)
 	stats, err := service.Sync(ctx, syncer.Options{
-		Owner:            owner,
-		Repo:             repo,
-		State:            strings.TrimSpace(options.State),
-		Since:            strings.TrimSpace(options.Since),
-		Limit:            options.Limit,
-		Numbers:          options.Numbers,
-		IncludeComments:  options.IncludeComments,
-		IncludePRDetails: options.IncludePRDetails,
-		Reporter:         reporter,
-		Logger:           logger,
-		Progress:         options.Progress,
+		Owner:             owner,
+		Repo:              repo,
+		State:             strings.TrimSpace(options.State),
+		Since:             strings.TrimSpace(options.Since),
+		Limit:             options.Limit,
+		Numbers:           options.Numbers,
+		IncludeComments:   options.IncludeComments,
+		IncludePRMetadata: options.IncludePRMetadata,
+		IncludePRDetails:  options.IncludePRDetails,
+		Reporter:          reporter,
+		Logger:            logger,
+		Progress:          options.Progress,
 	})
 	if err != nil {
 		return syncer.Stats{}, target, err
@@ -5432,7 +5436,10 @@ Usage:
 	"sync": `gitcrawl sync mirrors GitHub issue and pull request metadata.
 
 Usage:
-  gitcrawl sync owner/repo [--state open|closed|all] [--numbers refs] [--with pr-details] [--include-pr-details] [--json]
+  gitcrawl sync owner/repo [--state open|closed|all] [--numbers refs] [--with pr-metadata|pr-details] [--include-pr-details] [--json]
+
+pr-metadata fetches only the pull request object; pr-details also hydrates files,
+commits, checks, workflows, and review threads. Comments are selected separately.
 `,
 	"sync-failures": `gitcrawl sync-failures lists failed sync hydration attempts.
 
@@ -5459,7 +5466,7 @@ choose a different floor.
 	"refresh": `gitcrawl refresh runs sync, enrichment, embedding, and clustering.
 
 Usage:
-  gitcrawl refresh owner/repo [--state open|closed|all] [--with pr-details] [--include-pr-details] [--no-sync] [--no-embed] [--no-cluster] [--strict-vectors] [--json]
+  gitcrawl refresh owner/repo [--state open|closed|all] [--with pr-metadata|pr-details] [--include-pr-details] [--no-sync] [--no-embed] [--no-cluster] [--strict-vectors] [--json]
 `,
 	"summarize": `gitcrawl summarize generates key summaries for current thread revisions.
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -2675,8 +2675,8 @@ func TestControlRepositoryAndClusterHelperBranches(t *testing.T) {
 		t.Fatalf("short github remote repo = %q", got)
 	}
 
-	with, err := parseSyncWith(" pr-details, ")
-	if err != nil || !with["pr-details"] {
+	with, err := parseSyncWith(" pr-details, pr-metadata, ")
+	if err != nil || !with["pr-details"] || !with["pr-metadata"] {
 		t.Fatalf("parse sync with = %#v, %v", with, err)
 	}
 	if _, err := parseSyncWith("reviews"); err == nil {

--- a/internal/cli/pr_metadata_test.go
+++ b/internal/cli/pr_metadata_test.go
@@ -75,11 +75,16 @@ func TestPRMetadataSyncAndRefreshCommands(t *testing.T) {
 }
 
 func TestPRMetadataHelpDoesNotRequireAuthentication(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
 	for _, command := range []string{"sync", "refresh"} {
 		app := New()
+		app.githubAuthTokenLookup = func(context.Context) (string, error) {
+			t.Fatal("help requested GitHub credentials")
+			return "", nil
+		}
 		var stdout bytes.Buffer
 		app.Stdout = &stdout
-		if err := app.Run(context.Background(), []string{command, "--help"}); err != nil {
+		if err := app.Run(context.Background(), []string{"help", command}); err != nil {
 			t.Fatal(err)
 		}
 		if !strings.Contains(stdout.String(), "pr-metadata") {

--- a/internal/cli/pr_metadata_test.go
+++ b/internal/cli/pr_metadata_test.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/gitcrawl/internal/store"
+)
+
+func TestPRMetadataSyncAndRefreshCommands(t *testing.T) {
+	for _, command := range []string{"sync", "refresh"} {
+		t.Run(command, func(t *testing.T) {
+			ctx := context.Background()
+			dir := t.TempDir()
+			configPath, dbPath := filepath.Join(dir, "config.toml"), filepath.Join(dir, "gitcrawl.db")
+			if err := New().Run(ctx, []string{"--config", configPath, "init", "--db", dbPath}); err != nil {
+				t.Fatal(err)
+			}
+			pulls := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/repos/openclaw/gitcrawl":
+					_ = json.NewEncoder(w).Encode(map[string]any{"id": 123})
+				case "/repos/openclaw/gitcrawl/issues":
+					_ = json.NewEncoder(w).Encode([]map[string]any{
+						githubIssueJSON(1, "issue", "Issue"),
+						githubIssueJSON(2, "pull_request", "Pull request"),
+					})
+				case "/repos/openclaw/gitcrawl/pulls/2":
+					pulls++
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"number": 2, "merged_by": map[string]any{"login": "alice"}, "changed_files": 0,
+					})
+				default:
+					t.Errorf("unexpected hydration request: %s", r.URL.Path)
+					http.Error(w, "unexpected request", http.StatusBadRequest)
+				}
+			}))
+			defer server.Close()
+			t.Setenv("GITHUB_TOKEN", "test-gh-token")
+			t.Setenv("GITCRAWL_GITHUB_BASE_URL", server.URL)
+			app := New()
+			var stdout bytes.Buffer
+			app.Stdout = &stdout
+			args := []string{"--config", configPath, command, "openclaw/gitcrawl", "--with", "pr-metadata", "--json"}
+			if command == "refresh" {
+				args = append(args, "--no-embed", "--no-cluster")
+			}
+			if err := app.Run(ctx, args); err != nil {
+				t.Fatal(err)
+			}
+			if pulls != 1 || !strings.Contains(stdout.String(), `"pr_details_synced": 1`) {
+				t.Fatalf("pull requests=%d output=%s", pulls, stdout.String())
+			}
+			st, err := store.Open(ctx, dbPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer st.Close()
+			coverage, err := st.ArchiveCoverage(ctx, store.ArchiveCoverageOptions{})
+			if err != nil || len(coverage.Rows) != 1 {
+				t.Fatalf("coverage=%+v err=%v", coverage, err)
+			}
+			if coverage.Rows[0].Enrichment.PRFiles.Covered != 0 {
+				t.Fatal("zero-file metadata was reported as hydrated files")
+			}
+		})
+	}
+}
+
+func TestPRMetadataHelpDoesNotRequireAuthentication(t *testing.T) {
+	for _, command := range []string{"sync", "refresh"} {
+		app := New()
+		var stdout bytes.Buffer
+		app.Stdout = &stdout
+		if err := app.Run(context.Background(), []string{command, "--help"}); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(stdout.String(), "pr-metadata") {
+			t.Fatalf("%s help omits metadata hydration", command)
+		}
+	}
+}

--- a/internal/store/archive_coverage.go
+++ b/internal/store/archive_coverage.go
@@ -698,8 +698,13 @@ func (s *Store) archivePRFileCoverage(
 		left join thread_child_observation_reservations reservation
 			on reservation.thread_id = t.id
 				and reservation.family = 'pull_request_files'
+		left join thread_child_observation_reservations detail_reservation
+			on detail_reservation.thread_id = t.id
+				and detail_reservation.family = 'pull_request_details'
 		`
-		reservationPresent = "case when reservation.thread_id is null then 0 else 1 end"
+		// A details-only observation is not proof of an empty or complete file snapshot.
+		// Rows with neither reservation retain the legacy count/timestamp contract.
+		reservationPresent = "case when reservation.thread_id is not null then 1 when detail_reservation.thread_id is not null then -1 else 0 end"
 		reservationSourceUpdatedAt = "coalesce(reservation.source_updated_at, '')"
 		reservationObservationSequence = "coalesce(reservation.observation_sequence, 0)"
 	}
@@ -759,7 +764,7 @@ func (s *Store) archivePRFileCoverage(
 			return EnrichmentCoverageMetric{}, fmt.Errorf("scan archive PR file coverage: %w", err)
 		}
 		metric.Eligible++
-		if hasDetail == 0 || changedFiles < 0 || files != changedFiles {
+		if hasReservation < 0 || hasDetail == 0 || changedFiles < 0 || files != changedFiles {
 			continue
 		}
 		metric.Covered++

--- a/internal/store/archive_coverage_test.go
+++ b/internal/store/archive_coverage_test.go
@@ -436,6 +436,65 @@ func TestArchiveCoveragePRFilesUsesLegacySnapshotProof(t *testing.T) {
 	assertMetric(1, 0, false)
 }
 
+func TestArchiveCoveragePRFilesDistinguishesMetadataOnlyFromLegacy(t *testing.T) {
+	for _, mode := range []string{"legacy", "metadata", "full"} {
+		for _, files := range []int{0, 1} {
+			t.Run(fmt.Sprintf("%s/%d-files", mode, files), func(t *testing.T) {
+				ctx := context.Background()
+				st, err := Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer st.Close()
+				const observed = "2026-07-12T12:00:00Z"
+				repoID, err := st.UpsertRepository(ctx, Repository{
+					Owner: "openclaw", Name: "gitcrawl", FullName: "openclaw/gitcrawl", RawJSON: "{}", UpdatedAt: observed,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				thread := archiveCoverageThread(repoID, 1, "pull_request")
+				thread.UpdatedAtGitHub = observed
+				threadID, err := st.UpsertThread(ctx, thread)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var rows []PullRequestFile
+				if files > 0 {
+					rows = []PullRequestFile{{ThreadID: threadID, Path: "README.md", RawJSON: "{}", FetchedAt: observed}}
+				}
+				if err := st.UpsertPullRequestCache(ctx, PullRequestDetail{
+					ThreadID: threadID, RepoID: repoID, Number: 1, ChangedFiles: files, RawJSON: "{}", FetchedAt: observed, UpdatedAt: observed,
+				}, rows, nil, nil, nil); err != nil {
+					t.Fatal(err)
+				}
+				if mode != "legacy" {
+					if _, err := st.ReserveThreadChildObservation(ctx, threadID, ThreadChildPullRequestDetails, observed, 1); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if mode == "full" {
+					if _, err := st.ReserveThreadChildObservation(ctx, threadID, ThreadChildPullRequestFiles, observed, 1); err != nil {
+						t.Fatal(err)
+					}
+				}
+				coverage, err := st.ArchiveCoverage(ctx, ArchiveCoverageOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				metric := coverage.Rows[0].Enrichment.PRFiles
+				want := 1
+				if mode == "metadata" {
+					want = 0
+				}
+				if metric.Covered != want || metric.Fresh != want || metric.Complete != (want == 1) {
+					t.Fatalf("file coverage=%+v", metric)
+				}
+			})
+		}
+	}
+}
+
 func TestArchiveObservationFreshnessUsesSequenceForEqualSource(t *testing.T) {
 	const source = "2026-07-12T12:00:00Z"
 	if archiveObservationAtOrAfter(source, 10, source, 11) {

--- a/internal/store/sync_failures.go
+++ b/internal/store/sync_failures.go
@@ -83,9 +83,22 @@ where repo_id = ? and number = ? and operation = ? and error_class = ?
 	return id, nil
 }
 
-func (s *Store) ResolveSyncAttemptFailures(ctx context.Context, repoID int64, number int, resolvedAt string) (int, error) {
+func (s *Store) ResolveSyncAttemptFailures(ctx context.Context, repoID int64, number int, resolvedAt string, operations ...string) (int, error) {
 	if repoID == 0 || number <= 0 {
 		return 0, nil
+	}
+	operationFilter := ""
+	args := []any{resolvedAt, resolvedAt, repoID, number}
+	if len(operations) > 0 {
+		placeholders := make([]string, len(operations))
+		for i, operation := range operations {
+			if strings.TrimSpace(operation) == "" {
+				return 0, fmt.Errorf("resolve sync attempt failures: missing operation")
+			}
+			placeholders[i] = "?"
+			args = append(args, operation)
+		}
+		operationFilter = " and operation in (" + strings.Join(placeholders, ",") + ")"
 	}
 	result, err := s.q().ExecContext(ctx, `
 update sync_attempt_failures
@@ -93,7 +106,7 @@ set resolved_at = ?, last_seen_at = ?
 where repo_id = ?
   and number = ?
   and resolved_at is null
-`, resolvedAt, resolvedAt, repoID, number)
+`+operationFilter, args...)
 	if err != nil {
 		return 0, fmt.Errorf("resolve sync attempt failures: %w", err)
 	}

--- a/internal/store/sync_failures_test.go
+++ b/internal/store/sync_failures_test.go
@@ -95,6 +95,35 @@ func TestSyncAttemptFailureRetryAndResolve(t *testing.T) {
 	}
 }
 
+func TestSyncAttemptFailureResolutionScopesOperations(t *testing.T) {
+	ctx := context.Background()
+	st, repoID := seedPortableSyncFailure(t, ctx, "full hydration failed")
+	defer st.Close()
+	for _, operation := range []string{"pull_request_metadata", "pull_review_threads"} {
+		if _, err := st.RecordSyncAttemptFailure(ctx, SyncAttemptFailure{
+			RepoID: repoID, Number: 90, Operation: operation, LastSeenAt: "2026-07-16T00:00:00Z",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := st.ResolveSyncAttemptFailures(ctx, repoID, 90, "2026-07-16T00:01:00Z", ""); err == nil {
+		t.Fatal("empty operation must not resolve failures")
+	}
+	resolved, err := st.ResolveSyncAttemptFailures(ctx, repoID, 90, "2026-07-16T00:01:00Z", "pull_request_metadata")
+	if err != nil || resolved != 1 {
+		t.Fatalf("resolved=%d err=%v", resolved, err)
+	}
+	failures, err := st.ListSyncAttemptFailures(ctx, SyncAttemptFailureListOptions{RepoID: repoID})
+	if err != nil || len(failures) != 2 {
+		t.Fatalf("unrelated failures=%+v err=%v", failures, err)
+	}
+	for _, failure := range failures {
+		if failure.Operation == "pull_request_metadata" {
+			t.Fatal("metadata failure remains unresolved")
+		}
+	}
+}
+
 func TestListSyncAttemptFailuresTreatsPreLedgerReadOnlyStoreAsEmpty(t *testing.T) {
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "gitcrawl.db")

--- a/internal/syncer/pr_metadata_test.go
+++ b/internal/syncer/pr_metadata_test.go
@@ -1,0 +1,202 @@
+package syncer
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	gh "github.com/openclaw/gitcrawl/internal/github"
+	"github.com/openclaw/gitcrawl/internal/store"
+)
+
+type metadataGitHub struct {
+	interleavedPRDetailsGitHub
+	pullErr error
+}
+
+func (f *metadataGitHub) GetPull(ctx context.Context, owner, repo string, number int, reporter gh.Reporter) (map[string]any, error) {
+	if f.pullErr != nil {
+		return nil, f.pullErr
+	}
+	row, err := f.interleavedPRDetailsGitHub.GetPull(ctx, owner, repo, number, reporter)
+	row["merged_by"] = map[string]any{"login": "alice"}
+	return row, err
+}
+
+func (f *metadataGitHub) ListIssueComments(ctx context.Context, owner, repo string, number int, reporter gh.Reporter) ([]map[string]any, error) {
+	return pullCommentRows(1), nil
+}
+
+func TestSyncPRMetadataSelectsOnlyRequestedFamilies(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		comments bool
+		full     bool
+	}{
+		{name: "metadata"},
+		{name: "metadata with comments", comments: true},
+		{name: "full details wins", comments: true, full: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			st, err := store.Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer st.Close()
+			client := &metadataGitHub{}
+			stats, err := New(client, st).Sync(ctx, Options{
+				Owner: "openclaw", Repo: "gitcrawl", Numbers: []int{8},
+				IncludePRMetadata: true, IncludeComments: tc.comments, IncludePRDetails: tc.full,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if client.pullCalls != 1 || stats.PRDetailsSynced != 1 || stats.MetadataOnly {
+				t.Fatalf("metadata fetches=%d stats=%+v", client.pullCalls, stats)
+			}
+			wantChildren := 0
+			if tc.full {
+				wantChildren = 1
+			}
+			for _, count := range []int{client.fileCalls, client.commitCalls, client.checkCalls, client.runCalls, client.reviewCalls} {
+				if count != wantChildren {
+					t.Fatalf("child fetch count=%d, want %d", count, wantChildren)
+				}
+			}
+			if (stats.CommentsSynced > 0) != tc.comments || stats.RevisionsCreated != wantChildren || stats.FingerprintsUpserted != wantChildren {
+				t.Fatalf("comments/revision stats=%+v", stats)
+			}
+			repo, err := st.RepositoryByFullName(ctx, "openclaw/gitcrawl")
+			if err != nil {
+				t.Fatal(err)
+			}
+			cache, err := st.PullRequestCache(ctx, repo.ID, 8)
+			if err != nil || !strings.Contains(cache.Detail.RawJSON, `"merged_by":{"login":"alice"}`) {
+				t.Fatalf("stored metadata=%+v err=%v", cache.Detail, err)
+			}
+			reservations := 1 + 4*wantChildren
+			if tc.comments {
+				reservations++
+			}
+			assertTableRowCount(t, st, "thread_child_observation_reservations", reservations)
+			assertTableRowCount(t, st, "pull_request_review_thread_syncs", wantChildren)
+			assertTableRowCount(t, st, "github_workflow_runs", wantChildren)
+		})
+	}
+}
+
+func TestSyncPRMetadataPreservesFullHydration(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	client := &metadataGitHub{}
+	service := New(client, st)
+	options := Options{Owner: "openclaw", Repo: "gitcrawl", Numbers: []int{8}, IncludeComments: true, IncludePRDetails: true}
+	if _, err := service.Sync(ctx, options); err != nil {
+		t.Fatal(err)
+	}
+	repo, err := st.RepositoryByFullName(ctx, "openclaw/gitcrawl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := st.PullRequestCache(ctx, repo.ID, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reviews, err := st.PullRequestReviewThreads(ctx, before.Detail.ThreadID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runs, err := st.ListWorkflowRuns(ctx, repo.ID, store.WorkflowRunListOptions{Limit: -1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	options.IncludeComments, options.IncludePRDetails, options.IncludePRMetadata = false, false, true
+	stats, err := service.Sync(ctx, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := st.PullRequestCache(ctx, repo.ID, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterReviews, err := st.PullRequestReviewThreads(ctx, before.Detail.ThreadID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterRuns, err := st.ListWorkflowRuns(ctx, repo.ID, store.WorkflowRunListOptions{Limit: -1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Detail.RawJSON == before.Detail.RawJSON || stats.PRDetailsSynced != 1 {
+		t.Fatal("metadata was not refreshed")
+	}
+	if !reflect.DeepEqual(before.Files, after.Files) || !reflect.DeepEqual(before.Commits, after.Commits) ||
+		!reflect.DeepEqual(before.Checks, after.Checks) || !reflect.DeepEqual(reviews, afterReviews) || !reflect.DeepEqual(runs, afterRuns) {
+		t.Fatal("metadata refresh changed child hydration")
+	}
+	for _, family := range []store.ThreadChildObservationFamily{
+		store.ThreadChildComments, store.ThreadChildPullRequestFiles, store.ThreadChildPullRequestCommits,
+		store.ThreadChildPullRequestChecks, store.ThreadChildReviewThreads,
+	} {
+		assertChildReservation(t, ctx, st, before.Detail.ThreadID, family, 1)
+	}
+	if client.pullCalls != 2 || client.fileCalls != 1 || client.commitCalls != 1 || client.checkCalls != 1 || client.runCalls != 1 || client.reviewCalls != 1 {
+		t.Fatal("metadata refresh fetched unrelated families")
+	}
+	if stats.EvidenceObserved != 0 || stats.RevisionsCreated != 0 || stats.FingerprintsUpserted != 0 {
+		t.Fatalf("metadata refresh claimed full evidence: %+v", stats)
+	}
+	assertTableRowCount(t, st, "thread_revisions", 1)
+	assertTableRowCount(t, st, "thread_fingerprints", 1)
+}
+
+func TestSyncPRMetadataResolvesOnlyMetadataFailures(t *testing.T) {
+	ctx := context.Background()
+	st, err := store.Open(ctx, filepath.Join(t.TempDir(), "gitcrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	client := &metadataGitHub{pullErr: errors.New("metadata unavailable")}
+	service := New(client, st)
+	options := Options{Owner: "openclaw", Repo: "gitcrawl", Numbers: []int{8}, IncludePRMetadata: true}
+	if _, err := service.Sync(ctx, options); err == nil {
+		t.Fatal("metadata failure was accepted")
+	}
+	repo, err := st.RepositoryByFullName(ctx, "openclaw/gitcrawl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	failures, err := st.ListSyncAttemptFailures(ctx, store.SyncAttemptFailureListOptions{RepoID: repo.ID})
+	if err != nil || len(failures) != 1 || failures[0].Operation != "pull_request_metadata" {
+		t.Fatalf("metadata failure=%+v err=%v", failures, err)
+	}
+	for _, operation := range []string{"pull_request_details", "pull_review_threads"} {
+		if _, err := st.RecordSyncAttemptFailure(ctx, store.SyncAttemptFailure{
+			RepoID: repo.ID, Number: 8, Operation: operation, LastSeenAt: "2026-04-26T00:00:00Z",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	client.pullErr = nil
+	if _, err := service.Sync(ctx, options); err != nil {
+		t.Fatal(err)
+	}
+	failures, err = st.ListSyncAttemptFailures(ctx, store.SyncAttemptFailureListOptions{RepoID: repo.ID, IncludeResolved: true})
+	if err != nil || len(failures) != 3 {
+		t.Fatalf("failure history=%+v err=%v", failures, err)
+	}
+	for _, failure := range failures {
+		if (failure.ResolvedAt != "") != (failure.Operation == "pull_request_metadata") {
+			t.Fatalf("wrong failure resolved: %+v", failure)
+		}
+	}
+}

--- a/internal/syncer/pull_details.go
+++ b/internal/syncer/pull_details.go
@@ -46,12 +46,21 @@ type workflowRunLookupClient interface {
 	) (map[string]any, error)
 }
 
-func (s *Syncer) fetchPullRequestDetails(ctx context.Context, options Options, number int) (pullRequestDetailRows, error) {
+func (s *Syncer) fetchPullRequestMetadata(ctx context.Context, options Options, number int) (pullRequestDetailRows, error) {
 	fetchedAt := s.now().Format(time.RFC3339Nano)
 	pull, err := s.client.GetPull(ctx, options.Owner, options.Repo, number, options.Reporter)
 	if err != nil {
 		return pullRequestDetailRows{}, err
 	}
+	return pullRequestDetailRows{fetchedAt: fetchedAt, pull: pull}, nil
+}
+
+func (s *Syncer) fetchPullRequestDetails(ctx context.Context, options Options, number int) (pullRequestDetailRows, error) {
+	metadata, err := s.fetchPullRequestMetadata(ctx, options, number)
+	if err != nil {
+		return pullRequestDetailRows{}, err
+	}
+	pull := metadata.pull
 	filesRaw, err := s.client.ListPullFiles(ctx, options.Owner, options.Repo, number, options.Reporter)
 	if err != nil {
 		return pullRequestDetailRows{}, err
@@ -85,7 +94,7 @@ func (s *Syncer) fetchPullRequestDetails(ctx context.Context, options Options, n
 		return pullRequestDetailRows{}, err
 	}
 	return pullRequestDetailRows{
-		fetchedAt:               fetchedAt,
+		fetchedAt:               metadata.fetchedAt,
 		workflowSourceUpdatedAt: workflowSourceUpdatedAt,
 		workflowSnapshotFresh:   workflowSnapshotFresh,
 		workflowBaseline:        workflowBaseline,

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -41,17 +41,18 @@ type Syncer struct {
 }
 
 type Options struct {
-	Owner            string
-	Repo             string
-	State            string
-	Since            string
-	Limit            int
-	Numbers          []int
-	IncludeComments  bool
-	IncludePRDetails bool
-	Reporter         gh.Reporter
-	Logger           *slog.Logger
-	Progress         SyncProgressReporter
+	Owner             string
+	Repo              string
+	State             string
+	Since             string
+	Limit             int
+	Numbers           []int
+	IncludeComments   bool
+	IncludePRMetadata bool
+	IncludePRDetails  bool
+	Reporter          gh.Reporter
+	Logger            *slog.Logger
+	Progress          SyncProgressReporter
 }
 
 type Stats struct {
@@ -210,6 +211,16 @@ func (s *Syncer) Sync(ctx context.Context, options Options) (Stats, error) {
 			pullDetails.workflowObservationOrder = workflowObservationOrder
 			payload.pullDetails = pullDetails
 			payload.hasPullDetails = true
+		} else if options.IncludePRMetadata && kind == "pull_request" {
+			pullDetails, err := s.fetchPullRequestMetadata(ctx, options, number)
+			if err != nil {
+				if recordErr := s.recordPullRequestSyncFailure(ctx, options, repoRaw, row, "pull_request_metadata", err); recordErr != nil {
+					return Stats{}, fmt.Errorf("%w; additionally failed to record sync attempt failure: %v", err, recordErr)
+				}
+				return Stats{}, err
+			}
+			payload.pullDetails = pullDetails
+			payload.hasPullDetails = true
 		}
 		payloads = append(payloads, payload)
 		if err := reportSyncProgress(options.Progress, received); err != nil {
@@ -242,7 +253,7 @@ func (s *Syncer) Sync(ctx context.Context, options Options) (Stats, error) {
 		RequestedSince: since,
 		Limit:          options.Limit,
 		Numbers:        numbers,
-		MetadataOnly:   !options.IncludeComments && !options.IncludePRDetails,
+		MetadataOnly:   !options.IncludeComments && !options.IncludePRMetadata && !options.IncludePRDetails,
 		StartedAt:      started,
 	}
 	tracker := progress.New(options.Logger, progress.Options{
@@ -341,9 +352,13 @@ func (s *Syncer) Sync(ctx context.Context, options Options) (Stats, error) {
 					return err
 				}
 			}
+			if payload.hasPullDetails {
+				if err := reserveChild(store.ThreadChildPullRequestDetails); err != nil {
+					return err
+				}
+			}
 			if options.IncludePRDetails && thread.Kind == "pull_request" {
 				for _, family := range []store.ThreadChildObservationFamily{
-					store.ThreadChildPullRequestDetails,
 					store.ThreadChildPullRequestFiles,
 					store.ThreadChildPullRequestCommits,
 					store.ThreadChildPullRequestChecks,
@@ -382,7 +397,7 @@ func (s *Syncer) Sync(ctx context.Context, options Options) (Stats, error) {
 					return err
 				}
 			}
-			if options.IncludePRDetails && thread.Kind == "pull_request" {
+			if payload.hasPullDetails {
 				if childReservations[store.ThreadChildReviewThreads] {
 					count, err := s.persistPullReviewThreads(ctx, st, thread, payload.reviewThreads, payload.reviewThreadsFetchedAt)
 					if err != nil {
@@ -390,34 +405,39 @@ func (s *Syncer) Sync(ctx context.Context, options Options) (Stats, error) {
 					}
 					attempt.ReviewThreadsSynced += count
 				}
-				if payload.hasPullDetails {
-					detailStats, err := s.persistPullRequestDetails(
-						ctx,
-						st,
-						thread,
-						payload.pullDetails,
-						store.PullRequestHydrationFamilies{
-							Details:      childReservations[store.ThreadChildPullRequestDetails],
-							Files:        childReservations[store.ThreadChildPullRequestFiles],
-							Commits:      childReservations[store.ThreadChildPullRequestCommits],
-							Checks:       childReservations[store.ThreadChildPullRequestChecks],
-							WorkflowRuns: workflowRunsEligible,
-						},
-					)
-					if err != nil {
-						return err
-					}
-					if detailStats.details {
-						attempt.PRDetailsSynced++
-					}
-					if _, err := st.ResolveSyncAttemptFailures(ctx, repoID, thread.Number, s.now().Format(time.RFC3339Nano)); err != nil {
-						return err
-					}
-					attempt.PRFilesSynced += detailStats.files
-					attempt.PRCommitsSynced += detailStats.commits
-					attempt.PRChecksSynced += detailStats.checks
-					attempt.WorkflowRunsSynced += detailStats.runs
+				detailStats, err := s.persistPullRequestDetails(
+					ctx,
+					st,
+					thread,
+					payload.pullDetails,
+					store.PullRequestHydrationFamilies{
+						Details:      childReservations[store.ThreadChildPullRequestDetails],
+						Files:        childReservations[store.ThreadChildPullRequestFiles],
+						Commits:      childReservations[store.ThreadChildPullRequestCommits],
+						Checks:       childReservations[store.ThreadChildPullRequestChecks],
+						WorkflowRuns: workflowRunsEligible,
+					},
+				)
+				if err != nil {
+					return err
 				}
+				if detailStats.details {
+					attempt.PRDetailsSynced++
+				}
+				// Metadata cannot repair failures from child collections it did not fetch.
+				var operations []string
+				if !options.IncludePRDetails {
+					operations = []string{"pull_request_metadata"}
+				}
+				if options.IncludePRDetails || detailStats.details {
+					if _, err := st.ResolveSyncAttemptFailures(ctx, repoID, thread.Number, s.now().Format(time.RFC3339Nano), operations...); err != nil {
+						return err
+					}
+				}
+				attempt.PRFilesSynced += detailStats.files
+				attempt.PRCommitsSynced += detailStats.commits
+				attempt.PRChecksSynced += detailStats.checks
+				attempt.WorkflowRunsSynced += detailStats.runs
 			}
 			var pullFiles []store.PullRequestFile
 			var pullCommits []store.PullRequestCommit


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Users who need pull request metadata, such as merge attribution and head/base references, currently have to select full PR hydration, which also fetches files, commits, checks, workflow runs, and review threads.

## Why This Change Was Made

Add `--with pr-metadata` to `sync` and `refresh`, reusing the existing PR fetch, observation ordering, and family-specific persistence. The new mode writes the PR object without fetching, clearing, reserving, or claiming freshness for those child collections. Comments remain independently selected.

Metadata success resolves only metadata-fetch failures. Full hydration and review-thread failures remain unresolved. File coverage distinguishes a metadata-only reservation from a completed file snapshot, while preserving the legacy count/timestamp fallback when neither reservation exists.

No schema, dependency, authentication, service, or remote-store changes. This adds a hydration choice, not a promise of historical coverage: existing `--since`, state, and row-selection semantics remain unchanged.

## User Impact

- Use `gitcrawl sync owner/repo --with pr-metadata` for PR metadata without full child hydration; `refresh` accepts the same selector.
- Add `--include-comments` independently. Selecting `pr-details` as well still performs full hydration.
- Full PR revision and fingerprint requirements remain unchanged; metadata-only hydration does not claim complete revision evidence.
- `fill-pr-details` still selects PRs missing a metadata row. Upgrade metadata-only rows with `gitcrawl sync owner/repo --numbers 123,456 --with pr-details`, adding `--include-comments` when full revision evidence is required.

## Evidence

- Source head: `0e9b0a5c03d07cd5a196c1df21db2e7ec0c38261`, signed and based on `9dbbf4602bf107b210488cf24caafa36b6c68e7c`.
- Local `internal/store` package passed in 29.953s, including metadata-versus-file coverage and operation-scoped failure-resolution regressions.
- The first local `internal/syncer` build found an incorrect test-helper argument list, corrected before the first push. Hosted CI on `fc4450fc3659681e98b3fdd72a1b97a23e229a7d` then found that the new help test used `sync --help` instead of the established `help sync` entrypoint. This test-only successor corrects that invocation and explicitly rejects credential lookup. Exact-head hosted CI now passes; no local test rerun is claimed.
- Exact-head [CI on Ubuntu and macOS](https://github.com/openclaw/gitcrawl/actions/runs/34214893487), [Docker validation](https://github.com/openclaw/gitcrawl/actions/runs/34214893473), secret scanning, and CodeQL passed.
- Fresh committed-head P0/P1/P2 autoreview found no defects in one scanner-qualified pass covering all 12 changed files. [ClawSweeper's exact-head review](https://github.com/openclaw/gitcrawl/pull/173#issuecomment-5583592490) reported no findings or security findings, with no before-merge actions.
- Pinned Go 1.27.1 formatting checks and `git diff --check` passed.
- New tests cover metadata-only requests, independent comments, full-hydration precedence, preservation of existing child data and reservations, failure-ledger isolation, CLI selectors/help, and legacy file coverage.
- Production: +136/-82, net +54 lines. Tests: +386/-2, net +384. Docs: +18/-2, net +16. Production growth adds the selector, reuses the canonical metadata fetch/write path, and keeps failure resolution and coverage scoped to the observed families.
- Exact-head hosted CI and independent review are complete. No new live GitHub synchronization or producer deployment is claimed.
