### PR TITLE
refactor: share summary and embedding retry policy

### DIFF
--- a/internal/openai/client.go
+++ b/internal/openai/client.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	crawlembed "github.com/openclaw/crawlkit/embed"
@@ -52,8 +51,6 @@ type Client struct {
 
 	now   func() time.Time
 	sleep func(context.Context, time.Duration) error
-	rand  *rand.Rand
-	randM sync.Mutex
 }
 
 type Options struct {
@@ -65,24 +62,6 @@ type Options struct {
 
 	Now   func() time.Time
 	Sleep func(context.Context, time.Duration) error
-}
-
-type embeddingRequest struct {
-	Model      string   `json:"model"`
-	Input      []string `json:"input"`
-	Dimensions int      `json:"dimensions,omitempty"`
-}
-
-type embeddingResponse struct {
-	Data []struct {
-		Index     int       `json:"index"`
-		Embedding []float64 `json:"embedding"`
-	} `json:"data"`
-	Error *struct {
-		Message string `json:"message"`
-		Type    string `json:"type"`
-		Code    string `json:"code"`
-	} `json:"error,omitempty"`
 }
 
 func New(options Options) *Client {
@@ -115,7 +94,6 @@ func New(options Options) *Client {
 		retry:      retry,
 		now:        now,
 		sleep:      sleep,
-		rand:       rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
 
@@ -149,56 +127,9 @@ func (c *Client) Embed(ctx context.Context, model string, texts []string) ([][]f
 	}
 	texts = capEmbeddingInputs(texts)
 
-	deadline := c.now().Add(c.retry.MaxElapsed)
-	var lastErr error
-	for attempt := 0; attempt < c.retry.MaxAttempts; attempt++ {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		vectors, apiErr, err := c.embedOnce(ctx, model, texts)
-		if err != nil {
-			if isContextErr(err) {
-				return nil, err
-			}
-			lastErr = err
-			if attempt+1 >= c.retry.MaxAttempts {
-				return nil, err
-			}
-			delay := c.backoff(attempt, c.retry.BaseDelay, 0)
-			if !c.canSleep(deadline, delay) {
-				return nil, err
-			}
-			if sleepErr := c.sleep(ctx, delay); sleepErr != nil {
-				return nil, sleepErr
-			}
-			continue
-		}
-		if apiErr == nil {
-			return vectors, nil
-		}
-		lastErr = apiErr
-		if !apiErr.Retryable() {
-			return nil, apiErr
-		}
-		if attempt+1 >= c.retry.MaxAttempts {
-			return nil, apiErr
-		}
-		base := c.retry.BaseDelay
-		if apiErr.IsOverloaded() {
-			base = c.retry.OverloadedBase
-		}
-		delay := c.backoff(attempt, base, apiErr.RetryAfter)
-		if !c.canSleep(deadline, delay) {
-			return nil, apiErr
-		}
-		if sleepErr := c.sleep(ctx, delay); sleepErr != nil {
-			return nil, sleepErr
-		}
-	}
-	if lastErr == nil {
-		lastErr = fmt.Errorf("openai embeddings: exhausted %d attempts", c.retry.MaxAttempts)
-	}
-	return nil, lastErr
+	return retryRequest(ctx, c, func() ([][]float64, *APIError, error) {
+		return c.embedOnce(ctx, model, texts)
+	})
 }
 
 func (c *Client) embedOnce(ctx context.Context, model string, texts []string) ([][]float64, *APIError, error) {
@@ -255,9 +186,7 @@ func (c *Client) backoff(attempt int, base time.Duration, retryAfter time.Durati
 		delay = c.retry.MaxDelay
 	}
 	if c.retry.Jitter > 0 {
-		c.randM.Lock()
-		offset := (c.rand.Float64()*2 - 1) * c.retry.Jitter * float64(delay)
-		c.randM.Unlock()
+		offset := (rand.Float64()*2 - 1) * c.retry.Jitter * float64(delay)
 		delay += time.Duration(offset)
 		if delay < 0 {
 			delay = 0

--- a/internal/openai/client_test.go
+++ b/internal/openai/client_test.go
@@ -20,6 +20,24 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
+type embeddingRequest struct {
+	Model      string   `json:"model"`
+	Input      []string `json:"input"`
+	Dimensions int      `json:"dimensions,omitempty"`
+}
+
+type embeddingResponse struct {
+	Data []struct {
+		Index     int       `json:"index"`
+		Embedding []float64 `json:"embedding"`
+	} `json:"data"`
+	Error *struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+		Code    string `json:"code"`
+	} `json:"error,omitempty"`
+}
+
 func TestEmbedAcceptsLargeBatchResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var request embeddingRequest
@@ -381,11 +399,12 @@ func TestEmbedPropagatesContextCancellation(t *testing.T) {
 }
 
 func TestEmbedRetryAfterDateForm(t *testing.T) {
+	now := time.Date(2026, time.September, 1, 12, 0, 0, 0, time.UTC)
 	var calls int32
 	server := newSingleVectorServer(func(w http.ResponseWriter, r *http.Request) {
 		n := atomic.AddInt32(&calls, 1)
 		if n == 1 {
-			w.Header().Set("Retry-After", time.Now().Add(3*time.Second).UTC().Format(http.TimeFormat))
+			w.Header().Set("Retry-After", now.Add(3*time.Second).Format(http.TimeFormat))
 			w.WriteHeader(http.StatusTooManyRequests)
 			return
 		}
@@ -395,15 +414,15 @@ func TestEmbedRetryAfterDateForm(t *testing.T) {
 
 	var slept []time.Duration
 	retry := RetryConfig{MaxAttempts: 3, BaseDelay: time.Millisecond, MaxDelay: time.Hour, MaxElapsed: time.Hour}
-	client := New(Options{APIKey: "test", BaseURL: server.URL, Retry: &retry, Sleep: func(_ context.Context, d time.Duration) error {
+	client := New(Options{APIKey: "test", BaseURL: server.URL, Retry: &retry, Now: func() time.Time { return now }, Sleep: func(_ context.Context, d time.Duration) error {
 		slept = append(slept, d)
 		return nil
 	}})
 	if _, err := client.Embed(context.Background(), "model", []string{"hi"}); err != nil {
 		t.Fatalf("embed: %v", err)
 	}
-	if len(slept) != 1 || slept[0] < time.Second || slept[0] > 4*time.Second {
-		t.Fatalf("expected ~3s sleep from HTTP-date Retry-After, got %v", slept)
+	if len(slept) != 1 || slept[0] != 3*time.Second {
+		t.Fatalf("expected exactly 3s sleep from HTTP-date Retry-After, got %v", slept)
 	}
 }
 

--- a/internal/openai/errors.go
+++ b/internal/openai/errors.go
@@ -83,18 +83,7 @@ func apiErrorFromEmbed(err error, now time.Time) *APIError {
 	if !errors.As(err, &httpErr) {
 		return nil
 	}
-	apiErr := &APIError{
-		Status:     httpErr.StatusCode,
-		Message:    strings.TrimSpace(httpErr.Body),
-		RetryAfter: parseRetryAfter(httpErr.Header.Get("Retry-After"), now),
-	}
-	var parsed embeddingResponse
-	if jerr := json.Unmarshal([]byte(httpErr.Body), &parsed); jerr == nil && parsed.Error != nil {
-		apiErr.Message = parsed.Error.Message
-		apiErr.Type = parsed.Error.Type
-		apiErr.Code = parsed.Error.Code
-	}
-	return apiErr
+	return apiErrorFromHTTP(httpErr.StatusCode, httpErr.Header, []byte(httpErr.Body), now)
 }
 
 func parseRetryAfter(header string, now time.Time) time.Duration {

--- a/internal/openai/retry.go
+++ b/internal/openai/retry.go
@@ -1,0 +1,46 @@
+package openai
+
+import (
+	"context"
+	"time"
+)
+
+func retryRequest[T any](ctx context.Context, c *Client, request func() (T, *APIError, error)) (T, error) {
+	var zero T
+	deadline := c.now().Add(c.retry.MaxElapsed)
+	for attempt := 0; ; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return zero, err
+		}
+		value, apiErr, err := request()
+		if err == nil && apiErr == nil {
+			return value, nil
+		}
+		base := c.retry.BaseDelay
+		var retryAfter time.Duration
+		if err != nil {
+			if isContextErr(err) {
+				return zero, err
+			}
+		} else {
+			err = apiErr
+			if !apiErr.Retryable() {
+				return zero, err
+			}
+			if apiErr.IsOverloaded() {
+				base = c.retry.OverloadedBase
+			}
+			retryAfter = apiErr.RetryAfter
+		}
+		if attempt+1 >= c.retry.MaxAttempts {
+			return zero, err
+		}
+		delay := c.backoff(attempt, base, retryAfter)
+		if !c.canSleep(deadline, delay) {
+			return zero, err
+		}
+		if sleepErr := c.sleep(ctx, delay); sleepErr != nil {
+			return zero, sleepErr
+		}
+	}
+}

--- a/internal/openai/summaries.go
+++ b/internal/openai/summaries.go
@@ -53,53 +53,9 @@ func (c *Client) Summarize(ctx context.Context, model, instructions, input strin
 		return "", fmt.Errorf("OpenAI API key is required")
 	}
 
-	deadline := c.now().Add(c.retry.MaxElapsed)
-	var lastErr error
-	for attempt := 0; attempt < c.retry.MaxAttempts; attempt++ {
-		if err := ctx.Err(); err != nil {
-			return "", err
-		}
-		text, apiErr, err := c.summarizeOnce(ctx, model, instructions, input)
-		if err != nil {
-			if isContextErr(err) {
-				return "", err
-			}
-			lastErr = err
-			if attempt+1 >= c.retry.MaxAttempts {
-				return "", err
-			}
-			delay := c.backoff(attempt, c.retry.BaseDelay, 0)
-			if !c.canSleep(deadline, delay) {
-				return "", err
-			}
-			if sleepErr := c.sleep(ctx, delay); sleepErr != nil {
-				return "", sleepErr
-			}
-			continue
-		}
-		if apiErr == nil {
-			return text, nil
-		}
-		lastErr = apiErr
-		if !apiErr.Retryable() || attempt+1 >= c.retry.MaxAttempts {
-			return "", apiErr
-		}
-		base := c.retry.BaseDelay
-		if apiErr.IsOverloaded() {
-			base = c.retry.OverloadedBase
-		}
-		delay := c.backoff(attempt, base, apiErr.RetryAfter)
-		if !c.canSleep(deadline, delay) {
-			return "", apiErr
-		}
-		if sleepErr := c.sleep(ctx, delay); sleepErr != nil {
-			return "", sleepErr
-		}
-	}
-	if lastErr == nil {
-		lastErr = fmt.Errorf("openai summary: exhausted %d attempts", c.retry.MaxAttempts)
-	}
-	return "", lastErr
+	return retryRequest(ctx, c, func() (string, *APIError, error) {
+		return c.summarizeOnce(ctx, model, instructions, input)
+	})
 }
 
 func (c *Client) summarizeOnce(ctx context.Context, model, instructions, input string) (string, *APIError, error) {


### PR DESCRIPTION
## What Problem This Solves

Summary and embedding requests duplicated their retry policy, making cancellation, quota errors, and retry timing easy to change inconsistently.

## Why This Change Was Made

Both request paths now use one typed retry loop and HTTP error decoder. Go's concurrency-safe random generator replaces the per-client generator and mutex. Request/response structs used only by fixtures live with their tests, and the HTTP-date retry test uses an injected fixed clock.

## User Impact

No intended behavior or configuration changes. Retry limits, overload delays, Retry-After handling, cancellation, and error propagation are preserved. The Go 1.27.1 floor is unchanged.

## Evidence

- Isolated Codex autoreview: scoped-clean through P2, no accepted/actionable findings.
- `GOWORK=off go test ./internal/openai`, `GOWORK=off go vet ./...`, and `git diff --check` pass.
- Built CLI proof: initialized an isolated archive, synced one synthetic issue with full comment evidence, then ran `embed example/archive --number 1 --json` and `summarize example/archive --number 1 --json` against a loopback fixture. Each endpoint returned HTTP 429 with Retry-After before succeeding. Observed results:

```json
{"sync_threads":1,"embedded":1,"summarized":1,"embed_status":"success","summary_status":"success","requests":{"/embeddings":2,"/responses":2}}
```

The fixture used synthetic data and credentials. No external API calls or production archive writes were needed. Full coverage and the platform/build/security gates run on this PR's exact head before merge.
