### PR TITLE
fix: stop repeated REST pagination links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Compatibility: report portable publication time as `last_export_at`; `last_sync_at` now describes retained successful sync runs instead of old repository scan checkpoints. Thanks @obviyus.
+- Stop REST pagination when GitHub returns repeated or cyclic next links, preventing repeated requests and incomplete sync results.
+
 - Validate documentation builds before merge, pin CI actions and build tools to verified releases, update govulncheck to v1.8.0, and avoid duplicate cross-platform snapshot builds.
 
 ## 0.9.6 - 2026-09-11

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -144,6 +144,11 @@ gitcrawl sync owner/repo --limit 200
 
 `--limit` caps the number of rows fetched in this invocation. The underlying GitHub paginator surfaces total page counts in run records and honors GitHub's `Retry-After` and rate-limit response headers, so partial syncs interrupted by rate limiting resume cleanly.
 
+REST pagination stops with an error if a `next` link returns to an already
+fetched page. This prevents repeated requests and avoids treating a cyclic
+response as a complete page collection. Retry when GitHub or the proxy returns
+advancing links.
+
 ## JSON output
 
 The result reports processed thread and hydration counts, not separate insert

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -404,12 +404,14 @@ func (c *Client) paginateEnvelope(ctx context.Context, firstPath string, limit i
 func (c *Client) paginatePages(ctx context.Context, firstPath string, limit int, expectedItems int, reporter Reporter, decode func(*http.Response) ([]map[string]any, error)) ([]map[string]any, error) {
 	var out []map[string]any
 	nextPath := firstPath
+	visited := make(map[string]struct{})
 	page := 0
 	totalPages := 0
 	if expectedItems > 0 {
 		totalPages = (expectedItems + 99) / 100
 	}
 	for nextPath != "" {
+		visited[nextPath] = struct{}{}
 		page++
 		resp, err := c.do(ctx, http.MethodGet, nextPath, nil, reporter)
 		if err != nil {
@@ -441,6 +443,9 @@ func (c *Client) paginatePages(ctx context.Context, firstPath string, limit int,
 			break
 		}
 		nextPath = nextPage(linkHeader, c.baseURL)
+		if _, repeated := visited[nextPath]; repeated {
+			return nil, fmt.Errorf("github pagination repeated next link")
+		}
 		if nextPath != "" && c.pageDelay > 0 {
 			select {
 			case <-ctx.Done():

--- a/internal/github/pagination_test.go
+++ b/internal/github/pagination_test.go
@@ -1,0 +1,62 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestPaginationRejectsCycles(t *testing.T) {
+	for _, envelope := range []bool{false, true} {
+		for _, cycleToFirst := range []bool{false, true} {
+			name := "array"
+			if envelope {
+				name = "envelope"
+			}
+			if cycleToFirst {
+				name += "/return-to-first-page"
+			} else {
+				name += "/repeat-next-page"
+			}
+			t.Run(name, func(t *testing.T) {
+				var calls atomic.Int32
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					call := calls.Add(1)
+					if call > 2 {
+						http.Error(w, "unexpected extra request", http.StatusInternalServerError)
+						return
+					}
+					query := "?page=2"
+					if cycleToFirst && call == 2 {
+						query = "?per_page=100"
+					}
+					w.Header().Set("Link", `<`+serverURL(r)+query+`>; rel="next"`)
+					var payload any = []map[string]any{{"id": call}}
+					if envelope {
+						payload = map[string]any{"check_runs": payload}
+					}
+					_ = json.NewEncoder(w).Encode(payload)
+				}))
+				defer server.Close()
+				client := New(Options{BaseURL: server.URL, PageDelay: -1})
+				var rows []map[string]any
+				var err error
+				if envelope {
+					rows, err = client.ListCommitCheckRuns(context.Background(), "example", "archive", "abc", nil)
+				} else {
+					rows, err = client.ListIssueComments(context.Background(), "example", "archive", 1, nil)
+				}
+				if err == nil || !strings.Contains(err.Error(), "repeated next link") {
+					t.Fatalf("pagination error = %v, want repeated next link", err)
+				}
+				if rows != nil || calls.Load() != 2 {
+					t.Fatalf("rows = %v, requests = %d; want no partial result and two requests", rows, calls.Load())
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

Sync could repeatedly fetch the same REST page when GitHub or a proxy returned a cyclic `next` link, spending quota without completing the archive.

## User Impact

A cyclic page collection now stops with a clear error. Normal pagination and explicit row limits are unchanged; partial results are not returned as a completed collection.

## Why This Change Was Made

Track visited request paths in the shared REST paginator so both array and envelope endpoints enforce forward progress. The changelog also records the compatibility note and @obviyus credit for the concurrently landed timestamp fix in #182.

## Evidence

- Four regression cases failed before the fix and pass afterward: repeated next pages and cycles back to the first page, through both array and envelope decoders.
- GitHub client and syncer tests pass. Isolated Codex autoreview is scoped-clean through P2.
- Before/after built CLI proof used an isolated synthetic archive and a loopback GitHub fixture. Before, sync attempted a third page request and hit the fixture's safety error. After, it stopped after two requests with `github pagination repeated next link`. Both exited nonzero and retained zero stored threads; no cyclic response became a completed sync.
- Exact-head platform, coverage, Docker, documentation, security, and snapshot checks are required before merge.
