### PR TITLE
fix(portable): stage initial clones before publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,3 +95,19 @@ jobs:
           distribution: goreleaser
           version: "~> v2"
           args: release --snapshot --clean --skip=publish
+
+  portable-windows:
+    name: Portable filesystem / windows
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+      - name: Test exclusive publication and long paths
+        run: go test ./internal/cli -run '^TestPortableExclusiveRename' -count=1
+      - name: Build and smoke test CLI
+        run: |
+          go build -o gitcrawl.exe ./cmd/gitcrawl
+          ./gitcrawl.exe --version

--- a/docs/portable-stores.md
+++ b/docs/portable-stores.md
@@ -59,6 +59,14 @@ Initialization validates portable arguments before invoking Git and validates
 the artifact before saving configuration. Repeated initialization and a
 publisher's raw-to-gzip transition do not require a raw `.db` in the checkout.
 Use `init` for setup; it still regenerates configuration on success.
+Initial clones are staged privately and published only after Git
+finishes successfully. A failed clone leaves an absent or empty destination
+unchanged, so retrying `init` does not reuse an incomplete Git checkout.
+Pre-created empty directories stay in place with their permissions and ACLs;
+publication refuses to replace concurrently created entries. If publication
+fails after moving files, recovery material is preserved at the reported path.
+Platforms or filesystems without native exclusive renames retain the legacy
+clone behavior; support is probed before transferring data.
 If a dirty merge triggers legacy reset recovery and that reset fails, `init`
 reports the reset failure with the same credential-safe Git diagnostics used
 elsewhere, so the error identifies the recovery step that needs attention.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -3807,13 +3807,7 @@ func syncPortableStore(ctx context.Context, remoteURL, dir string) (string, erro
 	if err := os.MkdirAll(filepath.Dir(dir), 0o755); err != nil {
 		return "", fmt.Errorf("create portable store parent: %w", err)
 	}
-	if err := runGit(ctx, "", "clone", "--depth", "1", "--", remoteURL, dir); err != nil {
-		return "", err
-	}
-	if err := markPortableStoreCheckout(dir); err != nil {
-		return "", err
-	}
-	if err := removePortableSQLiteSidecars(dir); err != nil {
+	if err := clonePortableStore(ctx, remoteURL, dir); err != nil {
 		return "", err
 	}
 	return "cloned", nil

--- a/internal/cli/portable_clone.go
+++ b/internal/cli/portable_clone.go
@@ -1,0 +1,127 @@
+//go:build darwin || linux || windows
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Stage clones so a failed Git transfer cannot leave an unusable .git at the
+// destination, where the next init would mistake it for an existing checkout.
+func clonePortableStore(ctx context.Context, remoteURL, dir string) error {
+	return clonePortableStoreWithRename(ctx, remoteURL, dir, renamePortableExclusive)
+}
+
+var errPortableExclusiveUnavailable = errors.New("exclusive rename unavailable")
+
+func clonePortableStoreWithRename(ctx context.Context, remoteURL, dir string, rename func(string, string) error) (resultErr error) {
+	parent := filepath.Dir(dir)
+	existing := false
+	if entries, err := os.ReadDir(dir); err == nil {
+		if len(entries) != 0 {
+			return fmt.Errorf("portable clone destination is no longer empty")
+		}
+		// Keep pre-created directories in place, including their permissions,
+		// ACLs and ability to work beneath a non-writable parent.
+		parent, existing = dir, true
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read portable clone destination: %w", err)
+	}
+	staging, err := os.MkdirTemp(parent, "."+filepath.Base(dir)+".clone-")
+	if err != nil {
+		return fmt.Errorf("create portable clone staging directory: %w", err)
+	}
+	preserve := false
+	owned := true
+	defer func() {
+		if !owned {
+			return
+		}
+		if preserve {
+			resultErr = errors.Join(resultErr, fmt.Errorf("incomplete portable publication preserved at %s", staging))
+			return
+		}
+		if err := os.RemoveAll(staging); err != nil {
+			resultErr = errors.Join(resultErr, fmt.Errorf("remove portable clone staging directory: %w", err))
+		}
+	}()
+	probeSource, probeTarget := filepath.Join(staging, "probe-source"), filepath.Join(staging, "probe-target")
+	for _, path := range []string{probeSource, probeTarget} {
+		if err := os.Mkdir(path, 0o700); err != nil {
+			return err
+		}
+	}
+	probeErr := rename(probeSource, probeTarget)
+	if errors.Is(probeErr, os.ErrExist) {
+		if err := os.Remove(probeTarget); err != nil {
+			return err
+		}
+		// Linux may reject an existing destination before consulting the
+		// filesystem. Also prove that an absent destination can be published.
+		probeErr = rename(probeSource, probeTarget)
+	} else if probeErr == nil {
+		probeErr = errPortableExclusiveUnavailable
+	}
+	if errors.Is(probeErr, errPortableExclusiveUnavailable) {
+		// Probe before transferring data. A pre-existing empty destination must
+		// be empty again before Git's compatibility path can use it.
+		if err := os.RemoveAll(staging); err != nil {
+			return err
+		}
+		owned = false
+		return clonePortableStoreLegacy(ctx, remoteURL, dir)
+	} else if probeErr != nil {
+		return fmt.Errorf("probe exclusive portable publication: %w", probeErr)
+	}
+	checkout := filepath.Join(staging, "checkout")
+	if err := runGit(ctx, "", "clone", "--depth", "1", "--", remoteURL, checkout); err != nil {
+		return err
+	}
+	if err := markPortableStoreCheckout(checkout); err != nil {
+		return err
+	}
+	if err := removePortableSQLiteSidecars(checkout); err != nil {
+		return err
+	}
+	if !existing {
+		return rename(checkout, dir)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	if len(entries) != 1 || entries[0].Name() != filepath.Base(staging) {
+		return fmt.Errorf("portable clone destination changed during cloning")
+	}
+	entries, err = os.ReadDir(checkout)
+	if err != nil {
+		return err
+	}
+	var names []string
+	for _, entry := range entries {
+		if entry.Name() != ".git" {
+			names = append(names, entry.Name())
+		}
+	}
+	// Publish Git metadata last; failed transfers never become checkouts.
+	names = append(names, ".git")
+	var moved []string
+	for _, name := range names {
+		if err := rename(filepath.Join(checkout, name), filepath.Join(dir, name)); err != nil {
+			resultErr = fmt.Errorf("publish portable clone: %w", err)
+			preserve = len(moved) > 0
+			for _, previous := range moved {
+				if err := rename(filepath.Join(dir, previous), filepath.Join(checkout, previous)); err != nil {
+					resultErr = errors.Join(resultErr, fmt.Errorf("roll back portable publication: %w", err))
+				}
+			}
+			return resultErr
+		}
+		moved = append(moved, name)
+	}
+	return nil
+}

--- a/internal/cli/portable_clone.go
+++ b/internal/cli/portable_clone.go
@@ -31,7 +31,7 @@ func clonePortableStoreWithRename(ctx context.Context, remoteURL, dir string, re
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("read portable clone destination: %w", err)
 	}
-	staging, err := os.MkdirTemp(parent, "."+filepath.Base(dir)+".clone-")
+	staging, err := os.MkdirTemp(parent, ".gitcrawl-clone-")
 	if err != nil {
 		return fmt.Errorf("create portable clone staging directory: %w", err)
 	}

--- a/internal/cli/portable_clone_legacy.go
+++ b/internal/cli/portable_clone_legacy.go
@@ -1,0 +1,15 @@
+package cli
+
+import "context"
+
+// Retain the existing clone contract on platforms and filesystems without
+// exclusive publication, rather than introducing a new installation minimum.
+func clonePortableStoreLegacy(ctx context.Context, remoteURL, dir string) error {
+	if err := runGit(ctx, "", "clone", "--depth", "1", "--", remoteURL, dir); err != nil {
+		return err
+	}
+	if err := markPortableStoreCheckout(dir); err != nil {
+		return err
+	}
+	return removePortableSQLiteSidecars(dir)
+}

--- a/internal/cli/portable_clone_other.go
+++ b/internal/cli/portable_clone_other.go
@@ -1,0 +1,11 @@
+//go:build !darwin && !linux && !windows
+
+package cli
+
+import "context"
+
+// Preserve the existing source-build contract on other operating systems;
+// the published platforms use their exclusive directory rename primitives.
+func clonePortableStore(ctx context.Context, remoteURL, dir string) error {
+	return clonePortableStoreLegacy(ctx, remoteURL, dir)
+}

--- a/internal/cli/portable_clone_test.go
+++ b/internal/cli/portable_clone_test.go
@@ -1,0 +1,58 @@
+//go:build darwin || linux || windows
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPortableExclusiveRenamePreservesExistingDestination(t *testing.T) {
+	for _, directory := range []bool{false, true} {
+		t.Run(map[bool]string{false: "file", true: "directory"}[directory], func(t *testing.T) {
+			root := t.TempDir()
+			from, to := filepath.Join(root, "source"), filepath.Join(root, "destination")
+			if directory {
+				if err := os.Mkdir(from, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Mkdir(to, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				if err := os.WriteFile(from, []byte("new"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(to, []byte("keep"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			before, err := os.Stat(to)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := renamePortableExclusive(from, to); err == nil {
+				t.Fatal("exclusive rename replaced an existing destination")
+			}
+			after, err := os.Stat(to)
+			if err != nil || !os.SameFile(before, after) {
+				t.Fatalf("destination changed: %v", err)
+			}
+			if err := os.Remove(to); err != nil {
+				t.Fatal(err)
+			}
+			if err := renamePortableExclusive(from, to); errors.Is(err, errPortableExclusiveUnavailable) {
+				if _, err := os.Stat(from); err != nil {
+					t.Fatalf("unsupported rename changed its source: %v", err)
+				}
+				if _, err := os.Lstat(to); !os.IsNotExist(err) {
+					t.Fatalf("unsupported rename changed its destination: %v", err)
+				}
+			} else if err != nil {
+				t.Fatalf("rename to absent destination: %v", err)
+			}
+		})
+	}
+}

--- a/internal/cli/portable_clone_test.go
+++ b/internal/cli/portable_clone_test.go
@@ -3,11 +3,27 @@
 package cli
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+func TestPortableExclusiveRenameInitialClone(t *testing.T) {
+	fixture := newPortableRefreshFixture(t, false)
+	var result struct {
+		Threads []struct {
+			Number int `json:"number"`
+		} `json:"threads"`
+	}
+	if err := json.Unmarshal(fixture.command(t, "threads", "openclaw/openclaw", "--json"), &result); err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Threads) != 1 || result.Threads[0].Number != 1 {
+		t.Fatalf("cloned archive is not readable: %+v", result)
+	}
+}
 
 func TestPortableExclusiveRenamePreservesExistingDestination(t *testing.T) {
 	for _, directory := range []bool{false, true} {

--- a/internal/cli/portable_clone_unix_test.go
+++ b/internal/cli/portable_clone_unix_test.go
@@ -1,0 +1,209 @@
+//go:build darwin || linux
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSyncPortableStoreFailedCloneCanRetry(t *testing.T) {
+	for _, existing := range []bool{false, true} {
+		t.Run(fmt.Sprintf("existing-empty-directory=%t", existing), func(t *testing.T) {
+			fixture := newPortableRefreshFixture(t, false)
+			target := filepath.Join(t.TempDir(), "checkout")
+			var original os.FileInfo
+			if existing {
+				if err := os.Mkdir(target, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chmod(target, 0o750); err != nil {
+					t.Fatal(err)
+				}
+				var err error
+				original, err = os.Stat(target)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			checkOriginal := func() {
+				t.Helper()
+				if original != nil {
+					current, err := os.Stat(target)
+					if err != nil || !os.SameFile(original, current) || current.Mode() != original.Mode() {
+						t.Fatalf("original destination metadata changed: %v %v", current, err)
+					}
+				}
+			}
+			realGit, err := exec.LookPath("git")
+			if err != nil {
+				t.Fatal(err)
+			}
+			wrapper := filepath.Join(t.TempDir(), "git")
+			script := `#!/bin/sh
+clone=false
+for arg in "$@"; do
+  if [ "$arg" = clone ]; then clone=true; fi
+  target="$arg"
+done
+if "$clone"; then
+  "$GITCRAWL_TEST_REAL_GIT" init -b main "$target" >/dev/null || exit $?
+  "$GITCRAWL_TEST_REAL_GIT" -C "$target" remote add origin "$GITCRAWL_TEST_REMOTE" || exit $?
+  printf partial > "$target/.git/index"
+  printf preserve > "$target/concurrent-file"
+  echo 'synthetic-private-path: No space left on device' >&2
+  exit 79
+fi
+exec "$GITCRAWL_TEST_REAL_GIT" "$@"
+`
+			if err := os.WriteFile(wrapper, []byte(script), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("GITCRAWL_TEST_REAL_GIT", realGit)
+			t.Setenv("GITCRAWL_TEST_REMOTE", fixture.remote)
+			t.Setenv("GITCRAWL_PORTABLE_GIT", wrapper)
+			_, err = syncPortableStore(context.Background(), fixture.remote, target)
+			var exit *exec.ExitError
+			if !errors.As(err, &exit) || exit.ExitCode() != 79 || !strings.Contains(err.Error(), "insufficient disk space for Git") {
+				t.Fatalf("expected original clone failure, got %v", err)
+			}
+			entries, err := os.ReadDir(target)
+			if existing && (err != nil || len(entries) != 0) || !existing && !os.IsNotExist(err) {
+				t.Fatalf("failed clone changed destination: entries=%v err=%v", entries, err)
+			}
+			checkOriginal()
+			stagingParent := filepath.Dir(target)
+			if existing {
+				stagingParent = target
+			}
+			staging, err := filepath.Glob(filepath.Join(stagingParent, ".checkout.clone-*"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(staging) != 0 {
+				t.Fatalf("failed clone left owned staging directories: %v", staging)
+			}
+			t.Setenv("GITCRAWL_PORTABLE_GIT", realGit)
+			if action, err := syncPortableStore(context.Background(), fixture.remote, target); err != nil || action != "cloned" {
+				t.Fatalf("retry: action=%q err=%v", action, err)
+			}
+			checkOriginal()
+			if err := sqliteStoreHealth(context.Background(), filepath.Join(target, fixture.relative)); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestPortableCloneRetainsLegacyFilesystemSupport(t *testing.T) {
+	for _, tc := range []struct{ existing, absentOnly bool }{{}, {existing: true}, {absentOnly: true}, {existing: true, absentOnly: true}} {
+		t.Run(fmt.Sprintf("existing=%t/absent-only=%t", tc.existing, tc.absentOnly), func(t *testing.T) {
+			fixture := newPortableRefreshFixture(t, false)
+			target := filepath.Join(t.TempDir(), "checkout")
+			if tc.existing {
+				if err := os.Mkdir(target, 0o750); err != nil {
+					t.Fatal(err)
+				}
+			}
+			ctx, release, err := acquirePortableOwner(context.Background(), target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer release()
+			calls := 0
+			unsupported := func(string, string) error {
+				calls++
+				if tc.absentOnly && calls == 1 {
+					return os.ErrExist
+				}
+				return errPortableExclusiveUnavailable
+			}
+			if err := clonePortableStoreWithRename(ctx, fixture.remote, target, unsupported); err != nil {
+				t.Fatal(err)
+			}
+			wantCalls := 1
+			if tc.absentOnly {
+				wantCalls = 2
+			}
+			if calls != wantCalls {
+				t.Fatalf("unsupported rename invoked %d times", calls)
+			}
+			if err := sqliteStoreHealth(ctx, filepath.Join(target, fixture.relative)); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestSyncPortableStorePreservesWritableDestinationUnderReadOnlyParent(t *testing.T) {
+	fixture := newPortableRefreshFixture(t, false)
+	parent := t.TempDir()
+	target := filepath.Join(parent, "checkout")
+	if err := os.Mkdir(target, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parent, ".checkout.gitcrawl.lock"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	original, err := os.Stat(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(parent, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+	if action, err := syncPortableStore(context.Background(), fixture.remote, target); err != nil || action != "cloned" {
+		t.Fatalf("clone beneath read-only parent: %q %v", action, err)
+	}
+	current, err := os.Stat(target)
+	if err != nil || !os.SameFile(original, current) || original.Mode() != current.Mode() {
+		t.Fatalf("original destination changed: %v", err)
+	}
+}
+
+func TestSyncPortableStorePreservesConcurrentFile(t *testing.T) {
+	fixture := newPortableRefreshFixture(t, false)
+	target := filepath.Join(t.TempDir(), "checkout")
+	if err := os.Mkdir(target, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrapper := filepath.Join(t.TempDir(), "git")
+	script := `#!/bin/sh
+clone=false
+for arg in "$@"; do
+  if [ "$arg" = clone ]; then clone=true; fi
+done
+"$GITCRAWL_TEST_REAL_GIT" "$@" || exit $?
+if "$clone"; then
+  printf preserve > "$GITCRAWL_TEST_DESTINATION/concurrent-file"
+fi
+`
+	if err := os.WriteFile(wrapper, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GITCRAWL_TEST_REAL_GIT", realGit)
+	t.Setenv("GITCRAWL_TEST_DESTINATION", target)
+	t.Setenv("GITCRAWL_PORTABLE_GIT", wrapper)
+	if _, err := syncPortableStore(context.Background(), fixture.remote, target); err == nil || !strings.Contains(err.Error(), "destination changed") {
+		t.Fatalf("expected concurrent destination refusal, got %v", err)
+	}
+	entries, err := os.ReadDir(target)
+	if err != nil || len(entries) != 1 || entries[0].Name() != "concurrent-file" {
+		t.Fatalf("unexpected destination contents: %v %v", entries, err)
+	}
+	content, err := os.ReadFile(filepath.Join(target, "concurrent-file"))
+	if err != nil || string(content) != "preserve" {
+		t.Fatalf("concurrent file lost: %q %v", content, err)
+	}
+}

--- a/internal/cli/portable_clone_unix_test.go
+++ b/internal/cli/portable_clone_unix_test.go
@@ -82,7 +82,7 @@ exec "$GITCRAWL_TEST_REAL_GIT" "$@"
 			if existing {
 				stagingParent = target
 			}
-			staging, err := filepath.Glob(filepath.Join(stagingParent, ".checkout.clone-*"))
+			staging, err := filepath.Glob(filepath.Join(stagingParent, ".gitcrawl-clone-*"))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -94,6 +94,26 @@ exec "$GITCRAWL_TEST_REAL_GIT" "$@"
 				t.Fatalf("retry: action=%q err=%v", action, err)
 			}
 			checkOriginal()
+			if err := sqliteStoreHealth(context.Background(), filepath.Join(target, fixture.relative)); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestSyncPortableStoreLongDestinationName(t *testing.T) {
+	for _, existing := range []bool{false, true} {
+		t.Run(fmt.Sprintf("existing=%t", existing), func(t *testing.T) {
+			fixture := newPortableRefreshFixture(t, false)
+			target := filepath.Join(t.TempDir(), strings.Repeat("x", 240))
+			if existing {
+				if err := os.Mkdir(target, 0o750); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if action, err := syncPortableStore(context.Background(), fixture.remote, target); err != nil || action != "cloned" {
+				t.Fatalf("clone into long directory name: %q %v", action, err)
+			}
 			if err := sqliteStoreHealth(context.Background(), filepath.Join(target, fixture.relative)); err != nil {
 				t.Fatal(err)
 			}

--- a/internal/cli/portable_rename_darwin.go
+++ b/internal/cli/portable_rename_darwin.go
@@ -1,0 +1,14 @@
+package cli
+
+import (
+	"fmt"
+	"golang.org/x/sys/unix"
+)
+
+func renamePortableExclusive(from, to string) error {
+	err := unix.RenameatxNp(unix.AT_FDCWD, from, unix.AT_FDCWD, to, unix.RENAME_EXCL)
+	if err == unix.ENOSYS || err == unix.EINVAL || err == unix.ENOTSUP {
+		return fmt.Errorf("%w: %w", errPortableExclusiveUnavailable, err)
+	}
+	return err
+}

--- a/internal/cli/portable_rename_linux.go
+++ b/internal/cli/portable_rename_linux.go
@@ -1,0 +1,14 @@
+package cli
+
+import (
+	"fmt"
+	"golang.org/x/sys/unix"
+)
+
+func renamePortableExclusive(from, to string) error {
+	err := unix.Renameat2(unix.AT_FDCWD, from, unix.AT_FDCWD, to, unix.RENAME_NOREPLACE)
+	if err == unix.ENOSYS || err == unix.EINVAL || err == unix.EOPNOTSUPP {
+		return fmt.Errorf("%w: %w", errPortableExclusiveUnavailable, err)
+	}
+	return err
+}

--- a/internal/cli/portable_rename_windows.go
+++ b/internal/cli/portable_rename_windows.go
@@ -1,8 +1,21 @@
 package cli
 
-import "golang.org/x/sys/windows"
+import (
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
 
 func renamePortableExclusive(from, to string) error {
+	from, err := portableWindowsExtendedPath(from)
+	if err != nil {
+		return err
+	}
+	to, err = portableWindowsExtendedPath(to)
+	if err != nil {
+		return err
+	}
 	source, err := windows.UTF16PtrFromString(from)
 	if err != nil {
 		return err
@@ -12,4 +25,22 @@ func renamePortableExclusive(from, to string) error {
 		return err
 	}
 	return windows.MoveFile(source, destination)
+}
+
+func portableWindowsExtendedPath(path string) (string, error) {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	// Match Go's threshold without changing short-path Win32 normalization.
+	if len(path) < 248 {
+		return path, nil
+	}
+	if strings.HasPrefix(path, `\\?\`) || strings.HasPrefix(path, `\\.\`) {
+		return path, nil
+	}
+	if strings.HasPrefix(path, `\\`) {
+		return `\\?\UNC\` + path[2:], nil
+	}
+	return `\\?\` + path, nil
 }

--- a/internal/cli/portable_rename_windows.go
+++ b/internal/cli/portable_rename_windows.go
@@ -1,0 +1,15 @@
+package cli
+
+import "golang.org/x/sys/windows"
+
+func renamePortableExclusive(from, to string) error {
+	source, err := windows.UTF16PtrFromString(from)
+	if err != nil {
+		return err
+	}
+	destination, err := windows.UTF16PtrFromString(to)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFile(source, destination)
+}

--- a/internal/cli/portable_rename_windows_test.go
+++ b/internal/cli/portable_rename_windows_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPortableExclusiveRenameNormalizesWindowsPaths(t *testing.T) {
+	for _, tc := range []struct{ input, want string }{
+		{`C:\archive\file`, `C:\archive\file`},
+		{`C:\archive\trailing.`, `C:\archive\trailing.`},
+		{`\\server\share\file`, `\\server\share\file`},
+		{`\\?\C:\archive\file`, `\\?\C:\archive\file`},
+		{`\\?\UNC\server\share\file`, `\\?\UNC\server\share\file`},
+		{`C:\archive\` + strings.Repeat("a", 250), `\\?\C:\archive\` + strings.Repeat("a", 250)},
+		{`\\server\share\` + strings.Repeat("a", 250), `\\?\UNC\server\share\` + strings.Repeat("a", 250)},
+	} {
+		got, err := portableWindowsExtendedPath(tc.input)
+		if err != nil || got != tc.want {
+			t.Errorf("extended path %q = %q, %v; want %q", tc.input, got, err, tc.want)
+		}
+	}
+}
+
+func TestPortableExclusiveRenameLongPaths(t *testing.T) {
+	root := t.TempDir()
+	for len(root) < 320 {
+		root = filepath.Join(root, strings.Repeat("segment", 7))
+	}
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	from, to := filepath.Join(root, "source"), filepath.Join(root, "destination")
+	if err := os.Mkdir(from, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(to, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := renamePortableExclusive(from, to); err == nil {
+		t.Fatal("long-path rename replaced an existing directory")
+	}
+	if err := os.Remove(to); err != nil {
+		t.Fatal(err)
+	}
+	if err := renamePortableExclusive(from, to); err != nil {
+		t.Fatalf("long-path publication failed: %v", err)
+	}
+	if _, err := os.Stat(to); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/portable_rename_windows_test.go
+++ b/internal/cli/portable_rename_windows_test.go
@@ -10,7 +10,7 @@ import (
 func TestPortableExclusiveRenameNormalizesWindowsPaths(t *testing.T) {
 	for _, tc := range []struct{ input, want string }{
 		{`C:\archive\file`, `C:\archive\file`},
-		{`C:\archive\trailing.`, `C:\archive\trailing.`},
+		{`C:\archive\trailing.`, `C:\archive\trailing`},
 		{`\\server\share\file`, `\\server\share\file`},
 		{`\\?\C:\archive\file`, `\\?\C:\archive\file`},
 		{`\\?\UNC\server\share\file`, `\\?\UNC\server\share\file`},


### PR DESCRIPTION
An initial portable-store clone can fail after writing a partial Git index. The next `init` then treats that directory as an existing checkout and enters reset/pull recovery even though it has no usable HEAD, so retrying continues to fail.

Stage initial clones until Git succeeds. New destinations use exclusive directory publication; pre-created empty destinations stay in place and receive completed entries through exclusive moves, with Git metadata published last. This preserves directory permissions/ACLs and writable destinations beneath a read-only parent. Concurrent entries are preserved, and incomplete publication retains recovery material instead of deleting possibly modified files.

A fixed short staging prefix preserves valid long destination names. Windows paths retain short-path semantics and gain extended-length prefixes when needed. A focused Windows CI job tests long paths and actual initial-clone/read behavior.

The implementation uses the native exclusive rename primitives on the released macOS, Linux, and Windows targets. Other source-build targets and filesystems lacking native exclusive renames retain their existing clone behavior; support is probed before transferring data. Existing malformed checkouts continue to use the existing recovery policy.

Validation:

- Regression reproduced on main: a synthetic interrupted clone leaves a partial index, and the real built CLI's retry exits 1. With the fix, the first error remains visible, failed staging is removed, and the retry exits 0 with `portable_store: cloned`.
- Built CLI proof covers absent and pre-created empty destinations; the latter keeps its original inode and mode.
- Focused tests cover retry, original directory metadata, writable destinations beneath read-only parents, concurrent-file preservation, and exclusive file/directory publication.
- Vet, local and final committed-branch autoreview through P2 pass. Exact-head Linux/macOS full CI and native Windows filesystem/CLI checks are green: https://github.com/openclaw/gitcrawl/actions/runs/34660078848 .

Changelog is collected in #183, the final notes/dependencies PR. Land this PR before #183. No release is included.

Captured real CLI proof (only temporary paths and unrelated JSON fields omitted):

```text
# Main baseline dab4d849, after an injected interrupted clone
baseline first-exit 1
baseline destination-exists-after-failure True
baseline retry-exit 1
baseline retry stderr: portable git failed: Git command failed; verify Git version, repository state and remote access: exit status 128

# Clean build of this PR
$ go version -m ./gitcrawl
  build vcs.revision=1958338280a1aacd8ac8d7408d34ceb5afe86d03
  build vcs.modified=false
$ python3 live-clone.py ./gitcrawl head-1958338-new
head-1958338-new first-exit 1
head-1958338-new destination-exists-after-failure False
head-1958338-new retry-exit 0
head-1958338-new retry-json: {"portable_store":"cloned"}
$ python3 live-clone.py ./gitcrawl head-1958338-empty existing
head-1958338-empty first-exit 1
head-1958338-empty destination-exists-after-failure True
head-1958338-empty retry-exit 0
head-1958338-empty retry-json: {"portable_store":"cloned"}
head-1958338-empty original-directory-inode-and-mode-preserved True
```

The fixture creates a synthetic SQLite archive and local Git publisher. A one-shot Git wrapper creates an incomplete repository with a partial index and exits 79 with an injected disk-space error. Both binaries preserve the original classified error. The retry uses the real Git executable, without injection. The pre-created-directory case also asserts unchanged inode and mode after recovery.
