### PR TITLE
fix: validate documentation links and stable site identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,10 @@
 ## Unreleased
 
 - Add explicit cloud archive admission with immutable source, integrity, enrichment, and warning evidence while preserving strict publication defaults. Thanks @vincentkoc.
-- Honor the global `--no-color` flag in the terminal browser.
-
 - Compatibility: report portable publication time as `last_export_at`; `last_sync_at` now describes retained successful sync runs instead of old repository scan checkpoints. Thanks @obviyus.
 - Stop REST pagination when GitHub returns repeated or cyclic next links, preventing repeated requests and incomplete sync results.
-
+- Honor the global `--no-color` flag in the terminal browser.
+- Keep the documentation index named Gitcrawl in renamed checkouts, validate same-page links, and escape link URLs exactly once.
 - Validate documentation builds before merge, pin CI actions and build tools to verified releases, update govulncheck to v1.8.0, and avoid duplicate cross-platform snapshot builds.
 
 ## 0.9.6 - 2026-09-11

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ test-release:
 	./scripts/test-release.sh
 
 docs:
+	$(NODE) --test scripts/build-docs-site.test.mjs
 	$(NODE) scripts/build-docs-site.mjs
 
 check: tidy-check fmt lint test-coverage smoke test-release docs snapshot

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -75,7 +75,7 @@ console.log(`built docs site: ${path.relative(root, outDir)}`);
 function llmsTxt() {
   const origin = siteBase.replace(/\/$/, "");
   const source = repoBase;
-  const name = path.basename(root);
+  const name = "gitcrawl";
   const description = `${name} documentation index.`;
   const docPages = docsLlmsPages().map((page) => `- ${page.title}: ${pageUrl(origin, page.outRel)}`);
   const lines = [
@@ -432,7 +432,7 @@ function inline(text, currentRel) {
     .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
     .replace(/(^|[^*])\*([^*\s][^*]*?)\*(?!\*)/g, "$1<em>$2</em>")
     .replace(/(^|[^_])_([^_\s][^_]*?)_(?!_)/g, "$1<em>$2</em>")
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, label, href) => `<a href="${escapeAttr(rewriteHref(href, currentRel))}">${label}</a>`)
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, label, href) => `<a href="${escapeAttr(rewriteHref(decodeHtmlText(href), currentRel))}">${label}</a>`)
     .replace(/&lt;(https?:\/\/[^\s<>]+)&gt;/g, '<a href="$1">$1</a>');
   return out.replace(/\u0000(\d+)\u0000/g, (_, i) => stash[Number(i)]);
 }
