### PR TITLE
chore: prepare v0.9.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.9.5 - Unreleased
+## 0.9.5 - 2026-09-09
 
 - Update CrawlKit to v0.15.0 while retaining the existing Go 1.27.1 source-build minimum.
 - Reconcile observed closures during default sync, retaining successful sweep coverage across offline periods without retiring omitted threads.


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This branch is in the base repository; repository maintainers can update it directly.

</details>

## What Problem This Solves

Prepares the existing Gitcrawl v0.9.5 release notes so the unified release workflow can publish the already-merged fixes.

## Why This Change Was Made

Dates the existing `0.9.5` changelog section as September 9, 2026. This is a one-line changelog-only change; application code, dependencies, release workflows, and stored data are unchanged.

The release will use only the existing `release-unified.yml` pipeline after review, exact-candidate CI, and a separate source-audit confirmation. This PR does not itself publish a release.

## User Impact

No behavior changes in this PR. The planned release delivers the already-merged cloud snapshot sanitization, CrawlKit v0.15.0 update, and other existing v0.9.5 notes. It does not backfill or repair any store.

## Evidence

- `git diff --check` passed.
- `./scripts/test-release.sh` passed using synthetic signing/notarization fixtures.
- Changelog assertions passed: the first release heading is exactly `0.9.5 - 2026-09-09`, the version occurs once, and existing fix notes remain intact.
- Structured autoreview completed with no findings.
- Unchanged application source at base `1a8b3f7b90a13f84beb8cee448a6ff62419ba3c9` passed [main CI](https://github.com/openclaw/gitcrawl/actions/runs/34294266547), including Linux/macOS tests and snapshot builds. Candidate CI is still required before merge.
- GoReleaser is not installed locally; no successful local snapshot build or full application test-suite rerun is claimed.
- At preparation, no `v0.9.5` tag, draft release, competing release PR, or active release workflow existed. These checks will be repeated immediately before any dispatch.
