### PR TITLE
chore: update CrawlKit to v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.9.5 - Unreleased
 
+- Update CrawlKit to v0.15.0 while retaining the existing Go 1.27.1 source-build minimum.
 - Reconcile observed closures during default sync, retaining successful sweep coverage across offline periods without retiring omitted threads.
 - Fill bounded embedding runs from older eligible threads when newer vectors are already current.
 - Exclude raw comment and review-thread revision payloads and sync failure diagnostics from cloud SQLite snapshots while preserving canonical bodies, history rows, and PR patches without changing the source archive.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Homebrew is the smallest install on macOS and Linux:
 brew install openclaw/tap/gitcrawl
 ```
 
-Prebuilt archives for macOS, Linux, and Windows are available from [GitHub Releases](https://github.com/openclaw/gitcrawl/releases/latest). The [installation guide](docs/installation.md) also covers source builds and update checks; source builds require Go 1.27.1 or newer for CrawlKit v0.14.8. Binaries built with this toolchain require macOS 13 Ventura or newer. A [Docker source build](docs/docker.md) keeps its runtime state under one mounted directory.
+Prebuilt archives for macOS, Linux, and Windows are available from [GitHub Releases](https://github.com/openclaw/gitcrawl/releases/latest). The [installation guide](docs/installation.md) also covers source builds and update checks; source builds require Go 1.27.1 or newer for CrawlKit v0.15.0. Binaries built with this toolchain require macOS 13 Ventura or newer. A [Docker source build](docs/docker.md) keeps its runtime state under one mounted directory.
 
 Sync needs a GitHub token from `GITHUB_TOKEN` or `gh auth token`. Generating summaries and embeddings also needs `OPENAI_API_KEY`; semantic search and clustering use those stored embeddings, while ordinary sync and keyword search do not.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ permalink: /installation/
 
 gitcrawl runs on macOS 13 Ventura or newer and Linux. Windows is not actively tested.
 
-CrawlKit v0.14.8 requires Go 1.27, so source and Docker builds use Go 1.27.1
+CrawlKit v0.15.0 requires Go 1.27, so source and Docker builds use Go 1.27.1
 or newer. Go 1.27 also raises the minimum macOS version for newly built binaries
 to macOS 13; the previous Go 1.26 build baseline no longer applies.
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/mattn/go-isatty v0.0.24
-	github.com/openclaw/crawlkit v0.14.8
+	github.com/openclaw/crawlkit v0.15.0
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/sys v0.47.0
 	modernc.org/sqlite v1.58.0

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.14.8 h1:JdmvIcfznzGGDNczACtktebd0ueLWaTrCwW8ZPtm7Fg=
-github.com/openclaw/crawlkit v0.14.8/go.mod h1:7QxbJgGm6ZQAiBXyWSR+U6Eyt8p4pMcC7zjY0h3GKjY=
+github.com/openclaw/crawlkit v0.15.0 h1:KAmdew2UQPZm/gOfqiLw/WhhDY7Y2UZj0EcgQ5s7dl4=
+github.com/openclaw/crawlkit v0.15.0/go.mod h1:JhEsXnoxozd2qp1p4Dw8ZhKzQoYm3WbrlvO0ILVx8cs=
 github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
 github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=


### PR DESCRIPTION
## What Problem This Solves

Gitcrawl still selects an older CrawlKit release, leaving the shared archive
and snapshot fixes in the published v0.15.0 release unused.

## Why This Change Was Made

Use the published module and public checksums from
[https://github.com/openclaw/crawlkit/releases/tag/v0.15.0](https://github.com/openclaw/crawlkit/releases/tag/v0.15.0).
Update both installation references and the changelog. Keep Go 1.27.1,
SQLite v1.58.0, libc v1.75.6, container settings and application source unchanged.

The selected graph also moves the transitive `golang.org/x/crypto` requirement
from v0.55.0 to v0.56.0 because CrawlKit requires it. No other selected
dependency changes, local replacement, unpublished API or broad dependency
upgrade is included.

## User Impact

New builds consume the shared fixes without changing command syntax, the
archive schema or the existing source-build minimum. This PR does not publish
an application release or migrate existing data.

CrawlKit intentionally tightens credential transport, including token login
and polling: credential-bearing requests require HTTPS (loopback HTTP remains
allowed), and redirects must retain the original scheme, host and effective
port. Configure the final HTTPS service endpoint instead of relying on a
cross-origin redirect. This compatibility change is inherited from the
published security fix; no live fresh or existing deployment was contacted
or certified by this PR's validation.

## Evidence

- Actual published module graph and sums verified; no `replace`.
- Go 1.27.1 Linux/amd64: tidy-no-diff, module verification, build and vet pass.
- Complete affected `internal/store`, `internal/syncer` and `internal/cli`
  package tests pass with synthetic data and provider access disabled.
- Built binary: `--help`, `--version`, `metadata --json`, `status --json`
  and `tui --json` pass in temporary homes; JSON identity and empty state
  checked, with no persistent files created.
- govulncheck v1.7.0 against a freshly verified public advisory snapshot:
  complete Config/SBOM/JSON evaluation reports zero called, imported or
  module findings for Linux/amd64, CGO enabled, Go 1.27.1 and default tags.
- Scoped independent review and public-diff privacy review pass.
- Final-head hosted CI passes on Linux/amd64 and macOS/arm64 with Go 1.27.1:
  full suites and 85.7% coverage on both. The current workflow does not run
  `-race`; no final-head race result is claimed.
  [https://github.com/openclaw/gitcrawl/actions/runs/34292669500](https://github.com/openclaw/gitcrawl/actions/runs/34292669500)

Draft pending normal maintainer review, including acceptance of the endpoint
compatibility restriction above. Hosted macOS tests do not certify live
remote configurations or unrelated native integrations. No merge, release,
deployment or policy change is included.