@@ -647,8 +647,8 @@ function validateLinks(outputDir) {
   for (const file of allHtml(outputDir)) {
     const html = fs.readFileSync(file, "utf8");
     for (const match of html.matchAll(/href="([^"]+)"/g)) {
-      const href = match[1];
-      if (/^(#|https?:|mailto:|tel:|javascript:)/.test(href)) continue;
+      const href = decodeHtmlText(match[1]);
+      if (/^(https?:|mailto:|tel:|javascript:)/.test(href)) continue;
       const [rawPath, anchor = ""] = href.split("#");
       const targetPath = rawPath
         ? path.resolve(path.dirname(file), rawPath)
@@ -661,8 +661,15 @@ function validateLinks(outputDir) {
         continue;
       }
       if (anchor) {
+        let fragment;
+        try {
+          fragment = escapeAttr(decodeURIComponent(anchor));
+        } catch {
+          failures.push(`${path.relative(outputDir, file)}: ${href} -> invalid anchor encoding`);
+          continue;
+        }
         const targetHtml = fs.readFileSync(target, "utf8");
-        if (!targetHtml.includes(`id="${anchor}"`) && !targetHtml.includes(`name="${anchor}"`)) {
+        if (!targetHtml.includes(`id="${fragment}"`) && !targetHtml.includes(`name="${fragment}"`)) {
           failures.push(`${path.relative(outputDir, file)}: ${href} -> missing anchor`);
         }
       }

--- a/scripts/build-docs-site.test.mjs
+++ b/scripts/build-docs-site.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const builder = fileURLToPath(new URL("./build-docs-site.mjs", import.meta.url));
+
+function buildFixture(t, markdown) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "renamed-checkout-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  fs.mkdirSync(path.join(root, "docs"));
+  fs.writeFileSync(path.join(root, "docs", "CNAME"), "gitcrawl.sh\n");
+  fs.writeFileSync(path.join(root, "docs", "index.md"), `---\ntitle: Fixture\npermalink: /\n---\n${markdown}`);
+  return {
+    root,
+    result: spawnSync(process.execPath, [builder], { cwd: root, encoding: "utf8", timeout: 20_000 }),
+  };
+}
+
+test("documentation identity does not depend on checkout directory", (t) => {
+  const { root, result } = buildFixture(t, "# Fixture\n");
+  assert.equal(result.status, 0, result.stderr);
+  const index = fs.readFileSync(path.join(root, "dist", "docs-site", "llms.txt"), "utf8");
+  assert.match(index, /^# gitcrawl\n/);
+  assert.match(index, /Source: https:\/\/github.com\/openclaw\/gitcrawl/);
+});
+
+test("same-page links must refer to an existing anchor", (t) => {
+  const { result } = buildFixture(t, "# Fixture\n\n[Missing](#missing-section)\n");
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /missing anchor/);
+});
+
+test("valid and URL-encoded same-page anchors are accepted", (t) => {
+  const { root, result } = buildFixture(t, "# Fixture\n\n[Plain](#existing-section) [Encoded](#%65xisting-section) [A & B](#existing-section)\n\n## Existing section\n");
+  assert.equal(result.status, 0, result.stderr);
+  const page = fs.readFileSync(path.join(root, "dist", "docs-site", "index.html"), "utf8");
+  assert.ok(page.includes(">A &amp; B</a>"));
+});
+
+
+test("link URLs are HTML-escaped exactly once", (t) => {
+  const { root, result } = buildFixture(t, "# Fixture\n\n[Query](https://example.test/?one=1&two=2)\n");
+  assert.equal(result.status, 0, result.stderr);
+  const page = fs.readFileSync(path.join(root, "dist", "docs-site", "index.html"), "utf8");
+  assert.ok(page.includes('href="https://example.test/?one=1&amp;two=2"'));
+});


### PR DESCRIPTION
## What Problem This Solves

Documentation built from a renamed checkout used that directory name in `llms.txt`, and same-page links bypassed validation. Markdown URLs containing `&` were also escaped twice, changing their destinations.

## User Impact

The documentation index consistently identifies Gitcrawl. Broken local fragments fail the docs gate, and valid encoded fragments and query strings retain their intended destinations.

## Why This Change Was Made

Use the canonical product identity and validate local fragments through the same target checks as cross-page links. Decode the renderer's first escaping pass before URL rewriting, then escape the output attribute once. The real builder is exercised through isolated fixtures in the existing docs gate.

## Evidence

- Renamed-checkout and broken-fragment cases failed before the fix.
- Four Node tests now pass: stable identity, missing-anchor rejection, valid/encoded anchors with escaped labels, and single URL escaping.
- Each test launches the actual Node builder and inspects its generated artifacts or exit result. The complete repository documentation build and link validation also pass.
- Isolated Codex autoreview is scoped-clean through P2; no new dependencies or toolchain changes.
- Exact-head CI must pass before merge; the normal Pages deployment will be verified after landing.

Actual builder output for synthetic Markdown in a renamed checkout, comparing main `42851fe` with this PR head `088a8a4` (Node 26.8.2). The valid page contains a query URL, an encoded same-page fragment, and an escaped label; the second build points at a missing same-page anchor:

```text
[before] actual Node builder; synthetic checkout basename: renamed-checkout
valid build exit: 0
built docs site: dist/docs-site
llms.txt first line: # renamed-checkout
<a href="https://example.test/?one=1&amp;amp;two=2">Query</a>
<a href="#%65xisting-section">Encoded</a>
<a href="#existing-section">A &amp; B</a>
missing anchor build exit: 0
built docs site: dist/docs-site

[after] actual Node builder; synthetic checkout basename: renamed-checkout
valid build exit: 0
built docs site: dist/docs-site
llms.txt first line: # gitcrawl
<a href="https://example.test/?one=1&amp;two=2">Query</a>
<a href="#%65xisting-section">Encoded</a>
<a href="#existing-section">A &amp; B</a>
missing anchor build exit: 1
index.html: #missing-section -> missing anchor
```
