### PR TITLE
fix: honor no-color in the terminal browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Honor the global `--no-color` flag in the terminal browser.
+
 - Compatibility: report portable publication time as `last_export_at`; `last_sync_at` now describes retained successful sync runs instead of old repository scan checkpoints. Thanks @obviyus.
 - Stop REST pagination when GitHub returns repeated or cyclic next links, preventing repeated requests and incomplete sync results.
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -22,6 +22,7 @@ actions, detail rendering, and status chrome wherever the data model allows it.
 
 ```bash
 gitcrawl tui owner/repo
+gitcrawl --no-color tui owner/repo # disable terminal colors
 gitcrawl tui                      # infers the most recently updated local repo
 gitcrawl tui --min-size 5         # default; show clusters with ≥5 active members
 gitcrawl tui --sort recent        # alternate sort

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/mattn/go-isatty v0.0.24
+	github.com/muesli/termenv v0.16.0
 	github.com/openclaw/crawlkit v0.16.1
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/sys v0.48.0
@@ -36,7 +37,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.30 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.4.3 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -33,6 +33,7 @@ type App struct {
 
 	configPath            string
 	format                OutputFormat
+	noColor               bool
 	getWorkingDirectory   func() (string, error)
 	githubAuthTokenLookup func(context.Context) (string, error)
 	dbTargetNoticeOnce    sync.Once
@@ -73,6 +74,7 @@ func (a *App) Run(ctx context.Context, args []string) error {
 	}
 	a.configPath = strings.TrimSpace(global.Config)
 	a.format = resolvedFormat
+	a.noColor = global.NoColor
 	a.githubTokenCommand = global.GitHubTokenCommand
 	a.observedGitHubToken = ""
 

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -206,17 +206,19 @@ func (a *App) runInteractiveTUI(ctx context.Context, st *store.Store, repoID int
 	if !ok {
 		return a.writeOutput("tui", payload, true)
 	}
-	tuiCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	model := newClusterBrowserModel(tuiCtx, st, repoID, payload)
-	program := tea.NewProgram(model, tea.WithInput(os.Stdin), tea.WithOutput(out), tea.WithAltScreen(), tea.WithMouseAllMotion())
-	finalModel, err := program.Run()
-	cancel()
-	if final, ok := finalModel.(clusterBrowserModel); ok && final.store != nil && final.store != st {
-		final.cancelNeighborLoad()
-		_ = final.store.Close()
-	}
-	return err
+	return a.withTUIRenderer(func() error {
+		tuiCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		model := newClusterBrowserModel(tuiCtx, st, repoID, payload)
+		program := tea.NewProgram(model, tea.WithInput(os.Stdin), tea.WithOutput(out), tea.WithAltScreen(), tea.WithMouseAllMotion())
+		finalModel, err := program.Run()
+		cancel()
+		if final, ok := finalModel.(clusterBrowserModel); ok && final.store != nil && final.store != st {
+			final.cancelNeighborLoad()
+			_ = final.store.Close()
+		}
+		return err
+	})
 }
 
 func newClusterBrowserModel(ctx context.Context, st *store.Store, repoID int64, payload clusterBrowserPayload) clusterBrowserModel {

--- a/internal/cli/tui_color.go
+++ b/internal/cli/tui_color.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
+
+func (a *App) withTUIRenderer(run func() error) error {
+	if !a.noColor {
+		return run()
+	}
+	// Lip Gloss styles use a package-wide renderer; keep this override scoped
+	// to the program so later commands retain the caller's color policy.
+	previous := lipgloss.DefaultRenderer()
+	renderer := lipgloss.NewRenderer(a.Stdout)
+	renderer.SetColorProfile(termenv.Ascii)
+	lipgloss.SetDefaultRenderer(renderer)
+	defer lipgloss.SetDefaultRenderer(previous)
+	return run()
+}

--- a/internal/cli/tui_color_test.go
+++ b/internal/cli/tui_color_test.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
+
+func TestNoColorFlagControlsTUIRendering(t *testing.T) {
+	previous := lipgloss.DefaultRenderer()
+	renderer := lipgloss.NewRenderer(io.Discard)
+	renderer.SetColorProfile(termenv.TrueColor)
+	lipgloss.SetDefaultRenderer(renderer)
+	defer lipgloss.SetDefaultRenderer(previous)
+
+	app := New()
+	app.Stdout, app.Stderr = io.Discard, io.Discard
+	for _, noColor := range []bool{false, true, false} {
+		args := []string{"version"}
+		if noColor {
+			args = append([]string{"--no-color"}, args...)
+		}
+		if err := app.Run(context.Background(), args); err != nil {
+			t.Fatal(err)
+		}
+		var view string
+		if err := app.withTUIRenderer(func() error {
+			model := newClusterBrowserModel(context.Background(), nil, 0, clusterBrowserPayload{
+				Repository: "example/archive", Clusters: sampleTUIClusters(),
+			})
+			model.width, model.height = 160, 40
+			view = model.View()
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(view, "example/archive") {
+			t.Fatal("rendered view lost the repository")
+		}
+		if colored := hasTUIColors(view); colored == noColor {
+			t.Fatalf("no-color=%t: colored output=%t", noColor, colored)
+		}
+		if lipgloss.DefaultRenderer() != renderer {
+			t.Fatal("TUI did not restore the caller's renderer")
+		}
+	}
+	if err := app.Run(context.Background(), []string{"--no-color", "version"}); err != nil {
+		t.Fatal(err)
+	}
+	failure := errors.New("program failed")
+	if err := app.withTUIRenderer(func() error { return failure }); !errors.Is(err, failure) {
+		t.Fatalf("program error = %v", err)
+	}
+	if lipgloss.DefaultRenderer() != renderer {
+		t.Fatal("failed TUI did not restore the caller's renderer")
+	}
+}
+
+func hasTUIColors(value string) bool {
+	for _, sequence := range regexp.MustCompile("\x1b\\[[0-9;:]*m").FindAllString(value, -1) {
+		for _, raw := range strings.FieldsFunc(sequence[2:len(sequence)-1], func(r rune) bool { return r == ';' || r == ':' }) {
+			code, _ := strconv.Atoi(raw)
+			if code >= 30 && code <= 49 || code >= 90 && code <= 107 || code == 58 {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What Problem This Solves

The global `--no-color` flag was accepted but never applied, so the terminal browser still emitted colored output.

## User Impact

`gitcrawl --no-color tui owner/repo` now renders without terminal colors while retaining screen controls and interaction. Other commands keep their existing color policy.

## Why This Change Was Made

Pass the parsed flag into a renderer scoped to the interactive program, then restore the caller's renderer on success or error. The existing termenv v0.16.0 dependency becomes direct for its color-profile constant; no dependency version changes.

## Evidence

- The regression failed before the fix with `no-color=true: colored output=true`; it now passes, including reused-command flag reset and renderer restoration after an error.
- Focused TUI/model/rendering tests pass. Isolated Codex autoreview is scoped-clean through P2.
- Before/after built binaries ran the same command in a real 160×40 PTY with a synthetic archive and forced color capability. Color sequences dropped from 334 to 0, alternate-screen controls remained present, and both programs exited successfully after `q`.
- These images are rendered from the recorded PTY bytes, not desktop captures. The complete frames were inspected and contain only synthetic data.

| Before | After |
| --- | --- |
| ![Before: no-color still emitted colors](https://github.com/user-attachments/assets/1de40d43-fff7-489c-879d-ce5c9d95e87d) | ![After: no-color disables colors](https://github.com/user-attachments/assets/7cbbeb45-368d-4b47-8831-778cc64eca72) |

Exact-head platform, coverage, Docker, docs, security, and snapshot checks must pass before merge.
